### PR TITLE
Fix race condition when regular empty file was created before fifo file

### DIFF
--- a/2.4/root/usr/share/container-scripts/mongodb/common.sh
+++ b/2.4/root/usr/share/container-scripts/mongodb/common.sh
@@ -139,10 +139,7 @@ function mongo_add() {
 # run_mongod_supervisor runs the MongoDB replica supervisor that manages
 # registration of the new members to the MongoDB replica cluster
 function run_mongod_supervisor() {
-  local log_pipe_path=$(mktemp --suffix=log)
-  rm -rf ${log_pipe_path}
-  ( mkfifo ${log_pipe_path} && cat ${log_pipe_path} ) &
-  ${CONTAINER_SCRIPTS_PATH}/replica_supervisor.sh ${log_pipe_path} &
+  ${CONTAINER_SCRIPTS_PATH}/replica_supervisor.sh 2>&1 &
 }
 
 # mongo_create_users creates the MongoDB admin user and the database user

--- a/2.4/root/usr/share/container-scripts/mongodb/replica_supervisor.sh
+++ b/2.4/root/usr/share/container-scripts/mongodb/replica_supervisor.sh
@@ -5,12 +5,6 @@
 
 source  ${CONTAINER_SCRIPTS_PATH}/common.sh
 
-# Redirect all stdout && stderr into a FIFO pipe
-exec 1<&-
-exec 2<&-
-exec 1<>$1
-exec 2>&1
-
 echo "=> Waiting for local MongoDB to accept connections ..."
 wait_for_mongo_up
 set -x

--- a/2.6/root/usr/share/container-scripts/mongodb/common.sh
+++ b/2.6/root/usr/share/container-scripts/mongodb/common.sh
@@ -139,10 +139,7 @@ function mongo_add() {
 # run_mongod_supervisor runs the MongoDB replica supervisor that manages
 # registration of the new members to the MongoDB replica cluster
 function run_mongod_supervisor() {
-  local log_pipe_path=$(mktemp --suffix=log)
-  rm -rf ${log_pipe_path}
-  ( mkfifo ${log_pipe_path} && cat ${log_pipe_path} ) &
-  ${CONTAINER_SCRIPTS_PATH}/replica_supervisor.sh ${log_pipe_path} &
+  ${CONTAINER_SCRIPTS_PATH}/replica_supervisor.sh 2>&1 &
 }
 
 # mongo_create_users creates the MongoDB admin user and the database user

--- a/2.6/root/usr/share/container-scripts/mongodb/replica_supervisor.sh
+++ b/2.6/root/usr/share/container-scripts/mongodb/replica_supervisor.sh
@@ -5,12 +5,6 @@
 
 source  ${CONTAINER_SCRIPTS_PATH}/common.sh
 
-# Redirect all stdout && stderr into a FIFO pipe
-exec 1<&-
-exec 2<&-
-exec 1<>$1
-exec 2>&1
-
 echo "=> Waiting for local MongoDB to accept connections ..."
 wait_for_mongo_up
 set -x


### PR DESCRIPTION
The error was:

```
+ run_mongod_supervisor
++ mktemp --suffix=log
+ local log_pipe_path=/tmp/tmp.N3fNyC3Bwklog
+ rm -rf /tmp/tmp.N3fNyC3Bwklog
+ trap cleanup SIGINT SIGTERM
+ auth_args=' --auth'
+ '[' '!' -v MONGODB_NO_AUTH ']'
+ auth_args=
+ wait
+ unset_env_vars
+ unset MONGODB_USER MONGODB_PASSWORD MONGODB_DATABASE MONGODB_ADMIN_PASSWORD
+ mongod -f /etc/mongod.conf --oplogSize 64 --replSet rs0 --keyFile /var/lib/mongodb/keyfile
+ /usr/share/container-scripts/mongodb/replica_supervisor.sh /tmp/tmp.N3fNyC3Bwklog
+ mkfifo /tmp/tmp.N3fNyC3Bwklog
mkfifo: cannot create fifo '/tmp/tmp.N3fNyC3Bwklog': File exists
```

Race happens because we're creating fifo file and redirecting to it in parallel:

``` bash
function run_mongod_supervisor() {
  local log_pipe_path=$(mktemp --suffix=log)
  rm -rf ${log_pipe_path}
  ( mkfifo ${log_pipe_path} && cat ${log_pipe_path} ) &
  ${CONTAINER_SCRIPTS_PATH}/replica_supervisor.sh ${log_pipe_path} &
}
```

And the content of `replica_supervisor.sh`:

``` bash
# Redirect all stdout && stderr into a FIFO pipe
exec 1<&-
exec 2<&-
exec 1<>$1
exec 2>&1
```

In some cases `replica_supervisor.sh` is executing before `mkfifo` and creating regular file, hence `File exists` error.

@bparees @rhcarvalho PTAL.

P.S. Easy fix was to execute `mkfifo` outside of subshell, but @legionus helped me to understand that creating fifo, writing to it and doing just `cat` is the same as executing command without this magic. 
