### PR TITLE
Don't stop the script when unable to determine ip of the primary node

### DIFF
--- a/2.4/root/usr/bin/run-mongod
+++ b/2.4/root/usr/bin/run-mongod
@@ -41,7 +41,7 @@ function unset_env_vars() {
 }
 
 function cleanup() {
-  if [ ! -z "${MONGODB_REPLICA_NAME-}" ]; then
+  if [ -n "${MONGODB_REPLICA_NAME-}" ]; then
     mongo_remove
   fi
   echo "=> Shutting down MongoDB server ..."

--- a/2.6/root/usr/bin/run-mongod
+++ b/2.6/root/usr/bin/run-mongod
@@ -41,7 +41,7 @@ function unset_env_vars() {
 }
 
 function cleanup() {
-  if [ ! -z "${MONGODB_REPLICA_NAME-}" ]; then
+  if [ -n "${MONGODB_REPLICA_NAME-}" ]; then
     mongo_remove
   fi
   echo "=> Shutting down MongoDB server ..."


### PR DESCRIPTION
When we are trying to add or remove MongoDB to/from replica set and we didn't determine IP-address of the primary node we shouldn't exit immediately from the whole script because there is also the code that should be executed always (for example, we are invoking `mongo_remove` from the cleanup method before killing the mongod process).

Other bash improvements/fixes:
- fixed a bug when we're comparing with a static string (`[ "$node" == container_addr ]`)
- use local keyword in more places
- remove `set +e/`set -e` hack
- prefer `-n` over `! -z`

PTAL @bparees @rhcarvalho 
