### PR TITLE
Print message if database directory is already initialized.

### DIFF
--- a/2.4/run-mongod.sh
+++ b/2.4/run-mongod.sh
@@ -84,7 +84,7 @@ if [ "$1" = "mongod" ]; then
       mongod $mongo_common_args --shutdown
       wait_for_mongo_down
     else
-      echo "=> Database directory is already initialized. Skipping creation of users..."
+      echo "=> Database directory is already initialized. Skipping creation of users ..."
     fi
     unset_env_vars
     exec mongod $mongo_common_args --auth

--- a/2.4/run-mongod.sh
+++ b/2.4/run-mongod.sh
@@ -83,6 +83,8 @@ if [ "$1" = "mongod" ]; then
       # Restart the MongoDB daemon to bind on all interfaces
       mongod $mongo_common_args --shutdown
       wait_for_mongo_down
+    else
+      echo "=> Database directory is already initialized. Skipping creation of users..."
     fi
     unset_env_vars
     exec mongod $mongo_common_args --auth


### PR DESCRIPTION
Container user is not notified if database directory is already initialized and new database users are not created. So now environmental variables in container for linking could be invalid and container user don't know about it.

For example when you run container with reattached data directory, you can specify different env variables (for example you don't know that data directory is already initialized) and you are not notified that database users were already initialized and database users specified by you weren't created.
