### PR TITLE
Print variable name in error message

### DIFF
--- a/2.4/root/usr/share/container-scripts/mongodb/common.sh
+++ b/2.4/root/usr/share/container-scripts/mongodb/common.sh
@@ -255,7 +255,7 @@ function mongo_reset_passwords() {
 # mounts the secret files with 'too open' permissions.
 function setup_keyfile() {
   if [ -z "${MONGODB_KEYFILE_VALUE-}" ]; then
-    echo "ERROR: You have to provide the 'keyfile' value in $MONGODB_KEYFILE_VALUE"
+    echo "ERROR: You have to provide the 'keyfile' value in MONGODB_KEYFILE_VALUE"
     exit 1
   fi
   echo ${MONGODB_KEYFILE_VALUE} > ${MONGODB_KEYFILE_PATH}


### PR DESCRIPTION
Include the variable name, and not its content.

Code for version 2.4 and 2.6 got out of sync in #122, this change make that particular line match between the two versions.
