### PR TITLE
Fix replication of MongoDB

### DIFF
--- a/2.4/contrib/common.sh
+++ b/2.4/contrib/common.sh
@@ -7,8 +7,7 @@ SLEEP_TIME=1
 export MONGODB_CONFIG_PATH=/var/lib/mongodb/mongodb.conf
 export MONGODB_PID_FILE=/var/lib/mongodb/mongodb.pid
 export MONGODB_KEYFILE_PATH=/var/lib/mongodb/keyfile
-
-export CONTAINER_PORT=$(echo -n $IMAGE_EXPOSE_SERVICES | cut -d ':' -f 1)
+export CONTAINER_PORT=27017
 
 # container_addr returns the current container external IP address
 function container_addr() {
@@ -94,8 +93,6 @@ function no_endpoints() {
   [ "$(endpoints)" == "$(container_addr)" ]
 }
 
-
-
 # build_mongo_config builds the MongoDB replicaSet config used for the cluster
 # initialization
 function build_mongo_config() {
@@ -149,12 +146,10 @@ function run_mongod_supervisor() {
 # mongo_create_users creates the MongoDB admin user and the database user
 # configured by MONGO_USER
 function mongo_create_users() {
-  mongo admin --eval "db.addUser({user: 'admin', pwd: '${MONGODB_ADMIN_PASSWORD}', roles: ['dbAdminAnyDatabase', 'userAdminAnyDatabase' , 'readWriteAnyDatabase','clusterAdmin' ]});"
-  local mongo_cmd="mongo ${MONGODB_DATABASE}"
-  if [ ! -z "${MONGODB_REPLICA_NAME-}" ]; then
-    mongo_cmd+=" -u admin -p ${MONGODB_ADMIN_PASSWORD}"
-  fi
-  $mongo_cmd --eval "db.addUser({user: '${MONGODB_USER}', pwd: '${MONGODB_PASSWORD}', roles: [ 'readWrite' ]});"
+  mongo ${MONGODB_DATABASE} --eval "db.addUser({user: '${MONGODB_USER}', pwd: '${MONGODB_PASSWORD}', roles: [ 'readWrite' ]});"
+ 
+  mongo admin --eval "db.addUser({user: 'admin', pwd: '${MONGODB_ADMIN_PASSWORD}', roles: ['dbAdminAnyDatabase', 'userAdminAnyDatabase' , 'readWriteAnyDatabase','clusterAdmin' ]})"
+
   touch /var/lib/mongodb/data/.mongodb_datadir_initialized
 }
 

--- a/2.4/contrib/initiate_replica.sh
+++ b/2.4/contrib/initiate_replica.sh
@@ -25,12 +25,11 @@ echo "=> Initiating the replSet ${MONGODB_REPLICA_NAME} ..."
 # This MongoDB server is just temporary and will be removed later in this
 # script.
 export MONGODB_REPLICA_NAME
-export MONGODB_NO_SUPERVISOR=1
-/usr/local/bin/run-mongod.sh mongod &>/dev/null &
+MONGODB_NO_SUPERVISOR=1 MONGODB_NO_AUTH=1 /usr/local/bin/run-mongod.sh mongod &
 wait_for_mongo_up
 
 # This will perform the 'rs.initiate()' command on the current MongoDB.
-mongo_initiate &>/dev/null
+mongo_initiate
 
 echo "=> Creating MongoDB users ..."
 mongo_create_users

--- a/2.4/examples/replica/mongodb_controller.json
+++ b/2.4/examples/replica/mongodb_controller.json
@@ -11,6 +11,9 @@
       "tags": "database,mongodb,replication"
     }
   },
+  "labels": {
+    "template": "mongodb-replica-example"
+  },
   "parameters": [
     {
       "name": "MONGODB_USER",
@@ -57,9 +60,9 @@
       "kind": "Service",
       "apiVersion": "v1",
       "metadata": {
-        "name": "mongodb",
+        "name": "${MONGODB_SERVICE_NAME}",
         "labels": {
-          "name": "mongodb"
+          "name": "${MONGODB_SERVICE_NAME}"
         }
       },
       "spec": {
@@ -83,8 +86,8 @@
       }
     },
     {
-      "kind": "DeploymentConfig",
-      "apiVersion": "v1",
+      "kind": "Pod",
+      "apiVersion": "v1beta3",
       "metadata": {
         "name": "mongodb-service",
         "creationTimestamp": null,
@@ -93,76 +96,52 @@
         }
       },
       "spec": {
-        "strategy": {
-          "type": "Recreate",
-          "resources": {}
-        },
-        "triggers": [
+        "restartPolicy": "Never",
+        "dnsPolicy": "ClusterFirst",
+        "containers": [
           {
-            "type":"ConfigChange"
-          }
-        ],
-        "replicas": 1,
-        "selector": {
-          "name": "mongodb-replica"
-        },
-        "template": {
-          "metadata": {
-            "creationTimestamp": null,
-            "labels": {
-              "name": "mongodb-replica"
-            }
-          },
-          "spec": {
-            "containers": [
+            "name": "initiate",
+            "image": "openshift/mongodb-24-centos7",
+            "args": ["initiate"],
+            "env": [
               {
-                "name": "initiate",
-                "image": "openshift/mongodb-24-centos7",
-                "args": ["initiate"],
-                "env": [
-                  {
-                    "name": "MONGODB_USER",
-                    "value": "${MONGODB_USER}"
-                  },
-                  {
-                    "name": "MONGODB_PASSWORD",
-                    "value": "${MONGODB_PASSWORD}"
-                  },
-                  {
-                    "name": "MONGODB_DATABASE",
-                    "value": "${MONGODB_DATABASE}"
-                  },
-                  {
-                    "name": "MONGODB_ADMIN_PASSWORD",
-                    "value": "${MONGODB_ADMIN_PASSWORD}"
-                  },
-                  {
-                    "name": "MONGODB_REPLICA_NAME",
-                    "value": "${MONGODB_REPLICA_NAME}"
-                  },
-                  {
-                    "name": "MONGODB_SERVICE_NAME",
-                    "value": "${MONGODB_SERVICE_NAME}"
-                  },
-                  {
-                    "name": "MONGODB_KEYFILE_VALUE",
-                    "value": "${MONGODB_KEYFILE_VALUE}"
-                  }
-                ]
+                "name": "MONGODB_USER",
+                "value": "${MONGODB_USER}"
+              },
+              {
+                "name": "MONGODB_PASSWORD",
+                "value": "${MONGODB_PASSWORD}"
+              },
+              {
+                "name": "MONGODB_DATABASE",
+                "value": "${MONGODB_DATABASE}"
+              },
+              {
+                "name": "MONGODB_ADMIN_PASSWORD",
+                "value": "${MONGODB_ADMIN_PASSWORD}"
+              },
+              {
+                "name": "MONGODB_REPLICA_NAME",
+                "value": "${MONGODB_REPLICA_NAME}"
+              },
+              {
+                "name": "MONGODB_SERVICE_NAME",
+                "value": "${MONGODB_SERVICE_NAME}"
+              },
+              {
+                "name": "MONGODB_KEYFILE_VALUE",
+                "value": "${MONGODB_KEYFILE_VALUE}"
               }
             ]
           }
-        },
-        "restartPolicy": "Never",
-        "dnsPolicy": "ClusterFirst"
-      },
-      "status": {}
+        ]
+      }
     },
     {
       "kind": "DeploymentConfig",
       "apiVersion": "v1",
       "metadata": {
-        "name": "mongodb",
+        "name": "${MONGODB_SERVICE_NAME}",
         "creationTimestamp": null
       },
       "spec": {
@@ -175,7 +154,7 @@
             "type":"ConfigChange"
           }
         ],
-        "replicas": 1,
+        "replicas": 3,
         "selector": {
           "name": "mongodb-replica"
         },

--- a/2.4/run-mongod.sh
+++ b/2.4/run-mongod.sh
@@ -94,9 +94,15 @@ if [ "$1" = "mongod" ]; then
       run_mongod_supervisor
       trap 'cleanup' SIGINT SIGTERM
     fi
+    auth_args=" --auth"
+    # When initializing the MongoDB cluster, we have to run without
+    # authentication
+    if [ ! -v MONGODB_NO_AUTH ]; then
+      auth_args=""
+    fi
     unset_env_vars
     mongod $mongo_common_args --replSet ${MONGODB_REPLICA_NAME} \
-      --keyFile ${MONGODB_KEYFILE_PATH} --auth & mongo_pid=$!
+      --keyFile ${MONGODB_KEYFILE_PATH} ${auth_args} & mongo_pid=$!
     wait $mongo_pid
   fi
 else


### PR DESCRIPTION
- Remove `IMAGE_EXPOSE_SERVICES` as we don't use it anymore
- Create userdb first and admin afterwards (for some reason this fixed replication....)
- The `mongodb-service` is a Pod not DeploymentConfig (runs just once to initialize the replSet)
