### PR TITLE
Add MongoDB replica set example

### DIFF
--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -29,7 +29,7 @@ RUN yum install -y epel-release && \
     yum -y --setopt=tsflags=nodocs install \
     https://www.softwarecollections.org/en/scls/rhscl/v8314/epel-7-x86_64/download/rhscl-v8314-epel-7-x86_64.noarch.rpm \
     https://www.softwarecollections.org/en/scls/rhscl/mongodb24/epel-7-x86_64/download/rhscl-mongodb24-epel-7-x86_64.noarch.rpm && \
-    yum install -y --setopt=tsflags=nodocs gettext v8314 mongodb24-mongodb mongodb24 && \
+    yum install -y --setopt=tsflags=nodocs bind-utils gettext v8314 mongodb24-mongodb mongodb24 && \
     yum clean all && \
     mkdir -p /var/lib/mongodb/data && chown -R mongodb.mongodb /var/lib/mongodb/ && \
     test "$(id mongodb)" = "uid=184(mongodb) gid=998(mongodb) groups=998(mongodb)"

--- a/2.4/contrib/common.sh
+++ b/2.4/contrib/common.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+
+# Used for wait_for_mongo_* functions
+MAX_ATTEMPTS=60
+SLEEP_TIME=1
+
+export MONGODB_CONFIG_PATH=/var/lib/mongodb/mongodb.conf
+export MONGODB_PID_FILE=/var/lib/mongodb/mongodb.pid
+
+export CONTAINER_PORT=$(echo -n $IMAGE_EXPOSE_SERVICES | cut -d ':' -f 1)
+
+# container_addr returns the current container external IP address
+function container_addr() {
+  echo -n $(cat /var/lib/mongodb/.address)
+}
+
+# mongo_addr returns the IP:PORT of the currently running MongoDB instance
+function mongo_addr() {
+  echo -n "$(container_addr):${CONTAINER_PORT}"
+}
+
+# cache_container_addr waits till the container gets the external IP address and
+# cache it to disk
+function cache_container_addr() {
+  echo -n "=> Waiting for container IP address ..."
+  for i in $(seq $MAX_ATTEMPTS); do
+    result=$(ip addr | grep 'state UP' -A2 | tail -n1 | awk '{print $2}' | cut -f1 -d'/')
+    if [ ! -z "${result}" ]; then
+      echo -n $result > /var/lib/mongodb/.address
+      echo " $(mongo_addr)"
+      return 0
+    fi
+    sleep $SLEEP_TIME
+  done
+  echo "Failed to get Docker container IP address." && exit 1
+}
+
+# wait_for_mongo_up waits until the mongo server accepts incomming connections
+function wait_for_mongo_up() {
+  local mongo_host="${1-}"
+  local mongo_cmd="mongo admin "
+
+  if [ ! -z "${mongo_host}" ]; then
+    mongo_cmd+="--host ${mongo_host}:${CONTAINER_PORT} "
+  fi
+
+  for i in $(seq $MAX_ATTEMPTS); do
+    echo "=> Waiting for MongoDB service startup ${mongo_host} ..."
+    set +e
+    $mongo_cmd --eval "help" &>/dev/null
+    status=$?
+    set -e
+    if [ $status -eq 0 ]; then
+      echo "=> MongoDB service has started"
+      return 0
+    fi
+    sleep $SLEEP_TIME
+  done
+  echo "=> Giving up: Failed to start MongoDB service!"
+  exit 1
+}
+
+# wait_for_mongo_down waits until the mongo server is down
+function wait_for_mongo_down() {
+  for i in $(seq $MAX_ATTEMPTS); do
+    echo "=> Waiting for MongoDB service shutdown ..."
+    set +e
+    mongo admin --eval "help" &>/dev/null
+    status=$?
+    set -e
+    if [ $status -ne 0 ]; then
+      echo "=> MongoDB service has stopped"
+      return 0
+    fi
+    sleep $SLEEP_TIME
+  done
+  echo "=> Giving up: Failed to stop MongoDB service"
+  exit 1
+}
+
+# endpoints returns list of IP addresses with other instances of MongoDB
+# To get list of endpoints, you need to have headless Service named 'mongodb'.
+# NOTE: This won't work with standalone Docker container.
+function endpoints() {
+  service_name=${MONGODB_SERVICE_NAME:-mongodb}
+  dig ${service_name} A +search +short 2>/dev/null
+}
+
+# no_endpoints returns true if the only endpoint is the current container itself
+# or there are no endpoints registered (running as standalone Docker container)
+function no_endpoints() {
+  [ -z "$(endpoints)" ] && return 0
+  [ "$(endpoints)" == "$(container_addr)" ]
+}
+
+
+
+# build_mongo_config builds the MongoDB replicaSet config used for the cluster
+# initialization
+function build_mongo_config() {
+  local members="{ _id: 0, host: \"$(mongo_addr)\"},"
+  local member_id=1
+  for node in $(endpoints); do
+    members+="{ _id: ${member_id}, host: \"${node}:${CONTAINER_PORT}\"},"
+    let member_id++
+  done
+  echo -n "var config={ _id: \"${MONGODB_REPLICA_NAME}\", members: [ ${members%,} ] }"
+}
+
+# mongo_initiate initiate the replica set
+function mongo_initiate() {
+  local mongo_wait="while (rs.status().startupStatus || (rs.status().hasOwnProperty(\"myState\") && rs.status().myState != 1)) { printjson( rs.status() ); sleep(1000); }; printjson( rs.status() );"
+  config=$(build_mongo_config)
+  echo "=> Initiating MongoDB replica using: ${config}"
+  mongo admin --eval "${config};rs.initiate(config);${mongo_wait}"
+}
+
+# get the address of the current primary member
+function mongo_primary_member_addr() {
+  local current_endpoints=$(endpoints)
+  local mongo_node="$(echo -n ${current_endpoints} | cut -d ' ' -f 1):${CONTAINER_PORT}"
+  echo -n $(mongo admin -u admin -p "${MONGODB_ADMIN_PASSWORD}" --host ${mongo_node} --quiet --eval "print(rs.isMaster().primary);")
+}
+
+# mongo_remove removes the current MongoDB from the cluster
+function mongo_remove() {
+  echo "=> Removing $(mongo_addr) on $(mongo_primary_member_addr) ..."
+  mongo admin -u admin -p "${MONGODB_ADMIN_PASSWORD}" \
+    --host $(mongo_primary_member_addr) --eval "rs.remove('$(mongo_addr)');" &>/dev/null || true
+}
+
+# mongo_add advertise the current container to other mongo replicas
+function mongo_add() {
+  echo "=> Adding $(mongo_addr) to $(mongo_primary_member_addr) ..."
+  mongo admin -u admin -p "${MONGODB_ADMIN_PASSWORD}" \
+    --host $(mongo_primary_member_addr) --eval "rs.add('$(mongo_addr)');"
+}
+
+# run_mongod_supervisor runs the MongoDB replica supervisor that manages
+# registration of the new members to the MongoDB replica cluster
+function run_mongod_supervisor() {
+  local log_pipe_path=$(mktemp --suffix=log)
+  rm -rf ${log_pipe_path}
+  ( mkfifo ${log_pipe_path} && cat ${log_pipe_path} ) &
+  /var/lib/mongodb/replica_supervisor.sh ${log_pipe_path} &
+}
+
+# mongo_create_users creates the MongoDB admin user and the database user
+# configured by MONGO_USERNAME
+function mongo_create_users() {
+  local admin_pwd=${MONGODB_ADMIN_PASSWORD:-$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c16)}
+  mongo admin --eval "db.addUser({user: 'admin', pwd: '$admin_pwd', roles: ['dbAdminAnyDatabase', 'userAdminAnyDatabase' , 'readWriteAnyDatabase','clusterAdmin' ]});"
+  local mongo_cmd="mongo ${MONGODB_DATABASE}"
+  if [ ! -z "${MONGODB_REPLICA_NAME-}" ]; then
+    mongo_cmd+=" -u admin -p ${admin_pwd}"
+  fi
+  $mongo_cmd --eval "db.addUser({user: '${MONGODB_USERNAME}', pwd: '${MONGODB_PASSWORD}', roles: [ 'readWrite' ]});"
+  touch /var/lib/mongodb/data/.mongodb_users_created
+}
+
+# setup_keyfile fixes the bug in mounting the Kubernetes 'Secret' volume that
+# mounts the secret files with 'too open' permissions.
+function setup_keyfile() {
+  if [ ! -f "${MONGODB_KEYFILE_SOURCE_PATH}" ]; then
+    echo "ERROR: You have to provide the 'keyfile' in ${MONGODB_KEYFILE_SOURCE_PATH}"
+    exit 1
+  fi
+  cp ${MONGODB_KEYFILE_SOURCE_PATH} ${MONGODB_KEYFILE_PATH}
+  chmod 0600 ${MONGODB_KEYFILE_PATH}
+}

