### PR TITLE
common.sh(setup_keyfile): fix unbound variable error

### DIFF
--- a/2.4/root/usr/share/container-scripts/mongodb/common.sh
+++ b/2.4/root/usr/share/container-scripts/mongodb/common.sh
@@ -165,8 +165,8 @@ function mongo_reset_passwords() {
 # setup_keyfile fixes the bug in mounting the Kubernetes 'Secret' volume that
 # mounts the secret files with 'too open' permissions.
 function setup_keyfile() {
-  if [ -z "${MONGODB_KEYFILE_VALUE}" ]; then
-    echo "ERROR: You have to provide the 'keyfile' value in ${MONGODB_KEYFILE_VALUE}"
+  if [ -z "${MONGODB_KEYFILE_VALUE-}" ]; then
+    echo "ERROR: You have to provide the 'keyfile' value in $MONGODB_KEYFILE_VALUE"
     exit 1
   fi
   echo ${MONGODB_KEYFILE_VALUE} > ${MONGODB_KEYFILE_PATH}

--- a/2.6/root/usr/share/container-scripts/mongodb/common.sh
+++ b/2.6/root/usr/share/container-scripts/mongodb/common.sh
@@ -165,8 +165,8 @@ function mongo_reset_passwords() {
 # setup_keyfile fixes the bug in mounting the Kubernetes 'Secret' volume that
 # mounts the secret files with 'too open' permissions.
 function setup_keyfile() {
-  if [ -z "${MONGODB_KEYFILE_VALUE}" ]; then
-    echo "ERROR: You have to provide the 'keyfile' value in ${MONGODB_KEYFILE_VALUE}"
+  if [ -z "${MONGODB_KEYFILE_VALUE-}" ]; then
+    echo "ERROR: You have to provide the 'keyfile' value in MONGODB_KEYFILE_VALUE"
     exit 1
   fi
   echo ${MONGODB_KEYFILE_VALUE} > ${MONGODB_KEYFILE_PATH}


### PR DESCRIPTION
Before:

```
/usr/share/container-scripts/mongodb/common.sh: line 168: MONGODB_KEYFILE_VALUE: unbound variable
```

After:

```
ERROR: You have to provide the 'keyfile' value in MONGODB_KEYFILE_VALUE
```

@rhcarvalho @bparees PTAL
