### PR TITLE
Reformat template JSON

### DIFF
--- a/2.4/examples/replica/mongodb-clustered.json
+++ b/2.4/examples/replica/mongodb-clustered.json
@@ -53,7 +53,7 @@
       "from": "[a-zA-Z0-9]{255}"
     }
   ],
-  "objects":[
+  "objects": [
     {
       "kind": "Service",
       "apiVersion": "v1",
@@ -91,7 +91,8 @@
               "failurePolicy": "Retry",
               "execNewPod": {
                 "command": [
-                  "run-mongod", "initiate"
+                  "run-mongod",
+                  "initiate"
                 ],
                 "containerName": "mongodb",
                 "env": [
@@ -106,7 +107,7 @@
         },
         "triggers": [
           {
-            "type":"ConfigChange"
+            "type": "ConfigChange"
           }
         ],
         "replicas": 3,
@@ -122,14 +123,14 @@
           "spec": {
             "containers": [
               {
-                "name":  "mongodb",
+                "name": "mongodb",
                 "image": "openshift/mongodb-24-centos7",
                 "readinessProbe": {
-                    "tcpSocket":{
-                        "port": 27017
-                    },
-                    "initialDelaySeconds": 15,
-                    "timeoutSeconds": 1
+                  "tcpSocket": {
+                    "port": 27017
+                  },
+                  "initialDelaySeconds": 15,
+                  "timeoutSeconds": 1
                 },
                 "env": [
                   {
@@ -161,7 +162,7 @@
                     "value": "${MONGODB_KEYFILE_VALUE}"
                   }
                 ],
-                "ports":[
+                "ports": [
                   {
                     "containerPort": 27017
                   }


### PR DESCRIPTION
Consistently use 2 spaces for indentation, and single space after colon.

@bparees PTAL
