### PR TITLE
Use proper repository for rh-mongodb32 in CentOS.

### DIFF
--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -23,8 +23,7 @@ EXPOSE 27017
 
 # Due to the https://bugzilla.redhat.com/show_bug.cgi?id=1206151,
 # the whole /var/lib/mongodb/ dir has to be chown-ed.
-RUN yum install -y centos-release-scl-rh && \
-    yum-config-manager --enable centos-sclo-rh-testing && \
+RUN yum install -y centos-release-scl && \
     INSTALL_PKGS="bind-utils gettext iproute rsync tar rh-mongodb32-mongodb rh-mongodb32" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \


### PR DESCRIPTION
Now it is not necessary to use testing repository.

Fixes #129.
