### PR TITLE
Remove ignore fields in template

### DIFF
--- a/2.4/examples/replica/mongodb-clustered.json
+++ b/2.4/examples/replica/mongodb-clustered.json
@@ -170,9 +170,7 @@
               }
             ]
           }
-        },
-        "restartPolicy": "Never",
-        "dnsPolicy": "ClusterFirst"
+        }
       }
     }
   ]


### PR DESCRIPTION
The fields belong to a PodSpec, but they are for a very long time part
of the DeploymentConfigSpec, and simply ignored when the template is
loaded into OpenShift.
- restartPolicy: we probably want to keep the default behavior, which is
  restart 'Always'. If a pod running mongod dies, we want it to be
  restarted. The 'Never' was never really used.
- dnsPolicy: the default is 'ClusterFirst', so even if we'd move it to
  the PodSpec, it'd be a no-op.
