### PR TITLE
Do not rely on hidden file in dbpath

### DIFF
--- a/2.4/root/usr/bin/run-mongod
+++ b/2.4/root/usr/bin/run-mongod
@@ -72,26 +72,25 @@ if [ -z "${MONGODB_REPLICA_NAME-}" ]; then
     usage
   fi
   # Run the MongoDB in 'standalone' mode
-  if [ ! -f ${MONGODB_DATADIR}/.mongodb_datadir_initialized ]; then
-    # Create MongoDB users and restart MongoDB with authentication enabled
-    # At this time the MongoDB does not accept the incoming connections.
-    mongod $mongo_common_args & #--bind_ip 127.0.0.1 --quiet >/dev/null &
-    wait_for_mongo_up
-    mongo_create_admin
-    mongo_create_user
-    touch ${MONGODB_DATADIR}/.mongodb_datadir_initialized
-    # Restart the MongoDB daemon to bind on all interfaces
-    mongod $mongo_common_args --shutdown
-    wait_for_mongo_down
+  mongod $mongo_common_args &
+  wait_for_mongo_up
+  js_command="db.system.users.count({'user':'admin'})"
+  if [ "$(mongo admin --quiet --eval "$js_command")" == "1" ]; then
+    echo "=> Admin user is already created. Resetting password ..."
+    mongo_reset_admin
   else
-    echo "=> Database directory is already initialized. Skipping creation of users ..."
-    # Ensure passwords match environment variables
-    mongod $mongo_common_args &
-    wait_for_mongo_up
-    mongo_reset_passwords
-    mongod $mongo_common_args --shutdown
-    wait_for_mongo_down
+    mongo_create_admin
   fi
+  js_command="db.system.users.count({'user':'${MONGODB_USER}'})"
+  if [ "$(mongo ${MONGODB_DATABASE} --quiet --eval "$js_command")" == "1" ]; then
+    echo "=> MONGODB_USER user is already created. Resetting password ..."
+    mongo_reset_user
+  else
+    mongo_create_user
+  fi
+  # Restart the MongoDB daemon to bind on all interfaces
+  mongod $mongo_common_args --shutdown
+  wait_for_mongo_down
   unset_env_vars
   exec mongod $mongo_common_args --auth
 else

--- a/2.4/root/usr/share/container-scripts/mongodb/common.sh
+++ b/2.4/root/usr/share/container-scripts/mongodb/common.sh
@@ -227,10 +227,8 @@ function mongo_create_user() {
   fi
 }
 
