### PR TITLE
Don't stop the script when unable to determine ip of the primary

### DIFF
--- a/2.4/root/usr/bin/run-mongod
+++ b/2.4/root/usr/bin/run-mongod
@@ -41,7 +41,7 @@ function unset_env_vars() {
 }
 
 function cleanup() {
-  if [ ! -z "${MONGODB_REPLICA_NAME-}" ]; then
+  if [ -n "${MONGODB_REPLICA_NAME-}" ]; then
     mongo_remove
   fi
   echo "=> Shutting down MongoDB server ..."

--- a/2.4/root/usr/share/container-scripts/mongodb/common.sh
+++ b/2.4/root/usr/share/container-scripts/mongodb/common.sh
@@ -45,17 +45,14 @@ function wait_for_mongo_up() {
   local mongo_cmd
   mongo_cmd="mongo admin "
 
-  if [ ! -z "${mongo_host}" ]; then
+  if [ -n "${mongo_host}" ]; then
     mongo_cmd+="--host ${mongo_host}:${CONTAINER_PORT} "
   fi
 
+  local i
   for i in $(seq $MAX_ATTEMPTS); do
     echo "=> Waiting for MongoDB service startup ${mongo_host} ..."
-    set +e
-    $mongo_cmd --eval "help" &>/dev/null
-    status=$?
-    set -e
-    if [ $status -eq 0 ]; then
+    if $mongo_cmd --eval 'help' &>/dev/null; then
       echo "=> MongoDB service has started"
       return 0
     fi
@@ -67,13 +64,10 @@ function wait_for_mongo_up() {
 
 # wait_for_mongo_down waits until the mongo server is down
 function wait_for_mongo_down() {
+  local i
   for i in $(seq $MAX_ATTEMPTS); do
     echo "=> Waiting for MongoDB service shutdown ..."
-    set +e
-    mongo admin --eval "help" &>/dev/null
-    status=$?
-    set -e
-    if [ $status -ne 0 ]; then
+    if ! mongo admin --eval 'help' &>/dev/null; then
       echo "=> MongoDB service has stopped"
       return 0
     fi
@@ -103,10 +97,12 @@ function build_mongo_config() {
   member_id=1
   local container_addr
   container_addr="$(container_addr)"
+  local node
   for node in ${current_endpoints}; do
-    [ "$node" == container_addr ] && continue
-    members+="{ _id: ${member_id}, host: \"${node}:${CONTAINER_PORT}\"},"
-    let member_id++
+    if [ "$node" != "$container_addr" ]; then
+      members+="{ _id: ${member_id}, host: \"${node}:${CONTAINER_PORT}\"},"
+      let member_id++
+    fi
   done
   echo -n "var config={ _id: \"${MONGODB_REPLICA_NAME}\", members: [ ${members%,} ] }"
 }
@@ -152,7 +148,12 @@ function mongo_primary_member_addr() {
 # mongo_remove removes the current MongoDB from the cluster
 function mongo_remove() {
   local primary_addr
-  primary_addr="$(mongo_primary_member_addr)"
+  # if we cannot determine the IP address of the primary, exit without an error
+  # to allow callers to proceed with their logic
+  primary_addr="$(mongo_primary_member_addr || true)"
+  if [ -z "$primary_addr" ]; then
+    return
+  fi
 
   local mongo_addr
   mongo_addr="$(mongo_addr)"
@@ -165,7 +166,12 @@ function mongo_remove() {
 # mongo_add advertise the current container to other mongo replicas
 function mongo_add() {
   local primary_addr
-  primary_addr="$(mongo_primary_member_addr)"
+  # if we cannot determine the IP address of the primary, exit without an error
+  # to allow callers to proceed with their logic
+  primary_addr="$(mongo_primary_member_addr || true)"
+  if [ -z "$primary_addr" ]; then
+    return
+  fi
 
   local mongo_addr
   mongo_addr="$(mongo_addr)"

--- a/2.6/root/usr/bin/run-mongod
+++ b/2.6/root/usr/bin/run-mongod
@@ -41,7 +41,7 @@ function unset_env_vars() {
 }
 
 function cleanup() {
-  if [ ! -z "${MONGODB_REPLICA_NAME-}" ]; then
+  if [ -n "${MONGODB_REPLICA_NAME-}" ]; then
     mongo_remove
   fi
   echo "=> Shutting down MongoDB server ..."

--- a/2.6/root/usr/share/container-scripts/mongodb/common.sh
+++ b/2.6/root/usr/share/container-scripts/mongodb/common.sh
@@ -45,17 +45,14 @@ function wait_for_mongo_up() {
   local mongo_cmd
   mongo_cmd="mongo admin "
 
-  if [ ! -z "${mongo_host}" ]; then
+  if [ -n "${mongo_host}" ]; then
     mongo_cmd+="--host ${mongo_host}:${CONTAINER_PORT} "
   fi
 
+  local i
   for i in $(seq $MAX_ATTEMPTS); do
     echo "=> Waiting for MongoDB service startup ${mongo_host} ..."
-    set +e
-    $mongo_cmd --eval "help" &>/dev/null
-    status=$?
-    set -e
-    if [ $status -eq 0 ]; then
+    if $mongo_cmd --eval 'help' &>/dev/null; then
       echo "=> MongoDB service has started"
       return 0
     fi
@@ -67,13 +64,10 @@ function wait_for_mongo_up() {
 
 # wait_for_mongo_down waits until the mongo server is down
 function wait_for_mongo_down() {
+  local i
   for i in $(seq $MAX_ATTEMPTS); do
     echo "=> Waiting for MongoDB service shutdown ..."
-    set +e
-    mongo admin --eval "help" &>/dev/null
-    status=$?
-    set -e
-    if [ $status -ne 0 ]; then
+    if ! mongo admin --eval 'help' &>/dev/null; then
       echo "=> MongoDB service has stopped"
       return 0
     fi
@@ -103,10 +97,12 @@ function build_mongo_config() {
   member_id=1
   local container_addr
   container_addr="$(container_addr)"
+  local node
   for node in ${current_endpoints}; do
-    [ "$node" == container_addr ] && continue
-    members+="{ _id: ${member_id}, host: \"${node}:${CONTAINER_PORT}\"},"
-    let member_id++
+    if [ "$node" != "$container_addr" ]; then
+      members+="{ _id: ${member_id}, host: \"${node}:${CONTAINER_PORT}\"},"
+      let member_id++
+    fi
   done
   echo -n "var config={ _id: \"${MONGODB_REPLICA_NAME}\", members: [ ${members%,} ] }"
 }
@@ -152,7 +148,12 @@ function mongo_primary_member_addr() {
 # mongo_remove removes the current MongoDB from the cluster
 function mongo_remove() {
   local primary_addr
-  primary_addr="$(mongo_primary_member_addr)"
+  # if we cannot determine the IP address of the primary, exit without an error
+  # to allow callers to proceed with their logic
+  primary_addr="$(mongo_primary_member_addr || true)"
+  if [ -z "$primary_addr" ]; then
+    return
+  fi
 
   local mongo_addr
   mongo_addr="$(mongo_addr)"
@@ -165,7 +166,12 @@ function mongo_remove() {
 # mongo_add advertise the current container to other mongo replicas
 function mongo_add() {
   local primary_addr
-  primary_addr="$(mongo_primary_member_addr)"
+  # if we cannot determine the IP address of the primary, exit without an error
+  # to allow callers to proceed with their logic
+  primary_addr="$(mongo_primary_member_addr || true)"
+  if [ -z "$primary_addr" ]; then
+    return
+  fi
 
   local mongo_addr
   mongo_addr="$(mongo_addr)"


### PR DESCRIPTION
(Copy&pasted from #139 because it's the same PR in essence.)

When we are trying to add or remove MongoDB to/from replica set and we didn't determine IP-address of the primary node we shouldn't exit immediately from the whole script because there is also the code that should be executed always (for example, we are invoking mongo_remove from the cleanup method before killing the mongod process).

Other bash improvements/fixes:
- fixed a bug when we're comparing with a static string (`[ "$node" == container_addr ]`)
- use local keyword in more places
- remove `set +e`/`set -e` hack
- prefer `-n` over `! -z`

PTAL @bparees @rhcarvalho
