### PR TITLE
Mandatory admin user

### DIFF
--- a/2.4/contrib/common.sh
+++ b/2.4/contrib/common.sh
@@ -148,11 +148,10 @@ function run_mongod_supervisor() {
 # mongo_create_users creates the MongoDB admin user and the database user
 # configured by MONGO_USER
 function mongo_create_users() {
-  local admin_pwd=${MONGODB_ADMIN_PASSWORD:-$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c16)}
-  mongo admin --eval "db.addUser({user: 'admin', pwd: '$admin_pwd', roles: ['dbAdminAnyDatabase', 'userAdminAnyDatabase' , 'readWriteAnyDatabase','clusterAdmin' ]});"
+  mongo admin --eval "db.addUser({user: 'admin', pwd: '${MONGODB_ADMIN_PASSWORD}', roles: ['dbAdminAnyDatabase', 'userAdminAnyDatabase' , 'readWriteAnyDatabase','clusterAdmin' ]});"
   local mongo_cmd="mongo ${MONGODB_DATABASE}"
   if [ ! -z "${MONGODB_REPLICA_NAME-}" ]; then
-    mongo_cmd+=" -u admin -p ${admin_pwd}"
+    mongo_cmd+=" -u admin -p ${MONGODB_ADMIN_PASSWORD}"
   fi
   $mongo_cmd --eval "db.addUser({user: '${MONGODB_USER}', pwd: '${MONGODB_PASSWORD}', roles: [ 'readWrite' ]});"
   touch /var/lib/mongodb/data/.mongodb_users_created

--- a/2.4/run-mongod.sh
+++ b/2.4/run-mongod.sh
@@ -24,9 +24,9 @@ function usage() {
   echo "You must specify following environment variables:"
   echo "  MONGODB_USER"
   echo "  MONGODB_PASSWORD"
-  echo "Optional variables:"
-  echo "  MONGODB_DATABASE (default: \$MONGODB_USER)"
+  echo "  MONGODB_DATABASE"
   echo "  MONGODB_ADMIN_PASSWORD"
+  echo "Optional variables:"
   echo "  MONGODB_REPLICA_NAME"
   echo "MongoDB settings:"
   echo "  MONGODB_NOPREALLOC (default: true)"
@@ -55,7 +55,7 @@ function cleanup() {
 }
 
 if [ "$1" == "initiate" ]; then
-  if ! [[ -v MONGODB_USER && -v MONGODB_PASSWORD ]]; then
+  if ! [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE && -v MONGODB_ADMIN_PASSWORD ]]; then
     usage
   fi
   setup_keyfile
@@ -70,10 +70,9 @@ if [ "$1" = "mongod" ]; then
   cache_container_addr
   mongo_common_args="-f $MONGODB_CONFIG_PATH --oplogSize 64"
   if [ -z "${MONGODB_REPLICA_NAME-}" ]; then
-    if ! [[ -v MONGODB_USER && -v MONGODB_PASSWORD ]]; then
+    if ! [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE && -v MONGODB_ADMIN_PASSWORD ]]; then
       usage
     fi
-    export MONGODB_DATABASE=${MONGODB_DATABASE:-"${MONGODB_USER}"}
     # Run the MongoDB in 'standalone' mode
     if [ ! -f /var/lib/mongodb/data/.mongodb_users_created ]; then
       # Create MongoDB users and restart MongoDB with authentication enabled

--- a/2.4/test/run
+++ b/2.4/test/run
@@ -128,8 +128,6 @@ function run_tests() {
 
 # Tests.
 run_configuration_tests
-USER="user" PASS="pass" DB="test_db" run_tests no_admin
 USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin
 # Test with random uid in container
-CONTAINER_ARGS="-u 12345" USER="user" PASS="pass" DB="test_db" run_tests no_admin_altuid
 CONTAINER_ARGS="-u 12345" USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin_altuid

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ initialization, by passing `-e VAR=VALUE` to the Docker run command.
 |  `MONGODB_USER`       | User name for MONGODB account to be created |
 |  `MONGODB_PASSWORD`       | Password for the user account               |
 |  `MONGODB_DATABASE`       | Database name                               |
-|  `MONGODB_ADMIN_PASSWORD` | Password for the admin user (optional)      |
+|  `MONGODB_ADMIN_PASSWORD` | Password for the admin user                 |
 
 
 Following environment variables influence MongoDB configuration file. They are all optional.
@@ -95,23 +95,23 @@ in the `/home/user/database` directory on the host filesystem, you need to
 execute the following command:
 
 ```
-$ docker run -d -e MONGODB_USER=<user> -e MONGODB_PASSWORD=<password> -e MONGODB_DATABASE=<database> -v /home/user/database:/var/lib/mongodb/data openshift/mongodb-24-centos7
+$ docker run -d -e MONGODB_USER=<user> -e MONGODB_PASSWORD=<password> -e MONGODB_DATABASE=<database> -e MONGODB_ADMIN_PASSWORD=<admin_password> -v /home/user/database:/var/lib/mongodb/data openshift/mongodb-24-centos7
 ```
 
 If you are initializing the database and it's the first time you are using the
 specified shared volume, the database will be created, together with database
-administrator user and also MongoDB admin user if `MONGODB_ADMIN_PASSWORD`
-environment variable is specified. After that the MongoDB daemon will be started.
-If you are re-attaching the volume to another container the creation of the
-database user and the admin user will be skipped and only the mongodb daemon
-will be started.
+administrator user and also MongoDB admin user. After that the MongoDB daemon 
+will be started. If you are re-attaching the volume to another container the 
+creation of the database user and the admin user will be skipped and only the 
+mongodb daemon will be started.
 
 
 MongoDB admin user
 ---------------------------------
-The admin user is not set by default. You can create one by setting
-`MONGODB_ADMIN_PASSWORD` environment variable, in which case the admin user name
-will be set to `admin`. This process is done upon initializing the database.
+
+Admin user name is set to `admin` and you have to to specify his password by
+setting `MONGODB_ADMIN_PASSWORD` environment variable. This process is done
+upon database initialization.
 
 
 Test


### PR DESCRIPTION
Making admin user mandatory, since once the mongodb is launched in authentication mode with `--auth` flag, there is no easy way how to create admin user retrospectively, after the DB was created without admin user.
