### PR TITLE
Add ready/lifeness probes for replica

### DIFF
--- a/2.4/examples/replica/mongodb-clustered.json
+++ b/2.4/examples/replica/mongodb-clustered.json
@@ -119,6 +119,20 @@
               {
                 "name":  "mongodb",
                 "image": "openshift/mongodb-24-centos7",
+                "readinessProbe": {
+                  "timeoutSeconds": 1,
+                  "initialDelaySeconds": 3,
+                  "exec": {
+                    "command": [ "/bin/sh", "-i", "-c", "mongostat --host 127.0.0.1 -u admin -p $MONGODB_ADMIN_PASSWORD -n 1 --noheaders"]
+                  }
+                },
+                "livenessProbe": {
+                  "timeoutSeconds": 1,
+                  "initialDelaySeconds": 30,
+                  "tcpSocket": {
+                    "port": 27017
+                  }
+                },
                 "env": [
                   {
                     "name": "MONGODB_USER",


### PR DESCRIPTION
@php-coder can you try this one with your extended test? I wonder if we not get into a chicken-egg problems (the service will not be "ready", meaning no endpoints will be returned in dig) till the mongostat succeed. 
