### PR TITLE
Added ability to use user config file.

### DIFF
--- a/2.4/README.md
+++ b/2.4/README.md
@@ -58,6 +58,14 @@ will be started. If you are re-attaching the volume to another container, the
 creation of the database user and admin user will be skipped and only the
 MongoDB daemon will be started.
 
+Custom configuration file
+---------------------------------
+
+It is allowed to use custom configuration file for mongod server. Providing a custom configuration file supercedes the individual configuration environment variable values.
+
+To use custom configuration file in container it has to be mounted into `/etc/mongod.conf`. For example to use configuration file stored in `/home/user` directory use this option for `docker run` command: `-v /home/user/mongod.conf:/etc/mongod.conf:Z`.
+
+**Notice: Custom config file does not affect name of replica set. It has to be set in `MONGODB_REPLICA_NAME` environment variable.**
 
 MongoDB admin user
 ---------------------------------

--- a/2.4/root/usr/bin/run-mongod
+++ b/2.4/root/usr/bin/run-mongod
@@ -6,20 +6,6 @@ set -o pipefail
 
 source ${CONTAINER_SCRIPTS_PATH}/common.sh
 
-# Data directory where MongoDB database files live. The data subdirectory is here
-# because mongodb.conf lives in /var/lib/mongodb/ and we don't want a volume to
-# override it.
-export MONGODB_DATADIR=/var/lib/mongodb/data
-
-# Configuration settings.
-export MONGODB_NOPREALLOC=${MONGODB_NOPREALLOC:-true}
-export MONGODB_SMALLFILES=${MONGODB_SMALLFILES:-true}
-export MONGODB_QUIET=${MONGODB_QUIET:-true}
-export MONGODB_TEXT_SEARCH_ENABLED=${MONGODB_TEXT_SEARCH_ENABLED:-false}
-
-export MONGODB_KEYFILE_SOURCE_PATH="/var/run/secrets/mongo/keyfile"
-export MONGODB_KEYFILE_PATH="${HOME}/keyfile"
-
 function usage() {
   echo "You must specify the following environment variables:"
   echo "  MONGODB_USER"
@@ -61,12 +47,15 @@ if [ $# -gt 0 ] && [ "$1" == "initiate" ]; then
   exec ${CONTAINER_SCRIPTS_PATH}/initiate_replica.sh
 fi
 
-# Generate config file for MongoDB
-envsubst < ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template > $MONGODB_CONFIG_PATH
+# If user provides own config file use it and do not generate new one
+if [ ! -s $MONGODB_CONFIG_PATH ]; then
+  # Generate config file for MongoDB
+  envsubst < ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template > $MONGODB_CONFIG_PATH
+fi
 
 # Need to cache the container address for the cleanup
 cache_container_addr
-mongo_common_args="-f $MONGODB_CONFIG_PATH --oplogSize 64"
+mongo_common_args="-f $MONGODB_CONFIG_PATH"
 if [ -z "${MONGODB_REPLICA_NAME-}" ]; then
   if ! [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE && -v MONGODB_ADMIN_PASSWORD ]]; then
     usage
@@ -110,8 +99,7 @@ else
   # `cleanup` references it.
   (
     unset_env_vars
-    mongod $mongo_common_args --replSet "${MONGODB_REPLICA_NAME}" \
-      --keyFile "${MONGODB_KEYFILE_PATH}"
+    mongod $mongo_common_args --replSet "${MONGODB_REPLICA_NAME}"
   ) &
   wait
 fi

--- a/2.4/root/usr/share/container-scripts/mongodb/common.sh
+++ b/2.4/root/usr/share/container-scripts/mongodb/common.sh
@@ -4,14 +4,23 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# Used for wait_for_mongo_* functions
-MAX_ATTEMPTS=60
-SLEEP_TIME=1
-
-export MONGODB_CONFIG_PATH=/etc/mongod.conf
-export MONGODB_PID_FILE=/var/lib/mongodb/mongodb.pid
-export MONGODB_KEYFILE_PATH=/var/lib/mongodb/keyfile
+# Data directory where MongoDB database files live. The data subdirectory is here
+# because mongodb.conf lives in /var/lib/mongodb/ and we don't want a volume to
+# override it.
+export MONGODB_DATADIR=/var/lib/mongodb/data
 export CONTAINER_PORT=27017
+# Configuration settings.
+export MONGODB_NOPREALLOC=${MONGODB_NOPREALLOC:-true}
+export MONGODB_SMALLFILES=${MONGODB_SMALLFILES:-true}
+export MONGODB_QUIET=${MONGODB_QUIET:-true}
+export MONGODB_TEXT_SEARCH_ENABLED=${MONGODB_TEXT_SEARCH_ENABLED:-false}
+
+MONGODB_CONFIG_PATH=/etc/mongod.conf
+MONGODB_KEYFILE_PATH="${HOME}/keyfile"
+
+# Constants used for waiting
+readonly MAX_ATTEMPTS=60
+readonly SLEEP_TIME=1
 
 # container_addr returns the current container external IP address
 function container_addr() {
@@ -251,11 +260,17 @@ function mongo_reset_admin() {
 
 # setup_keyfile fixes the bug in mounting the Kubernetes 'Secret' volume that
 # mounts the secret files with 'too open' permissions.
+# add --keyFile argument to mongo_common_args
 function setup_keyfile() {
+  # If user specify keyFile in config file do not use generated keyFile
+  if grep -q "^\s*keyFile" ${MONGODB_CONFIG_PATH}; then
+    exit 0
+  fi
   if [ -z "${MONGODB_KEYFILE_VALUE-}" ]; then
     echo "ERROR: You have to provide the 'keyfile' value in MONGODB_KEYFILE_VALUE"
     exit 1
   fi
   echo ${MONGODB_KEYFILE_VALUE} > ${MONGODB_KEYFILE_PATH}
   chmod 0600 ${MONGODB_KEYFILE_PATH}
+  mongo_common_args+=" --keyFile ${MONGODB_KEYFILE_PATH}"
 }

--- a/2.4/root/usr/share/container-scripts/mongodb/mongodb.conf.template
+++ b/2.4/root/usr/share/container-scripts/mongodb/mongodb.conf.template
@@ -1,7 +1,6 @@
 # mongodb.conf
 
-port = 27017
-pidfilepath = ${MONGODB_PID_FILE}
+port = ${CONTAINER_PORT}
 
 # Set this value to designate a directory for the mongod instance to store its data.
 # Default: /var/lib/mongodb/data
@@ -19,6 +18,9 @@ quiet = ${MONGODB_QUIET}
 
 # Disable the HTTP interface (Defaults to localhost:28017).
 nohttpinterface = true
+
+# Size to use (in MB) for replication op log (default 5% of disk space)
+oplogSize = 64
 
 # If the flag is not enabled, you cannot create new text indexes, and you cannot perform text searches. 
 # Since it is not recommended to have this on in production, the default is "false".

--- a/2.4/test/run
+++ b/2.4/test/run
@@ -295,9 +295,57 @@ function run_change_password_test() {
     echo "  Success!"
 }
 
+function run_mount_config_test() {
+    local name="mount_config"
+    echo "  Testing config file mount"
+    local database='db'
+    local user='user'
+    local password='password'
+    local admin_password='adminPassword'
+
+    local volume_dir
+    volume_dir=`mktemp -d --tmpdir mongodb-testdata.XXXXX`
+    chmod a+rwx ${volume_dir}
+    config_file=$volume_dir/mongod.conf
+    echo "dbpath=/var/lib/mongodb/dbpath
+unixSocketPrefix = /var/lib/mongodb
+smallfiles = true
+noprealloc = true" > $config_file
+    chmod a+r ${config_file}
+
+    DOCKER_ARGS="
+-e MONGODB_DATABASE=${database}
+-e MONGODB_USER=${user}
+-e MONGODB_PASSWORD=${password}
+-e MONGODB_ADMIN_PASSWORD=${admin_password}
+-v ${config_file}:/etc/mongod.conf:Z
+-v ${volume_dir}:/var/lib/mongodb/dbpath:Z
+"
+    create_container ${name} ${DOCKER_ARGS}
+
+    # need to set these because `mongo_cmd` relies on global variables
+    USER=${user}
+    PASS=${password}
+    DB=${database}
+
+    # need this to wait for the container to start up
+    CONTAINER_IP=$(get_container_ip ${name})
+    echo "  Testing mongod is running"
+    test_connection ${name}
+    echo "  Testing config file works"
+    docker exec $(get_cid ${name}) bash -c "test -S /var/lib/mongodb/mongodb-27017.sock"
+
+    # need to remove volume_dir with sudo because of permissions of files written
+    # by the Docker container
+    sudo rm -rf ${volume_dir}
+
+    echo "  Success!"
+}
+
 # Tests.
 run_configuration_tests
 USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin
 # Test with random uid in container
 CONTAINER_ARGS="-u 12345" USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin_altuid
 run_change_password_test
+run_mount_config_test

--- a/2.6/README.md
+++ b/2.6/README.md
@@ -55,6 +55,14 @@ will be started. If you are re-attaching the volume to another container, the
 creation of the database user and admin user will be skipped and only the
 MongoDB daemon will be started.
 
+Custom configuration file
+---------------------------------
+
+It is allowed to use custom configuration file for mongod server. Providing a custom configuration file supercedes the individual configuration environment variable values.
+
+To use custom configuration file in container it has to be mounted into `/etc/mongod.conf`. For example to use configuration file stored in `/home/user` directory use this option for `docker run` command: `-v /home/user/mongod.conf:/etc/mongod.conf:Z`.
+
+**Notice: Custom config file does not affect name of replica set. It has to be set in `MONGODB_REPLICA_NAME` environment variable.**
 
 MongoDB admin user
 ---------------------------------

--- a/2.6/root/usr/bin/run-mongod
+++ b/2.6/root/usr/bin/run-mongod
@@ -6,20 +6,6 @@ set -o pipefail
 
 source ${CONTAINER_SCRIPTS_PATH}/common.sh
 
-# Data directory where MongoDB database files live. The data subdirectory is here
-# because mongodb.conf lives in /var/lib/mongodb/ and we don't want a volume to
-# override it.
-export MONGODB_DATADIR=/var/lib/mongodb/data
-
-# Configuration settings.
-export MONGODB_NOPREALLOC=${MONGODB_NOPREALLOC:-true}
-export MONGODB_SMALLFILES=${MONGODB_SMALLFILES:-true}
-export MONGODB_QUIET=${MONGODB_QUIET:-true}
-
-
-export MONGODB_KEYFILE_SOURCE_PATH="/var/run/secrets/mongo/keyfile"
-export MONGODB_KEYFILE_PATH="${HOME}/keyfile"
-
 function usage() {
   echo "You must specify the following environment variables:"
   echo "  MONGODB_USER"
@@ -61,12 +47,15 @@ if [ $# -gt 0 ] && [ "$1" == "initiate" ]; then
   exec ${CONTAINER_SCRIPTS_PATH}/initiate_replica.sh
 fi
 
-# Generate config file for MongoDB
-envsubst < ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template > $MONGODB_CONFIG_PATH
+# If user provides own config file use it and do not generate new one
+if [ ! -s $MONGODB_CONFIG_PATH ]; then
+  # Generate config file for MongoDB
+  envsubst < ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template > $MONGODB_CONFIG_PATH
+fi
 
 # Need to cache the container address for the cleanup
 cache_container_addr
-mongo_common_args="-f $MONGODB_CONFIG_PATH --oplogSize 64"
+mongo_common_args="-f $MONGODB_CONFIG_PATH"
 if [ -z "${MONGODB_REPLICA_NAME-}" ]; then
   if ! [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE && -v MONGODB_ADMIN_PASSWORD ]]; then
     usage
@@ -105,8 +94,7 @@ else
   # `cleanup` references it.
   (
     unset_env_vars
-    mongod $mongo_common_args --replSet "${MONGODB_REPLICA_NAME}" \
-      --keyFile "${MONGODB_KEYFILE_PATH}"
+    mongod $mongo_common_args --replSet "${MONGODB_REPLICA_NAME}"
   ) &
   wait
 fi

--- a/2.6/root/usr/share/container-scripts/mongodb/common.sh
+++ b/2.6/root/usr/share/container-scripts/mongodb/common.sh
@@ -4,14 +4,22 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# Used for wait_for_mongo_* functions
-MAX_ATTEMPTS=60
-SLEEP_TIME=1
-
-export MONGODB_CONFIG_PATH=/etc/mongod.conf
-export MONGODB_PID_FILE=/var/lib/mongodb/mongodb.pid
-export MONGODB_KEYFILE_PATH=/var/lib/mongodb/keyfile
+# Data directory where MongoDB database files live. The data subdirectory is here
+# because mongodb.conf lives in /var/lib/mongodb/ and we don't want a volume to
+# override it.
+export MONGODB_DATADIR=/var/lib/mongodb/data
 export CONTAINER_PORT=27017
+# Configuration settings.
+export MONGODB_NOPREALLOC=${MONGODB_NOPREALLOC:-true}
+export MONGODB_SMALLFILES=${MONGODB_SMALLFILES:-true}
+export MONGODB_QUIET=${MONGODB_QUIET:-true}
+
+MONGODB_CONFIG_PATH=/etc/mongod.conf
+MONGODB_KEYFILE_PATH="${HOME}/keyfile"
+
+# Constants used for waiting
+readonly MAX_ATTEMPTS=60
+readonly SLEEP_TIME=1
 
 # container_addr returns the current container external IP address
 function container_addr() {
@@ -251,11 +259,17 @@ function mongo_reset_admin() {
 
 # setup_keyfile fixes the bug in mounting the Kubernetes 'Secret' volume that
 # mounts the secret files with 'too open' permissions.
+# add --keyFile argument to mongo_common_args
 function setup_keyfile() {
+  # If user specify keyFile in config file do not use generated keyFile
+  if grep -q "^\s*keyFile" ${MONGODB_CONFIG_PATH}; then
+    exit 0
+  fi
   if [ -z "${MONGODB_KEYFILE_VALUE-}" ]; then
     echo "ERROR: You have to provide the 'keyfile' value in MONGODB_KEYFILE_VALUE"
     exit 1
   fi
   echo ${MONGODB_KEYFILE_VALUE} > ${MONGODB_KEYFILE_PATH}
   chmod 0600 ${MONGODB_KEYFILE_PATH}
+  mongo_common_args+=" --keyFile ${MONGODB_KEYFILE_PATH}"
 }

--- a/2.6/root/usr/share/container-scripts/mongodb/mongodb.conf.template
+++ b/2.6/root/usr/share/container-scripts/mongodb/mongodb.conf.template
@@ -1,7 +1,6 @@
 # mongodb.conf
 
-port = 27017
-pidfilepath = ${MONGODB_PID_FILE}
+port = ${CONTAINER_PORT}
 
 # Set this value to designate a directory for the mongod instance to store its data.
 # Default: /var/lib/mongodb/data
@@ -19,3 +18,6 @@ quiet = ${MONGODB_QUIET}
 
 # Disable the HTTP interface (Defaults to localhost:28017).
 nohttpinterface = true
+
+# Size to use (in MB) for replication op log (default 5% of disk space)
+oplogSize = 64

--- a/2.6/test/run
+++ b/2.6/test/run
@@ -280,9 +280,57 @@ function run_change_password_test() {
     echo "  Success!"
 }
 
+function run_mount_config_test() {
+    local name="mount_config"
+    echo "  Testing config file mount"
+    local database='db'
+    local user='user'
+    local password='password'
+    local admin_password='adminPassword'
+
+    local volume_dir
+    volume_dir=`mktemp -d --tmpdir mongodb-testdata.XXXXX`
+    chmod a+rwx ${volume_dir}
+    config_file=$volume_dir/mongod.conf
+    echo "dbpath=/var/lib/mongodb/dbpath
+unixSocketPrefix = /var/lib/mongodb
+smallfiles = true
+noprealloc = true" > $config_file
+    chmod a+r ${config_file}
+
+    DOCKER_ARGS="
+-e MONGODB_DATABASE=${database}
+-e MONGODB_USER=${user}
+-e MONGODB_PASSWORD=${password}
+-e MONGODB_ADMIN_PASSWORD=${admin_password}
+-v ${config_file}:/etc/mongod.conf:Z
+-v ${volume_dir}:/var/lib/mongodb/dbpath:Z
+"
+    create_container ${name} ${DOCKER_ARGS}
+
+    # need to set these because `mongo_cmd` relies on global variables
+    USER=${user}
+    PASS=${password}
+    DB=${database}
+
+    # need this to wait for the container to start up
+    CONTAINER_IP=$(get_container_ip ${name})
+    echo "  Testing mongod is running"
+    test_connection ${name}
+    echo "  Testing config file works"
+    docker exec $(get_cid ${name}) bash -c "test -S /var/lib/mongodb/mongodb-27017.sock"
+
+    # need to remove volume_dir with sudo because of permissions of files written
+    # by the Docker container
+    sudo rm -rf ${volume_dir}
+
+    echo "  Success!"
+}
+
 # Tests.
 run_configuration_tests
 USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin
 # Test with random uid in container
 CONTAINER_ARGS="-u 12345" USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin_altuid
 run_change_password_test
+run_mount_config_test

--- a/3.0-upg/README.md
+++ b/3.0-upg/README.md
@@ -57,6 +57,14 @@ will be started. If you are re-attaching the volume to another container, the
 creation of the database user and admin user will be skipped and only the
 MongoDB daemon will be started.
 
+Custom configuration file
+---------------------------------
+
+It is allowed to use custom configuration file for mongod server. Providing a custom configuration file supercedes the individual configuration environment variable values.
+
+To use custom configuration file in container it has to be mounted into `/etc/mongod.conf`. For example to use configuration file stored in `/home/user` directory use this option for `docker run` command: `-v /home/user/mongod.conf:/etc/mongod.conf:Z`.
+
+**Notice: Custom config file does not affect name of replica set. It has to be set in `MONGODB_REPLICA_NAME` environment variable.**
 
 MongoDB admin user
 ---------------------------------

--- a/3.0-upg/root/usr/bin/run-mongod
+++ b/3.0-upg/root/usr/bin/run-mongod
@@ -6,20 +6,6 @@ set -o pipefail
 
 source ${CONTAINER_SCRIPTS_PATH}/common.sh
 
-# Data directory where MongoDB database files live. The data subdirectory is here
-# because mongodb.conf lives in /var/lib/mongodb/ and we don't want a volume to
-# override it.
-export MONGODB_DATADIR=/var/lib/mongodb/data
-
-# Configuration settings.
-export MONGODB_NOPREALLOC=${MONGODB_NOPREALLOC:-true}
-export MONGODB_SMALLFILES=${MONGODB_SMALLFILES:-true}
-export MONGODB_QUIET=${MONGODB_QUIET:-true}
-
-
-export MONGODB_KEYFILE_SOURCE_PATH="/var/run/secrets/mongo/keyfile"
-export MONGODB_KEYFILE_PATH="${HOME}/keyfile"
-
 function usage() {
   echo "You must specify the following environment variables:"
   echo "  MONGODB_USER"
@@ -69,12 +55,15 @@ if [ $# -gt 0 ] && [ "$1" == "initiate" ]; then
   exec ${CONTAINER_SCRIPTS_PATH}/initiate_replica.sh
 fi
 
-# Generate config file for MongoDB
-envsubst < ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template > $MONGODB_CONFIG_PATH
+# If user provides own config file use it and do not generate new one
+if [ ! -s $MONGODB_CONFIG_PATH ]; then
+  # Generate config file for MongoDB
+  envsubst < ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template > $MONGODB_CONFIG_PATH
+fi
 
 # Need to cache the container address for the cleanup
 cache_container_addr
-mongo_common_args="-f $MONGODB_CONFIG_PATH --oplogSize 64"
+mongo_common_args="-f $MONGODB_CONFIG_PATH"
 if [ -z "${MONGODB_REPLICA_NAME-}" ]; then
   if ! [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE && -v MONGODB_ADMIN_PASSWORD ]]; then
     usage
@@ -113,8 +102,7 @@ else
   # `cleanup` references it.
   (
     unset_env_vars
-    mongod $mongo_common_args --replSet "${MONGODB_REPLICA_NAME}" \
-      --keyFile "${MONGODB_KEYFILE_PATH}"
+    mongod $mongo_common_args --replSet "${MONGODB_REPLICA_NAME}"
   ) &
   wait
 fi

--- a/3.0-upg/root/usr/share/container-scripts/mongodb/common.sh
+++ b/3.0-upg/root/usr/share/container-scripts/mongodb/common.sh
@@ -4,14 +4,22 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# Used for wait_for_mongo_* functions
-MAX_ATTEMPTS=60
-SLEEP_TIME=1
-
-export MONGODB_CONFIG_PATH=/etc/mongod.conf
-export MONGODB_PID_FILE=/var/lib/mongodb/mongodb.pid
-export MONGODB_KEYFILE_PATH=/var/lib/mongodb/keyfile
+# Data directory where MongoDB database files live. The data subdirectory is here
+# because mongodb.conf lives in /var/lib/mongodb/ and we don't want a volume to
+# override it.
+export MONGODB_DATADIR=/var/lib/mongodb/data
 export CONTAINER_PORT=27017
+# Configuration settings.
+export MONGODB_NOPREALLOC=${MONGODB_NOPREALLOC:-true}
+export MONGODB_SMALLFILES=${MONGODB_SMALLFILES:-true}
+export MONGODB_QUIET=${MONGODB_QUIET:-true}
+
+MONGODB_CONFIG_PATH=/etc/mongod.conf
+MONGODB_KEYFILE_PATH="${HOME}/keyfile"
+
+# Constants used for waiting
+readonly MAX_ATTEMPTS=60
+readonly SLEEP_TIME=1
 
 # container_addr returns the current container external IP address
 function container_addr() {
@@ -251,11 +259,17 @@ function mongo_reset_admin() {
 
 # setup_keyfile fixes the bug in mounting the Kubernetes 'Secret' volume that
 # mounts the secret files with 'too open' permissions.
+# add --keyFile argument to mongo_common_args
 function setup_keyfile() {
+  # If user specify keyFile in config file do not use generated keyFile
+  if grep -q "^\s*keyFile" ${MONGODB_CONFIG_PATH}; then
+    exit 0
+  fi
   if [ -z "${MONGODB_KEYFILE_VALUE-}" ]; then
     echo "ERROR: You have to provide the 'keyfile' value in MONGODB_KEYFILE_VALUE"
     exit 1
   fi
   echo ${MONGODB_KEYFILE_VALUE} > ${MONGODB_KEYFILE_PATH}
   chmod 0600 ${MONGODB_KEYFILE_PATH}
+  mongo_common_args+=" --keyFile ${MONGODB_KEYFILE_PATH}"
 }

--- a/3.0-upg/root/usr/share/container-scripts/mongodb/mongodb.conf.template
+++ b/3.0-upg/root/usr/share/container-scripts/mongodb/mongodb.conf.template
@@ -1,7 +1,6 @@
 # mongodb.conf
 
-port = 27017
-pidfilepath = ${MONGODB_PID_FILE}
+port = ${CONTAINER_PORT}
 
 # Set this value to designate a directory for the mongod instance to store its data.
 # Default: /var/lib/mongodb/data
@@ -19,3 +18,6 @@ quiet = ${MONGODB_QUIET}
 
 # Disable the HTTP interface (Defaults to localhost:28017).
 nohttpinterface = true
+
+# Size to use (in MB) for replication op log (default 5% of disk space)
+oplogSize = 64

--- a/3.0-upg/test/run
+++ b/3.0-upg/test/run
@@ -280,9 +280,57 @@ function run_change_password_test() {
     echo "  Success!"
 }
 
+function run_mount_config_test() {
+    local name="mount_config"
+    echo "  Testing config file mount"
+    local database='db'
+    local user='user'
+    local password='password'
+    local admin_password='adminPassword'
+
+    local volume_dir
+    volume_dir=`mktemp -d --tmpdir mongodb-testdata.XXXXX`
+    chmod a+rwx ${volume_dir}
+    config_file=$volume_dir/mongod.conf
+    echo "dbpath=/var/lib/mongodb/dbpath
+unixSocketPrefix = /var/lib/mongodb
+smallfiles = true
+noprealloc = true" > $config_file
+    chmod a+r ${config_file}
+
+    DOCKER_ARGS="
+-e MONGODB_DATABASE=${database}
+-e MONGODB_USER=${user}
+-e MONGODB_PASSWORD=${password}
+-e MONGODB_ADMIN_PASSWORD=${admin_password}
+-v ${config_file}:/etc/mongod.conf:Z
+-v ${volume_dir}:/var/lib/mongodb/dbpath:Z
+"
+    create_container ${name} ${DOCKER_ARGS}
+
+    # need to set these because `mongo_cmd` relies on global variables
+    USER=${user}
+    PASS=${password}
+    DB=${database}
+
+    # need this to wait for the container to start up
+    CONTAINER_IP=$(get_container_ip ${name})
+    echo "  Testing mongod is running"
+    test_connection ${name}
+    echo "  Testing config file works"
+    docker exec $(get_cid ${name}) bash -c "test -S /var/lib/mongodb/mongodb-27017.sock"
+
+    # need to remove volume_dir with sudo because of permissions of files written
+    # by the Docker container
+    sudo rm -rf ${volume_dir}
+
+    echo "  Success!"
+}
+
 # Tests.
 run_configuration_tests
 USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin
 # Test with random uid in container
 CONTAINER_ARGS="-u 12345" USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin_altuid
 run_change_password_test
+run_mount_config_test

--- a/3.2/README.md
+++ b/3.2/README.md
@@ -55,6 +55,14 @@ will be started. If you are re-attaching the volume to another container, the
 creation of the database user and admin user will be skipped and only the
 MongoDB daemon will be started.
 
+Custom configuration file
+---------------------------------
+
+It is allowed to use custom configuration file for mongod server. Providing a custom configuration file supercedes the individual configuration environment variable values.
+
+To use custom configuration file in container it has to be mounted into `/etc/mongod.conf`. For example to use configuration file stored in `/home/user` directory use this option for `docker run` command: `-v /home/user/mongod.conf:/etc/mongod.conf:Z`.
+
+**Notice: Custom config file does not affect name of replica set. It has to be set in `MONGODB_REPLICA_NAME` environment variable.**
 
 MongoDB admin user
 ---------------------------------

--- a/3.2/root/usr/bin/run-mongod
+++ b/3.2/root/usr/bin/run-mongod
@@ -6,20 +6,6 @@ set -o pipefail
 
 source ${CONTAINER_SCRIPTS_PATH}/common.sh
 
-# Data directory where MongoDB database files live. The data subdirectory is here
-# because mongodb.conf lives in /var/lib/mongodb/ and we don't want a volume to
-# override it.
-export MONGODB_DATADIR=/var/lib/mongodb/data
-
-# Configuration settings.
-export MONGODB_NOPREALLOC=${MONGODB_NOPREALLOC:-true}
-export MONGODB_SMALLFILES=${MONGODB_SMALLFILES:-true}
-export MONGODB_QUIET=${MONGODB_QUIET:-true}
-
-
-export MONGODB_KEYFILE_SOURCE_PATH="/var/run/secrets/mongo/keyfile"
-export MONGODB_KEYFILE_PATH="${HOME}/keyfile"
-
 function usage() {
   echo "You must specify the following environment variables:"
   echo "  MONGODB_USER"
@@ -61,12 +47,15 @@ if [ $# -gt 0 ] && [ "$1" == "initiate" ]; then
   exec ${CONTAINER_SCRIPTS_PATH}/initiate_replica.sh
 fi
 
-# Generate config file for MongoDB
-envsubst < ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template > $MONGODB_CONFIG_PATH
+# If user provides own config file use it and do not generate new one
+if [ ! -s $MONGODB_CONFIG_PATH ]; then
+  # Generate config file for MongoDB
+  envsubst < ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template > $MONGODB_CONFIG_PATH
+fi
 
 # Need to cache the container address for the cleanup
 cache_container_addr
-mongo_common_args="-f $MONGODB_CONFIG_PATH --oplogSize 64"
+mongo_common_args="-f $MONGODB_CONFIG_PATH"
 if [ -z "${MONGODB_REPLICA_NAME-}" ]; then
   if ! [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE && -v MONGODB_ADMIN_PASSWORD ]]; then
     usage
@@ -105,8 +94,7 @@ else
   # `cleanup` references it.
   (
     unset_env_vars
-    mongod $mongo_common_args --replSet "${MONGODB_REPLICA_NAME}" \
-      --keyFile "${MONGODB_KEYFILE_PATH}"
+    mongod $mongo_common_args --replSet "${MONGODB_REPLICA_NAME}"
   ) &
   wait
 fi

--- a/3.2/root/usr/share/container-scripts/mongodb/common.sh
+++ b/3.2/root/usr/share/container-scripts/mongodb/common.sh
@@ -4,14 +4,22 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# Used for wait_for_mongo_* functions
-MAX_ATTEMPTS=60
-SLEEP_TIME=1
-
-export MONGODB_CONFIG_PATH=/etc/mongod.conf
-export MONGODB_PID_FILE=/var/lib/mongodb/mongodb.pid
-export MONGODB_KEYFILE_PATH=/var/lib/mongodb/keyfile
+# Data directory where MongoDB database files live. The data subdirectory is here
+# because mongodb.conf lives in /var/lib/mongodb/ and we don't want a volume to
+# override it.
+export MONGODB_DATADIR=/var/lib/mongodb/data
 export CONTAINER_PORT=27017
+# Configuration settings.
+export MONGODB_NOPREALLOC=${MONGODB_NOPREALLOC:-true}
+export MONGODB_SMALLFILES=${MONGODB_SMALLFILES:-true}
+export MONGODB_QUIET=${MONGODB_QUIET:-true}
+
+MONGODB_CONFIG_PATH=/etc/mongod.conf
+MONGODB_KEYFILE_PATH="${HOME}/keyfile"
+
+# Constants used for waiting
+readonly MAX_ATTEMPTS=60
+readonly SLEEP_TIME=1
 
 # container_addr returns the current container external IP address
 function container_addr() {
@@ -251,11 +259,17 @@ function mongo_reset_admin() {
 
 # setup_keyfile fixes the bug in mounting the Kubernetes 'Secret' volume that
 # mounts the secret files with 'too open' permissions.
+# add --keyFile argument to mongo_common_args
 function setup_keyfile() {
+  # If user specify keyFile in config file do not use generated keyFile
+  if grep -q "^\s*keyFile" ${MONGODB_CONFIG_PATH}; then
+    exit 0
+  fi
   if [ -z "${MONGODB_KEYFILE_VALUE-}" ]; then
     echo "ERROR: You have to provide the 'keyfile' value in MONGODB_KEYFILE_VALUE"
     exit 1
   fi
   echo ${MONGODB_KEYFILE_VALUE} > ${MONGODB_KEYFILE_PATH}
   chmod 0600 ${MONGODB_KEYFILE_PATH}
+  mongo_common_args+=" --keyFile ${MONGODB_KEYFILE_PATH}"
 }

--- a/3.2/root/usr/share/container-scripts/mongodb/mongodb.conf.template
+++ b/3.2/root/usr/share/container-scripts/mongodb/mongodb.conf.template
@@ -1,7 +1,6 @@
 # mongodb.conf
 
-port = 27017
-pidfilepath = ${MONGODB_PID_FILE}
+port = ${CONTAINER_PORT}
 
 # Set this value to designate a directory for the mongod instance to store its data.
 # Default: /var/lib/mongodb/data
@@ -21,3 +20,6 @@ quiet = ${MONGODB_QUIET}
 
 # Disable the HTTP interface (Defaults to localhost:28017).
 nohttpinterface = true
+
+# Size to use (in MB) for replication op log (default 5% of disk space)
+oplogSize = 64

--- a/3.2/test/run
+++ b/3.2/test/run
@@ -280,9 +280,57 @@ function run_change_password_test() {
     echo "  Success!"
 }
 
+function run_mount_config_test() {
+    local name="mount_config"
+    echo "  Testing config file mount"
+    local database='db'
+    local user='user'
+    local password='password'
+    local admin_password='adminPassword'
+
+    local volume_dir
+    volume_dir=`mktemp -d --tmpdir mongodb-testdata.XXXXX`
+    chmod a+rwx ${volume_dir}
+    config_file=$volume_dir/mongod.conf
+    echo "dbpath=/var/lib/mongodb/dbpath
+unixSocketPrefix = /var/lib/mongodb
+smallfiles = true
+noprealloc = true" > $config_file
+    chmod a+r ${config_file}
+
+    DOCKER_ARGS="
+-e MONGODB_DATABASE=${database}
+-e MONGODB_USER=${user}
+-e MONGODB_PASSWORD=${password}
+-e MONGODB_ADMIN_PASSWORD=${admin_password}
+-v ${config_file}:/etc/mongod.conf:Z
+-v ${volume_dir}:/var/lib/mongodb/dbpath:Z
+"
+    create_container ${name} ${DOCKER_ARGS}
+
+    # need to set these because `mongo_cmd` relies on global variables
+    USER=${user}
+    PASS=${password}
+    DB=${database}
+
+    # need this to wait for the container to start up
+    CONTAINER_IP=$(get_container_ip ${name})
+    echo "  Testing mongod is running"
+    test_connection ${name}
+    echo "  Testing config file works"
+    docker exec $(get_cid ${name}) bash -c "test -S /var/lib/mongodb/mongodb-27017.sock"
+
+    # need to remove volume_dir with sudo because of permissions of files written
+    # by the Docker container
+    sudo rm -rf ${volume_dir}
+
+    echo "  Success!"
+}
+
 # Tests.
 run_configuration_tests
 USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin
 # Test with random uid in container
 CONTAINER_ARGS="-u 12345" USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin_altuid
 run_change_password_test
+run_mount_config_test


### PR DESCRIPTION
As discussed in #137 

Added ability to use user config file.
- user is able to create or mount custom config file  in `/etc/mongod.conf` (for example from non-docker MongoDB deployments)
- this config file does not affect MONGODB_DATADIR and MONGODB_REPLICA_NAME

Cleaned up MONGODB env variables and mongod parameters.
- all env var declations were moved into one place
- removed PIDFILE option (mongod stores PID into mongod.lock file in dbpath)
- fixed double declaration of MONGODB_KEYFILE_PATH
