### PR TITLE
Fix missing argument to _wait_for_mongo

### DIFF
--- a/2.4/root/usr/share/container-scripts/mongodb/common.sh
+++ b/2.4/root/usr/share/container-scripts/mongodb/common.sh
@@ -40,12 +40,12 @@ function cache_container_addr() {
 
 # wait_for_mongo_up waits until the mongo server accepts incomming connections
 function wait_for_mongo_up() {
-  _wait_for_mongo 1
+  _wait_for_mongo 1 "$@"
 }
 
 # wait_for_mongo_down waits until the mongo server is down
 function wait_for_mongo_down() {
-  _wait_for_mongo 0
+  _wait_for_mongo 0 "$@"
 }
 
 # wait_for_mongo waits until the mongo server is up/down


### PR DESCRIPTION
Host was always 'localhost', and the documented argument '$2' was never set.

Use '$@' instead of '$1' because 'wait_for_mongo_up' and 'wait_for_mongo_down' can be (and are) called without arguments. Using '${1:-}' would be more brittle.

Introduced in https://github.com/openshift/mongodb/pull/135.
