### PR TITLE
Renaming 'Database has been initialized' marker file

### DIFF
--- a/2.4/contrib/common.sh
+++ b/2.4/contrib/common.sh
@@ -154,7 +154,7 @@ function mongo_create_users() {
     mongo_cmd+=" -u admin -p ${MONGODB_ADMIN_PASSWORD}"
   fi
   $mongo_cmd --eval "db.addUser({user: '${MONGODB_USER}', pwd: '${MONGODB_PASSWORD}', roles: [ 'readWrite' ]});"
-  touch /var/lib/mongodb/data/.mongodb_users_created
+  touch /var/lib/mongodb/data/.mongodb_datadir_initialized
 }
 
 # setup_keyfile fixes the bug in mounting the Kubernetes 'Secret' volume that

--- a/2.4/run-mongod.sh
+++ b/2.4/run-mongod.sh
@@ -74,7 +74,7 @@ if [ "$1" = "mongod" ]; then
       usage
     fi
     # Run the MongoDB in 'standalone' mode
-    if [ ! -f /var/lib/mongodb/data/.mongodb_users_created ]; then
+    if [ ! -f /var/lib/mongodb/data/.mongodb_datadir_initialized ]; then
       # Create MongoDB users and restart MongoDB with authentication enabled
       # At this time the MongoDB does not accept the incoming connections.
       mongod $mongo_common_args & #--bind_ip 127.0.0.1 --quiet >/dev/null &


### PR DESCRIPTION
Based on the discussion with @mfojtik and @hhorak Im renaming the marker file 
