### PR TITLE
Fix adding arguments in mongo_cmd_local.

### DIFF
--- a/2.4/test/run
+++ b/2.4/test/run
@@ -47,7 +47,7 @@ function mongo_admin_cmd() {
 
 function mongo_cmd_local() {
     local name="$1" ; shift
-    docker exec $(get_cid $name) bash -c mongo "$@"
+    docker exec $(get_cid $name) bash -c "mongo $@"
 }
 
 function test_connection() {

--- a/2.6/test/run
+++ b/2.6/test/run
@@ -47,7 +47,7 @@ function mongo_admin_cmd() {
 
 function mongo_cmd_local() {
     local name="$1" ; shift
-    docker exec $(get_cid $name) bash -c mongo "$@"
+    docker exec $(get_cid $name) bash -c "mongo $@"
 }
 
 function test_connection() {


### PR DESCRIPTION
Execing command into container in tests in function `mongo_cmd_local` is not working properly. If `bash -c` does not take quoted string arguments are not passed to running command.

`mongo_cmd_local` could be used to connect to database which ofter requires adding additional arguments to mongo shell.