-# mongo_reset_passwords sets the MongoDB passwords to match MONGODB_PASSWORD
-# and MONGODB_ADMIN_PASSWORD
-function mongo_reset_passwords() {
-  # Reset password of MONGODB_USER
+# mongo_reset_user sets the MongoDB MONGODB_USER's password to match MONGODB_PASSWORD
+function mongo_reset_user() {
   if [[ -n "${MONGODB_USER:-}" && -n "${MONGODB_PASSWORD:-}" && -n "${MONGODB_DATABASE:-}" ]]; then
     local js_command="db.changeUserPassword('${MONGODB_USER}', '${MONGODB_PASSWORD}')"
     if ! mongo ${MONGODB_DATABASE} --eval "${js_command}"; then
@@ -238,8 +236,10 @@ function mongo_reset_passwords() {
       exit 1
     fi
   fi
+}
 
-  # Reset password of admin
+# mongo_reset_admin sets the MongoDB admin password to match MONGODB_ADMIN_PASSWORD
+function mongo_reset_admin() {
   if [[ -n "${MONGODB_ADMIN_PASSWORD:-}" ]]; then
     local js_command="db.changeUserPassword('admin', '${MONGODB_ADMIN_PASSWORD}')"
     if ! mongo admin --eval "${js_command}"; then

--- a/2.6/root/usr/bin/run-mongod
+++ b/2.6/root/usr/bin/run-mongod
@@ -72,26 +72,25 @@ if [ -z "${MONGODB_REPLICA_NAME-}" ]; then
     usage
   fi
   # Run the MongoDB in 'standalone' mode
-  if [ ! -f ${MONGODB_DATADIR}/.mongodb_datadir_initialized ]; then
-    # Create MongoDB users and restart MongoDB with authentication enabled
-    # At this time the MongoDB does not accept the incoming connections.
-    mongod $mongo_common_args & #--bind_ip 127.0.0.1 --quiet >/dev/null &
-    wait_for_mongo_up
-    mongo_create_admin
-    mongo_create_user
-    touch ${MONGODB_DATADIR}/.mongodb_datadir_initialized
-    # Restart the MongoDB daemon to bind on all interfaces
-    mongod $mongo_common_args --shutdown
-    wait_for_mongo_down
+  mongod $mongo_common_args &
+  wait_for_mongo_up
+  js_command="db.system.users.count({'user':'admin', 'db':'admin'})"
+  if [ "$(mongo admin --quiet --eval "$js_command")" == "1" ]; then
+    echo "=> Admin user is already created. Resetting password ..."
+    mongo_reset_admin
   else
-    echo "=> Database directory is already initialized. Skipping creation of users ..."
-    # Ensure passwords match environment variables
-    mongod $mongo_common_args &
-    wait_for_mongo_up
-    mongo_reset_passwords
-    mongod $mongo_common_args --shutdown
-    wait_for_mongo_down
+    mongo_create_admin
   fi
+  js_command="db.system.users.count({'user':'${MONGODB_USER}', 'db':'${MONGODB_DATABASE}'})"
+  if [ "$(mongo admin --quiet --eval "$js_command")" == "1" ]; then
+    echo "=> MONGODB_USER user is already created. Resetting password ..."
+    mongo_reset_user
+  else
+    mongo_create_user
+  fi
+  # Restart the MongoDB daemon to bind on all interfaces
+  mongod $mongo_common_args --shutdown
+  wait_for_mongo_down
   unset_env_vars
   exec mongod $mongo_common_args --auth
 else

--- a/2.6/root/usr/share/container-scripts/mongodb/common.sh
+++ b/2.6/root/usr/share/container-scripts/mongodb/common.sh
@@ -227,10 +227,8 @@ function mongo_create_user() {
   fi
 }
 
-# mongo_reset_passwords sets the MongoDB passwords to match MONGODB_PASSWORD
-# and MONGODB_ADMIN_PASSWORD
-function mongo_reset_passwords() {
-  # Reset password of MONGODB_USER
+# mongo_reset_user sets the MongoDB MONGODB_USER's password to match MONGODB_PASSWORD
+function mongo_reset_user() {
   if [[ -n "${MONGODB_USER:-}" && -n "${MONGODB_PASSWORD:-}" && -n "${MONGODB_DATABASE:-}" ]]; then
     local js_command="db.changeUserPassword('${MONGODB_USER}', '${MONGODB_PASSWORD}')"
     if ! mongo ${MONGODB_DATABASE} --eval "${js_command}"; then
@@ -238,8 +236,10 @@ function mongo_reset_passwords() {
       exit 1
     fi
   fi
+}
 
-  # Reset password of admin
+# mongo_reset_admin sets the MongoDB admin password to match MONGODB_ADMIN_PASSWORD
+function mongo_reset_admin() {
   if [[ -n "${MONGODB_ADMIN_PASSWORD:-}" ]]; then
     local js_command="db.changeUserPassword('admin', '${MONGODB_ADMIN_PASSWORD}')"
     if ! mongo admin --eval "${js_command}"; then


### PR DESCRIPTION
In current situation scripts check if database path contains file `.mongodb_datadir_initialized`. It allows user to mount database directory inside a container.
However if user mounts dbpath not created by openshift images this file does not exists!

This PR allows scripts to check if a user is present without relying on this hidden file. So it is possible to mount database from non container deployment.
This change is also part of removing dependencies of scripts on mongodb options - it necessary to allow using custom config file in #147
