### PR TITLE
Remove MAINTAINER in RHEL image

### DIFF
--- a/2.4/Dockerfile.rhel7
+++ b/2.4/Dockerfile.rhel7
@@ -1,6 +1,4 @@
 FROM rhel7
-MAINTAINER SoftwareCollections.org <sclorg@redhat.com>
-
 # MongoDB image for OpenShift.
 #
 # Volumes:

--- a/2.6/Dockerfile.rhel7
+++ b/2.6/Dockerfile.rhel7
@@ -1,6 +1,4 @@
 FROM rhel7
-MAINTAINER SoftwareCollections.org <sclorg@redhat.com>
-
 # MongoDB image for OpenShift.
 #
 # Volumes:


### PR DESCRIPTION
We don't use MAINTAINER internally.
