### PR TITLE
Use mongod to stop server instead of kill or pkill.

### DIFF
--- a/2.4/root/usr/bin/run-mongod
+++ b/2.4/root/usr/bin/run-mongod
@@ -46,9 +46,7 @@ function cleanup() {
     mongo_remove
   fi
   echo "=> Shutting down MongoDB server ..."
-  if [ -f "${MONGODB_PID_FILE}" ]; then
-    kill -2 $(cat ${MONGODB_PID_FILE})
-  else
+  if pgrep mongod; then
     pkill -2 mongod
   fi
   wait_for_mongo_down

--- a/2.6/root/usr/bin/run-mongod
+++ b/2.6/root/usr/bin/run-mongod
@@ -46,9 +46,7 @@ function cleanup() {
     mongo_remove
   fi
   echo "=> Shutting down MongoDB server ..."
-  if [ -f "${MONGODB_PID_FILE}" ]; then
-    kill -2 $(cat ${MONGODB_PID_FILE})
-  else
+  if pgrep mongod; then
     pkill -2 mongod
   fi
   wait_for_mongo_down


### PR DESCRIPTION
This method of stopping `mongod` is equivalent to using `kill -2` (https://docs.mongodb.com/manual/tutorial/manage-mongodb-processes/#use-shutdown).

This change is a part of removing dependencies of scripts on mongodb options - it necessary to allow using custom config file in #147  
