### PR TITLE
Add support for atomic command

### DIFF
--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -19,10 +19,25 @@ LABEL io.k8s.description="MongoDB is a scalable, high-performance, open source N
       io.openshift.expose-services="27017:mongodb" \
       io.openshift.tags="database,mongodb,mongodb24"
 
+# Support for atomic run/install/uninstall
+LABEL INSTALL docker run -t -i --rm --privileged -u 0:0 -v /:/host --net=host \
+      --ipc=host --pid=host -e HOST=/host -e LOGDIR=\${LOGDIR} -e CONFDIR=\${CONFDIR} \
+      -e DATADIR=\${DATADIR} -e IMAGE=\${IMAGE} -e NAME=\${NAME} -e OPT1 -e OPT2 -e OPT3 \
+      \${OPT1} \${IMAGE} /usr/share/cont-layer/mongodb/atomic/install.sh
+
+LABEL UNINSTALL docker run -t -i --rm --privileged -u 0:0 -v /:/host --net=host \
+      --ipc=host --pid=host -e HOST=/host -e LOGDIR=\${LOGDIR} -e CONFDIR=\${CONFDIR} \
+      -e DATADIR=\${DATADIR} -e IMAGE=\${IMAGE} -e NAME=\${NAME} -e OPT1 -e OPT2 -e OPT3 \
+      \${OPT1} \${IMAGE} /usr/share/cont-layer/mongodb/atomic/uninstall.sh
+
+LABEL RUN docker run -t -i --rm --name=\${NAME} -e OPT1 -e OPT2 -e OPT3 \${OPT1} \
+      \${IMAGE}
+
 EXPOSE 27017
 
 COPY run-mongod.sh /usr/local/bin/
 COPY contrib /var/lib/mongodb/
+COPY atomic /usr/share/cont-layer/mongodb/atomic/
 
 # This image must forever use UID 184 for mongodb user and GID 998 for the
 # mongodb group, so our volumes are safe in the future. This should *never*

--- a/2.4/Dockerfile.rhel7
+++ b/2.4/Dockerfile.rhel7
@@ -24,10 +24,25 @@ LABEL Component="mongodb24" \
       Version="2.4" \
       Release="1"
 
+# Support for atomic run/install/uninstall
+LABEL INSTALL docker run -t -i --rm --privileged -u 0:0 -v /:/host --net=host \
+      --ipc=host --pid=host -e HOST=/host -e LOGDIR=\${LOGDIR} -e CONFDIR=\${CONFDIR} \
+      -e DATADIR=\${DATADIR} -e IMAGE=\${IMAGE} -e NAME=\${NAME} -e OPT1 -e OPT2 -e OPT3 \
+      \${OPT1} \${IMAGE} /usr/share/cont-layer/mongodb/atomic/install.sh
+
+LABEL UNINSTALL docker run -t -i --rm --privileged -u 0:0 -v /:/host --net=host \
+      --ipc=host --pid=host -e HOST=/host -e LOGDIR=\${LOGDIR} -e CONFDIR=\${CONFDIR} \
+      -e DATADIR=\${DATADIR} -e IMAGE=\${IMAGE} -e NAME=\${NAME} -e OPT1 -e OPT2 -e OPT3 \
+      \${OPT1} \${IMAGE} /usr/share/cont-layer/mongodb/atomic/uninstall.sh
+
+LABEL RUN docker run -t -i --rm --name=\${NAME} -e OPT1 -e OPT2 -e OPT3 \${OPT1} \
+      \${IMAGE}
+
 EXPOSE 27017
 
 COPY run-mongod.sh /usr/local/bin/
 COPY contrib /var/lib/mongodb/
+COPY atomic /usr/share/cont-layer/mongodb/atomic/
 
 # This image must forever use UID 184 for mongodb user and GID 998 for the
 # mongodb group, so our volumes are safe in the future. This should *never*

--- a/2.4/atomic/include.sh
+++ b/2.4/atomic/include.sh
@@ -1,0 +1,11 @@
+# Check whether all required variables are set
+if ! [ -v NAME -a -v IMAGE -a -v HOST ] ; then
+  echo "Environment variables NAME, IMAGE and HOST must be set."
+  exit 1
+fi
+
+# Define well-known directories and names on the host
+DATADIR=${DATADIR:-/var/lib/${NAME}}
+CONFDIR=${CONFDIR:-/etc/${NAME}}
+LOGDIR=${LOGDIR:-/var/log/${NAME}}
+

--- a/2.4/atomic/install.sh
+++ b/2.4/atomic/install.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+. /usr/share/cont-layer/mongodb/atomic/include.sh
+
+# Make Data Dirs
+mkdir -p ${HOST}/${CONFDIR} ${HOST}/${LOGDIR} ${HOST}/${DATADIR}
+
+chown -R mongodb.mongodb "${HOST}/${DATADIR}"
+chmod -R 770 "${HOST}/${DATADIR}"
+
+# Install mongod.conf
+cp /var/lib/mongodb/mongodb.conf ${HOST}/${CONFDIR}/mongod.conf
+echo "logpath=/var/opt/rh/rh-mongodb26/lib/mongodb/mongod.log" >> ${HOST}/${CONFDIR}/mongod.conf
+
+# create container on host
+chroot ${HOST} /usr/bin/docker create -v ${DATADIR}:/var/lib/mongodb/data:Z -v ${CONFDIR}/mongod.conf:/etc/mongod.conf -v ${LOGDIR}:/var/opt/rh/rh-mongodb26/log/mongodb --name ${NAME} ${OPT1} ${IMAGE}
+
+# Create and enable systemd unit file for the service
+sed -e "s/TEMPLATE/${NAME}/g" /usr/share/cont-layer/mongodb/atomic/template.service > ${HOST}/etc/systemd/system/${NAME}.service
+chroot ${HOST} /usr/bin/systemctl enable /etc/systemd/system/${NAME}.service
+

--- a/2.4/atomic/template.service
+++ b/2.4/atomic/template.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=MongoDB 2.6 database server
+After=docker.service
+BindTo=docker.service
+
+[Service]
+ExecStart=/usr/bin/docker start -a TEMPLATE
+ExecStop=/usr/bin/docker stop TEMPLATE
+
+[Install]
+WantedBy=multi-user.target
+

--- a/2.4/atomic/uninstall.sh
+++ b/2.4/atomic/uninstall.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+. /usr/share/cont-layer/mongodb/atomic/include.sh
+
+chroot ${HOST} /usr/bin/systemctl disable ${NAME}.service
+chroot ${HOST} /usr/bin/systemctl stop ${NAME}.service
+rm -f ${HOST}/etc/systemd/system/${NAME}.service
+
+# Remove config file
+rm -f ${HOST}/${CONFDIR}/mongod.conf


### PR DESCRIPTION
Atomic command is standard way to run containers on Atomic host. This adds support for running this image on such a system using atomic install/uninstall/run, as described at https://github.com/projectatomic/atomic/.
