### PR TITLE
2.4: fix user creation in replica set configuration

### DIFF
--- a/2.4/root/usr/share/container-scripts/mongodb/initiate_replica.sh
+++ b/2.4/root/usr/share/container-scripts/mongodb/initiate_replica.sh
@@ -47,7 +47,7 @@ mongo_initiate "${current_endpoints}"
 
 echo "=> Creating MongoDB users ..."
 mongo_create_admin
-mongo_create_user
+mongo_create_user "-u admin -p ${MONGODB_ADMIN_PASSWORD}"
 
 echo "=> Waiting for replication to finish ..."
 # TODO: Replace this with polling or a Mongo script that will check if all


### PR DESCRIPTION
Extended tests for MongoDB replication are failing (https://github.com/openshift/origin/issues/8753) because of changes made in #136 (we updated code for 2.6 but forgot to update it for 2.4).

PTAL @bparees @mfojtik 
CC @omron93 