--- a/2.4/contrib/initiate_replica.sh
+++ b/2.4/contrib/initiate_replica.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+source /var/lib/mongodb/common.sh
+source /var/lib/mongodb/.bashrc
+
+echo -n "=> Waiting for MongoDB endpoints ..."
+while true; do
+  if [ ! -z "$(endpoints)" ]; then
+    echo $(endpoints)
+    break
+  fi
+  sleep 2
+done
+
+# Let initialize the first member of the cluster
+current_endpoints=$(endpoints)
+mongo_node="$(echo -n ${current_endpoints} | cut -d ' ' -f 1):${CONTAINER_PORT}"
+
+echo "=> Waiting for all endpoints to accept connections..."
+for node in ${current_endpoints}; do
+  wait_for_mongo_up ${node} &>/dev/null
+done
+
+echo "=> Initiating the replSet ${MONGODB_REPLICA_NAME} ..."
+# Start the MongoDB without authentication to initialize and kick-off the cluster:
+# This MongoDB server is just temporary and will be removed later in this
+# script.
+export MONGODB_REPLICA_NAME
+export MONGODB_NO_SUPERVISOR=1
+/usr/local/bin/run-mongod.sh mongod &>/dev/null &
+wait_for_mongo_up
+
+# This will perform the 'rs.initiate()' command on the current MongoDB.
+mongo_initiate &>/dev/null
+
+echo "=> Creating MongoDB users ..."
+mongo_create_users
+
+echo "=> Waiting for replication to finish ..."
+# TODO: Replace this with polling or a Mongo script that will check if all
+#       members of the cluster are now properly replicated (user accounts are
+#       created on all members).
+sleep 10
+
+# Some commands will force MongoDB client to re-connect. This is not working
+# well in combination with '--eval'. In that case the 'mongo' command will fail
+# with return code 254.
+echo "=> Initiate Pod giving up the PRIMARY role ..."
+mongo admin -u admin -p "${MONGODB_ADMIN_PASSWORD}" --quiet --eval "rs.stepDown(120);" &>/dev/null || true
+
+# Wait till the new PRIMARY member is elected
+echo "=> Waiting for the new PRIMARY to be elected ..."
+mongo admin -u admin -p "${MONGODB_ADMIN_PASSWORD}" --quiet --host ${mongo_node} --eval "var done=false;while(done==false){var members=rs.status().members;for(i=0;i<members.length;i++){if(members[i].stateStr=='PRIMARY' && members[i].name!='$(mongo_addr)'){done=true}};sleep(500)};" &>/dev/null
+
+# Remove the initialization container MongoDB from cluster and shutdown
+echo "=> The new PRIMARY member is $(mongo_primary_member_addr), shutting down current member ..."
+mongo_remove
+
+mongod -f ${MONGODB_CONFIG_PATH} --shutdown &>/dev/null
+wait_for_mongo_down
+
+echo "=> Successfully initialized replSet"

