### PR TITLE
Remove creationTimestamp from template

### DIFF
--- a/2.4/examples/replica/mongodb-clustered.json
+++ b/2.4/examples/replica/mongodb-clustered.json
@@ -81,8 +81,7 @@
       "kind": "DeploymentConfig",
       "apiVersion": "v1",
       "metadata": {
-        "name": "${MONGODB_SERVICE_NAME}",
-        "creationTimestamp": null
+        "name": "${MONGODB_SERVICE_NAME}"
       },
       "spec": {
         "strategy": {


### PR DESCRIPTION
The field shouldn't be in the template, it is set when the
DeploymentConfig is created.
