### PR TITLE
Clean passing arguments to mongod in replSet

### DIFF
--- a/2.4/root/usr/bin/run-mongod
+++ b/2.4/root/usr/bin/run-mongod
@@ -103,19 +103,18 @@ else
     run_mongod_supervisor
     trap 'cleanup' SIGINT SIGTERM
   fi
-  auth_args=" --auth"
-  # When initializing the MongoDB cluster, we have to run without
-  # authentication
-  if [ ! -v MONGODB_NO_AUTH ]; then
-    auth_args=""
+  # In MongoDB 2.4 --keyFile does not imply authentication, so enabling it explicitly
+  # When not initializing the MongoDB cluster, we have to run with authentication
+  if [ -v MONGODB_NO_AUTH ]; then
+    mongo_common_args+=" --auth"
   fi
   # Run `unset_env_vars` and `mongod` in a subshell because
   # MONGODB_ADMIN_PASSWORD should still be defined when the trapped call to
   # `cleanup` references it.
   (
     unset_env_vars
-    mongod $mongo_common_args --replSet ${MONGODB_REPLICA_NAME} \
-      --keyFile ${MONGODB_KEYFILE_PATH} ${auth_args}
+    mongod $mongo_common_args --replSet "${MONGODB_REPLICA_NAME}" \
+      --keyFile "${MONGODB_KEYFILE_PATH}"
   ) &
   wait
 fi

--- a/2.6/root/usr/bin/run-mongod
+++ b/2.6/root/usr/bin/run-mongod
@@ -103,19 +103,13 @@ else
     run_mongod_supervisor
     trap 'cleanup' SIGINT SIGTERM
   fi
-  auth_args=" --auth"
-  # When initializing the MongoDB cluster, we have to run without
-  # authentication
-  if [ ! -v MONGODB_NO_AUTH ]; then
-    auth_args=""
-  fi
   # Run `unset_env_vars` and `mongod` in a subshell because
   # MONGODB_ADMIN_PASSWORD should still be defined when the trapped call to
   # `cleanup` references it.
   (
     unset_env_vars
-    mongod $mongo_common_args --replSet ${MONGODB_REPLICA_NAME} \
-      --keyFile ${MONGODB_KEYFILE_PATH} ${auth_args}
+    mongod $mongo_common_args --replSet "${MONGODB_REPLICA_NAME}" \
+      --keyFile "${MONGODB_KEYFILE_PATH}"
   ) &
   wait
 fi


### PR DESCRIPTION
Clean handling authentication in replSet
- `--auth` could be added to `mongo_common_args`. There is no reason why to have it in separate variable. Also in MongoDB 2.6+ `--auth` is redundant with `--keyFile` (https://docs.mongodb.com/v2.6/reference/configuration-options/#security.keyFile) so removing it for 2.6 to have script more clean.

Double-quote mongod options - based on this comment https://github.com/openshift/mongodb/pull/147#discussion_r61588528