--- a/2.4/contrib/replica_supervisor.sh
+++ b/2.4/contrib/replica_supervisor.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+#
+# This script registers the current container into MongoDB replica set and
+# unregisters it when the container is terminated.
+
+source /var/lib/mongodb/common.sh
+source /var/lib/mongodb/.bashrc
+
+# Redirect all stdout && stderr into a FIFO pipe
+exec 1<&-
+exec 2<&-
+exec 1<>$1
+exec 2>&1
+
+echo "=> Waiting for local MongoDB to accept connections ..."
+wait_for_mongo_up
+set -x
+# Add the current container to the replSet
+mongo_add

--- a/2.4/examples/replica/README.md
+++ b/2.4/examples/replica/README.md
@@ -1,0 +1,87 @@
+# MongoDB Replica Set example
+
+**WARNING:**
+
+**This is only a Proof-Of-Concept example and it is not ment to be used in any
+production. Use at your own risk.**
+
+## What is MongoDB Replica Set?
+
+A cluster of MongoDB servers that implements master-slave replication and automated failover.
+MongoDB’s recommended replication strategy.
+
+## Deployment:
+
+In order to run this Docker image, you need to have the latest version of
+OpenShift Origin v3.
+
+* `openshift start --latest-images &> server.log &`
+* `osc create -f ./2.4/examples/replica/mongo_controller.json`
+
+## How does it work?
+
+### Service 'mongodb'
+
+This resource defines a headless Kubernetes Service that serve as an entrypoint
+to the MongoDB cluster. The Service endpoints are the Pods created by the
+MongoDB replication controller.
+Having 'headless' Service means that the `portalIP` attribute of this Service is
+set to `None`. This allows to use DNS queries to discover endpoints of the
+service from inside the container, by quering the Service name (eg. `dig mongodb
+A +short +search`).
+
+### Secret 'mongo-keyfile'
+
+The Secret resource defines the MongoDB 'keyFile[1](http://docs.mongodb.org/manual/tutorial/generate-key-file)' file that MongoDB members use for authorization internally.
+Using keyFile will make the communication more secure.
+
+**WARNING**: The provided `mongo_controller.json` file contains the base64 encoded keyFile, but it is highly recommended to generate your own private file.
+
+### Pod 'mongo-service'
+
+This Pod serves as an replSet initialization member. Inside the
+'initiate_replica.sh' command is ran, which will wait for all members created by
+the ReplicationController to become available and then creates the initial
+MongoDB replica set. This set is then distributed to all members.
+This Pod is a 'run-once' Pod, which means that once the replSet is initialized
+that the members receive the replication data, this Pod is destroyed.
+
+### ReplicationController 'mongo'
+
+This resource defines the PodTemplate of the MongoDB replica member. Each member
+is started as a MongoDB server without replication data. Once the member is up,
+the container will advertise this member to the MongoDB replica PRIMARY member
+and add it into the cluster.
+When this member is removed, the container, before it exits will properly remove
+the member from existing MongoDB cluster.
+
+To add/remove more MongoDB pods to replica set you can use following command:
+
+```
+$ osc update rc mongo --patch='{ "apiVersion": "v1beta1", "desiredState": { "replicas": 4 }}'
+```
+
+The provided `mongo_controller.json` example will start three MongoDB replica by
+default.
+
+## Settings and Security
+
+There are few environment variables that users need to set in order to create
+the MongoDB replSet:
+
+For the 'mongo-service' Pod, you have to set following variables:
+
+* `MONGODB_REPLICA_NAME` - the name of the replSet (`rs0`).
+* `MONGODB_SERVICE_NAME` - the name of the MongoDB Service (used to DNS lookup, default: 'mongodb')
+* `MONGODB_ADMIN_PASSWORD` - the password for the 'admin' user.
+* `MONGODB_USERNAME` - the name of the regular MongoDB user
+* `MONGODB_PASSWORD` - the regular MongoDB user password
+
+For the 'mongo' PodTemplate, you have to set following variables (they have to
+match the variables above):
+
+* `MONGODB_REPLICA_NAME`
+* `MONGODB_SERVICE_NAME`
+* `MONGODB_ADMIN_PASSWORD`
+
+Optionally you can set `MONGODB_DATABASE` (it defaults to `MONGODB_USERNAME`).

