### PR TITLE
Fix version typo mongo26 to mongo24

### DIFF
--- a/2.4/Dockerfile.rhel7
+++ b/2.4/Dockerfile.rhel7
@@ -41,7 +41,7 @@ RUN yum install -y yum-utils && \
 
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mongodb \
-    MONGODB_PREFIX=/opt/rh/mongodb26/root/usr \
+    MONGODB_PREFIX=/opt/rh/mongodb24/root/usr \
     ENABLED_COLLECTIONS=mongodb24
 
 # When bash is started non-interactively, to run a shell script, for example it


### PR DESCRIPTION
Fix `mongo26` in Mongo 2.4 script
