### PR TITLE
Re-ensure that hosts are ready before rs.initiate

### DIFF
--- a/2.4/root/usr/share/container-scripts/mongodb/initiate_replica.sh
+++ b/2.4/root/usr/share/container-scripts/mongodb/initiate_replica.sh
@@ -15,10 +15,7 @@ done
 current_endpoints=$(endpoints)
 mongo_node="$(echo -n ${current_endpoints} | cut -d ' ' -f 1):${CONTAINER_PORT}"
 
-echo "=> Waiting for all endpoints to accept connections..."
-for node in ${current_endpoints}; do
-  wait_for_mongo_up ${node} &>/dev/null
-done
+wait_for_all_hosts
 
 echo "=> Initiating the replSet ${MONGODB_REPLICA_NAME} ..."
 # Start the MongoDB without authentication to initialize and kick-off the cluster:

--- a/2.6/root/usr/share/container-scripts/mongodb/initiate_replica.sh
+++ b/2.6/root/usr/share/container-scripts/mongodb/initiate_replica.sh
@@ -15,10 +15,7 @@ done
 current_endpoints=$(endpoints)
 mongo_node="$(echo -n ${current_endpoints} | cut -d ' ' -f 1):${CONTAINER_PORT}"
 
-echo "=> Waiting for all endpoints to accept connections..."
-for node in ${current_endpoints}; do
-  wait_for_mongo_up ${node} &>/dev/null
-done
+wait_for_all_hosts
 
 echo "=> Initiating the replSet ${MONGODB_REPLICA_NAME} ..."
 # Start the MongoDB without authentication to initialize and kick-off the cluster:


### PR DESCRIPTION
We've noticed an intermittent issue where sometimes the rs.initiate
doesn't work successfully. This seems to be because not all of the hosts
discovered just beforehand in the call to build_mongo_config, are ready.

This _should_ be handled by the waiting that occurred in
initiate_replica.sh, but it seems that sometimes not all of the hosts
are up at that point (not all IPs are discoverable). The later
call (endpoints function) that happens in build_mongo_config then
sometimes finds more, but they're not checked to be ready.

This change performs the wait in two places: the original place (in case
there was some reason that it needed to happen before something else
there), and right before the call to rs.initiate. This should ensure
that any new hosts discovered in the build_mongo_config are ready for
replication.