--- a/2.4/examples/replica/mongo_controller.json
+++ b/2.4/examples/replica/mongo_controller.json
@@ -1,0 +1,135 @@
+{
+  "kind": "Config",
+  "apiVersion": "v1beta1",
+  "id": "mongo-example",
+  "items":[
+    {
+      "kind": "Service",
+      "apiVersion": "v1beta2",
+      "id": "mongodb",
+      "portalIP": "None",
+      "labels": {
+        "name": "mongodb"
+      },
+      "port": 27017,
+      "selector": {
+        "name": "mongo-replica"
+      }
+    },
+    {
+      "kind": "Secret",
+      "apiVersion": "v1beta3",
+      "metadata": {
+        "name": "mongo-keyfile"
+      },
+      "data": {
+        "keyfile": "WGV2dXN6bjNxLzJUVkEwd25ualhJNmxXODl0NlBFdGw4YmM1MENTTUFGaU9ncDh3U3JCWTA2YVZGamdBdHlYQwpoQlhNUXNQVmUxcFRYYjRPTnRnVE52d0prckVFWmR6Wjd2WWZQclorV3VwK2NsWUlMc3M4QmJuS1g3bjRzbjFJClpjMERKclJZVXNoeEdrcmhQVXNPTlVZM1NDeHorZnFXb1ljcjV1YmE3MDlib3FMQ0N1Vy90Z0laQUhGUkQ0QXYKZ2JZU1owYTQ5NmZMMGx5ZUZxS3R4a0w2aW1OUEM3dExsY3I0OUwzMGdZMkhiQmRHOGhYRnF0TkdPS2pIWVViagoxTEoxNE9nOG0zYWZDYy9DaUY1WGdaZWx2cDFhb3gwZzRGK05pR1lUWVVHTEZNT3k3UjFTc01TRFBIT2NDMWlyCllBN25KZEJoaWl5cTRteVFQa0ZxSmM1TnJEZml1QlA5STFKNEpuQ3dKUml5MThmSzNoNjJwMzBkeWNWK2dkMkQKRTk3Y0N3NzdRSmtTdXRsY29oMWZwQ2gwSVlhdDNNalBYSCtacDRkdzZFZ3Q3STlYRmJQeHdqaGk1NW5icXhodwpYbVl1R1RETDVBUm55OFNZWUdVa0dXWk5VZzRsUlhSV0xGSTdCTGdnQmJ3QjhCQzl2eS90YmJ6a0xoVjZRUnJlCm1XZVYxRVhDMDYwM3FqT1cvcEFkN2JodFkwM3pMYXduUElXZWc2UEpkL3l4T0lYbjFsN1pHdkxpRzhsbXlpY3EKeVZyS1c0M3V2Nk1tTVZWam5BL1B2MituclBuSWcyQVgrdVJWc1JVdFRQZXpta0FQOEJCNjhaRUJscWhMUXNpMQpQSVhuUFdHMVozN3JYVjVQZHlyMTJrWUlhQzBBM0NRNDNMakRjYjJTT3FNNnlmOEdzc2hqamZnYXpiZEcraEw3Ck9PMU9LeVhyWEFWamx4dGRydm9UQ0UwcEFYQjFJSWdqN21NZ2lPM2pNZ0lwSUxSOERqNVdyeFdTNDhaZkdtbFUKT1hxcUJma0NvZWp0ZmhaWmxzeW85bFJUK0orWlRqTnlJMXZ3YXVWMmNBKzJvSzJGcDBRRDY1SVdZSUdLcnlxcwphRXh6SCtoNXdlbUp0VWMrT0FNUnUrMlFBVTJ4Q3NUMm1ORzNhMzhLdUVEYkRPUE9MRUxZWlg0QlRuTFRKMkNMCnBpd2JxV3FzeXpVOXVMSktIVjNKSHR4QTB3aFZKZWI3dllXU281N0c5K1MxRXFVK1Nha1cwWEZ6SjR0WjRWY3gKQ0srUk5sdWZycTZ4bVdhV2x3alFtVm9Ob1lvZQo="
+      }
+    },
+    {
+      "kind": "Pod",
+      "apiVersion": "v1beta2",
+      "id": "mongo-service",
+      "labels": {
+        "name": "mongo-service"
+      },
+      "desiredState": {
+        "manifest": {
+          "restartPolicy": {
+            "never": {}
+          },
+          "volumes": [
+            {
+              "name": "keyfile",
+              "source": {
+                "secret": {
+                  "target": { "name": "mongo-keyfile" }
+                }
+              }
+            }
+          ],
+          "containers": [
+            {
+              "name": "initiate",
+              "image": "openshift/mongodb-24-centos7",
+              "command": ["initiate"],
+              "volumeMounts": [
+                {
+                  "name": "keyfile",
+                  "readOnly": true,
+                  "mountPath": "/var/run/secrets/mongo"
+                }
+              ],
+              "env": [
+                { "name": "MONGODB_USERNAME",       "value": "testuser" },
+                { "name": "MONGODB_PASSWORD",       "value": "test" },
+                { "name": "MONGODB_ADMIN_PASSWORD", "value": "admin" },
+                { "name": "MONGODB_REPLICA_NAME",   "value": "rs0" },
+                { "name": "MONGODB_SERVICE_NAME",   "value": "mongodb" }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
+      "kind": "ReplicationController",
+      "apiVersion": "v1beta2",
+      "id": "mongo",
+      "metadata": {
+        "name": "mongo",
+        "labels": {
+          "name":"mongo"
+        }
+      },
+      "desiredState": {
+        "replicas": 3,
+        "replicaSelector": {
+          "name": "mongo-replica"
+        },
+        "podTemplate": {
+          "labels": {
+            "name": "mongo-replica"
+          },
+          "desiredState": {
+            "manifest": {
+              "volumes": [
+                {
+                  "name": "keyfile",
+                  "source": {
+                    "secret": {
+                      "target": { "name": "mongo-keyfile" }
+                    }
+                  }
+                }
+              ],
+              "containers":[
+                {
+                  "name":  "member",
+                  "image": "openshift/mongodb-24-centos7",
+                  "volumeMounts": [
+                    {
+                      "name": "keyfile",
+                      "readOnly": true,
+                      "mountPath": "/var/run/secrets/mongo"
+                    }
+                  ],
+                  "env": [
+                    { "name": "MONGODB_REPLICA_NAME",   "value": "rs0" },
+                    { "name": "MONGODB_SERVICE_NAME",   "value": "mongodb" },
+                    { "name": "MONGODB_ADMIN_PASSWORD", "value": "admin" }
+                  ],
+                  "ports":[
+                    {
+                      "containerPort": 27017
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/2.4/examples/replica/teardown.sh
+++ b/2.4/examples/replica/teardown.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+osc delete services/mongodb
+osc update rc mongo --patch='{ "apiVersion": "v1beta1", "desiredState": { "replicas": 0 }}'
+osc delete rc mongo
+osc delete pods mongo-service
+osc delete secret mongo-keyfile


### PR DESCRIPTION
TODO:
- [x] Add authentication back and use keyFile for inter-mongo communication
- [ ] Re-create the replicaSet if all Pods died, but there is a persistent storage
- [x] Add more documentation about how this works
