### PR TITLE
Enable mongodb scl on exec

### DIFF
--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -22,7 +22,8 @@ EXPOSE 27017
 # This image must forever use UID 184 for mongodb user and GID 998 for the
 # mongodb group, so our volumes are safe in the future. This should *never*
 # change, the last test is there to make sure of that.
-# Due to the bug 1206151, the whole /var/lib/mongodb/ dir has to be chown-ed.
+# Due to the https://bugzilla.redhat.com/show_bug.cgi?id=1206151,
+# the whole /var/lib/mongodb/ dir has to be chown-ed.
 RUN yum install -y epel-release && \
     rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
     yum -y --setopt=tsflags=nodocs install \
@@ -35,6 +36,12 @@ RUN yum install -y epel-release && \
 
 COPY run-mongod.sh /usr/local/bin/
 COPY contrib /var/lib/mongodb/
+
+# Due to the https://bugzilla.redhat.com/show_bug.cgi?id=1206151,
+# the .bashrc has to be copied to the wrong $HOME dir, so when using
+# 'docker exec -it openshift/mongodb-24-centos7 /bin/bash' the mongodb
+# collection is enabled automatically.
+COPY contrib/.bashrc /opt/rh/mongodb24/root/var/lib/mongodb/
 
 VOLUME ["/var/lib/mongodb/data"]
 

--- a/2.4/Dockerfile.rhel7
+++ b/2.4/Dockerfile.rhel7
@@ -22,7 +22,8 @@ EXPOSE 27017
 # This image must forever use UID 184 for mongodb user and GID 998 for the
 # mongodb group, so our volumes are safe in the future. This should *never*
 # change, the last test is there to make sure of that.
-# Due to the bug 1206151, the whole /var/lib/mongodb/ dir has to be chown-ed.
+# Due to the https://bugzilla.redhat.com/show_bug.cgi?id=1206151,
+# the whole /var/lib/mongodb/ dir has to be chown-ed.
 RUN yum install -y yum-utils && \
     yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
@@ -33,6 +34,12 @@ RUN yum install -y yum-utils && \
 
 COPY run-mongod.sh /usr/local/bin/
 COPY contrib /var/lib/mongodb/
+
+# Due to the https://bugzilla.redhat.com/show_bug.cgi?id=1206151,
+# the .bashrc has to be copied to the wrong $HOME dir, so when using
+# 'docker exec -it openshift/mongodb-24-rhel7 /bin/bash' the mongodb
+# collection is enabled automatically.
+COPY contrib/.bashrc /opt/rh/mongodb24/root/var/lib/mongodb/
 
 VOLUME ["/var/lib/mongodb/data"]
 


### PR DESCRIPTION
Due to the bug https://bugzilla.redhat.com/show_bug.cgi?id=1206151, the .bashrc has to be copied to the wrong $HOME dir so when using 'docker exec' the mongodb collection is enabled automatically. 
