### PR TITLE
Add 3.0-upg version of MongoDB.

### DIFF
--- a/3.0-upg/Dockerfile
+++ b/3.0-upg/Dockerfile
@@ -1,0 +1,58 @@
+FROM centos:centos7
+MAINTAINER SoftwareCollections.org <sclorg@redhat.com>
+
+# MongoDB image for OpenShift.
+#
+# Volumes:
+#  * /var/lib/mongodb/data - Datastore for MongoDB
+# Environment:
+#  * $MONGODB_USER - Database user name
+#  * $MONGODB_PASSWORD - User's password
+#  * $MONGODB_DATABASE - Name of the database to create
+#  * $MONGODB_ADMIN_PASSWORD - Password of the MongoDB Admin
+
+ENV MONGODB_VERSION=3.0-upg \
+    HOME=/var/lib/mongodb
+
+LABEL io.k8s.description="MongoDB is a scalable, high-performance, open source NoSQL database." \
+      io.k8s.display-name="MongoDB 3.0-upg" \
+      io.openshift.expose-services="27017:mongodb" \
+      io.openshift.tags="database,mongodb,rh-mongodb30upg"
+
+EXPOSE 27017
+
+# Due to the https://bugzilla.redhat.com/show_bug.cgi?id=1206151,
+# the whole /var/lib/mongodb/ dir has to be chown-ed.
+RUN yum install -y centos-release-scl && \
+    INSTALL_PKGS="bind-utils gettext iproute rsync tar v8314 rh-mongodb30upg-mongodb rh-mongodb30upg" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all && \
+    mkdir -p /var/lib/mongodb/data && chown -R mongodb.0 /var/lib/mongodb/ /var/opt/rh/rh-mongodb30upg/lib/mongodb && \
+    # Loosen permission bits to avoid problems running container with arbitrary UID
+    chmod g+w -R /var/opt/rh/rh-mongodb30upg/lib/mongodb && \
+    chmod -R g+rwx /var/lib/mongodb
+
+# Get prefix path and path to scripts rather than hard-code them in scripts
+ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mongodb \
+    MONGODB_PREFIX=/opt/rh/rh-mongodb30upg/root/usr \
+    ENABLED_COLLECTIONS=rh-mongodb30upg
+
+# When bash is started non-interactively, to run a shell script, for example it
+# looks for this variable and source the content of this file. This will enable
+# the SCL for all scripts without need to do 'scl enable'.
+ENV BASH_ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
+    ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
+    PROMPT_COMMAND=". ${CONTAINER_SCRIPTS_PATH}/scl_enable"
+
+ADD root /
+
+# Container setup
+RUN touch /etc/mongod.conf && chown mongodb:0 /etc/mongod.conf && /usr/libexec/fix-permissions /etc/mongod.conf
+
+VOLUME ["/var/lib/mongodb/data"]
+
+USER 184
+
+ENTRYPOINT ["container-entrypoint"]
+CMD ["run-mongod"]

--- a/3.0-upg/Dockerfile.rhel7
+++ b/3.0-upg/Dockerfile.rhel7
@@ -1,0 +1,65 @@
+FROM rhel7.2
+# MongoDB image for OpenShift.
+#
+# Volumes:
+#  * /var/lib/mongodb/data - Datastore for MongoDB
+# Environment:
+#  * $MONGODB_USER - Database user name
+#  * $MONGODB_PASSWORD - User's password
+#  * $MONGODB_DATABASE - Name of the database to create
+#  * $MONGODB_ADMIN_PASSWORD - Password of the MongoDB Admin
+
+ENV MONGODB_VERSION=3.0-upg \
+    HOME=/var/lib/mongodb
+
+LABEL io.k8s.description="MongoDB is a scalable, high-performance, open source NoSQL database." \
+      io.k8s.display-name="MongoDB 3.0-upg" \
+      io.openshift.expose-services="27017:mongodb" \
+      io.openshift.tags="database,mongodb,rh-mongodb30upg"
+
+# Labels consumed by Red Hat build service
+LABEL BZComponent="rh-mongodb30-upg-docker" \
+      Name="rhscl/mongodb-30-upg-rhel7" \
+      Version="3.0-upg" \
+      Release="1" \
+      Architecture="x86_64"
+
+EXPOSE 27017
+
+# Due to the https://bugzilla.redhat.com/show_bug.cgi?id=1206151,
+# the whole /var/lib/mongodb/ dir has to be chown-ed.
+RUN yum install -y yum-utils && \
+    yum-config-manager --enable rhel-server-rhscl-7-rpms && \
+    yum-config-manager --enable rhel-7-server-optional-rpms && \
+    INSTALL_PKGS="bind-utils gettext iproute rsync tar v8314 rh-mongodb30upg-mongodb rh-mongodb30upg" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all && \
+    mkdir -p /var/lib/mongodb/data && chown -R mongodb.0 /var/lib/mongodb/ /var/opt/rh/rh-mongodb30upg/lib/mongodb && \
+    # Loosen permission bits to avoid problems running container with arbitrary UID
+    chmod g+w -R /var/opt/rh/rh-mongodb30upg/lib/mongodb && \
+    chmod -R g+rwx /var/lib/mongodb
+
+# Get prefix path and path to scripts rather than hard-code them in scripts
+ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mongodb \
+    MONGODB_PREFIX=/opt/rh/rh-mongodb30upg/root/usr \
+    ENABLED_COLLECTIONS=rh-mongodb30upg
+
+# When bash is started non-interactively, to run a shell script, for example it
+# looks for this variable and source the content of this file. This will enable
+# the SCL for all scripts without need to do 'scl enable'.
+ENV BASH_ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
+    ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
+    PROMPT_COMMAND=". ${CONTAINER_SCRIPTS_PATH}/scl_enable"
+
+ADD root /
+
+# Container setup
+RUN touch /etc/mongod.conf && chown mongodb:0 /etc/mongod.conf && /usr/libexec/fix-permissions /etc/mongod.conf
+
+VOLUME ["/var/lib/mongodb/data"]
+
+USER 184
+
+ENTRYPOINT ["container-entrypoint"]
+CMD ["run-mongod"]

--- a/3.0-upg/README.md
+++ b/3.0-upg/README.md
@@ -1,0 +1,81 @@
+MongoDB Docker image
+====================
+
+This repository contains Dockerfiles for MongoDB images for general usage and OpenShift.
+Users can choose between RHEL and CentOS based images.
+
+**Notice: This image is supported only for upgrade from centos/mongodb-26-centos7 to centos/mongodb-32-centos7.**
+
+Environment variables
+---------------------------------
+
+The image recognizes the following environment variables that you can set during
+initialization by passing `-e VAR=VALUE` to the Docker run command.
+
+|    Variable name          |    Description                              |
+| :------------------------ | -----------------------------------------   |
+|  `MONGODB_USER`       | User name for MONGODB account to be created |
+|  `MONGODB_PASSWORD`       | Password for the user account               |
+|  `MONGODB_DATABASE`       | Database name                               |
+|  `MONGODB_ADMIN_PASSWORD` | Password for the admin user                 |
+
+
+The following environment variables influence the MongoDB configuration file. They are all optional.
+
+|    Variable name      |    Description                                                            |    Default
+| :-------------------- | ------------------------------------------------------------------------- | ----------------
+|  `MONGODB_NOPREALLOC` | Disable data file preallocation.                                          |  true
+|  `MONGODB_SMALLFILES` | Set MongoDB to use a smaller default data file size.                      |  true
+|  `MONGODB_QUIET`      | Runs MongoDB in a quiet mode that attempts to limit the amount of output. |  true
+
+
+You can also set the following mount points by passing the `-v /host:/container` flag to Docker.
+
+|  Volume mount point         | Description            |
+| :-------------------------- | ---------------------- |
+|  `/var/lib/mongodb/data`   | MongoDB data directory |
+
+**Notice: When mouting a directory from the host into the container, ensure that the mounted
+directory has the appropriate permissions and that the owner and group of the directory
+matches the user UID or name which is running inside the container.**
+
+
+Usage
+---------------------------------
+
+For this, we will assume that you are using the `centos/mongodb-26-centos7` image.
+If you want to set only the mandatory environment variables and store the database
+in the `/home/user/database` directory on the host filesystem, execute the following command:
+
+```
+$ docker run -d -e MONGODB_USER=<user> -e MONGODB_PASSWORD=<password> -e MONGODB_DATABASE=<database> -e MONGODB_ADMIN_PASSWORD=<admin_password> -v /home/user/database:/var/lib/mongodb/data centos/mongodb-26-centos7
+```
+
+If you are initializing the database and it's the first time you are using the
+specified shared volume, the database will be created with two users: `admin` and `MONGODB_USER`. After that the MongoDB daemon
+will be started. If you are re-attaching the volume to another container, the
+creation of the database user and admin user will be skipped and only the
+MongoDB daemon will be started.
+
+
+MongoDB admin user
+---------------------------------
+
+The admin user name is set to `admin` and you have to to specify the password by
+setting the `MONGODB_ADMIN_PASSWORD` environment variable. This process is done
+upon database initialization.
+
+
+Changing passwords
+------------------
+
+Since passwords are part of the image configuration, the only supported method
+to change passwords for the database user (`MONGODB_USER`) and admin user is by
+changing the environment variables `MONGODB_PASSWORD` and
+`MONGODB_ADMIN_PASSWORD`, respectively.
+
+Changing database passwords directly in MongoDB will cause a mismatch between
+the values stored in the variables and the actual passwords. Whenever a database
+container starts it will reset the passwords to the values stored in the
+environment variables.
+

--- a/3.0-upg/cccp.yml
+++ b/3.0-upg/cccp.yml
@@ -1,0 +1,1 @@
+job-id: mongodb-30-upg-centos7

--- a/3.0-upg/root/usr/bin/container-entrypoint
+++ b/3.0-upg/root/usr/bin/container-entrypoint
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec "$@"

--- a/3.0-upg/root/usr/bin/run-mongod
+++ b/3.0-upg/root/usr/bin/run-mongod
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source ${CONTAINER_SCRIPTS_PATH}/common.sh
+
+# Data directory where MongoDB database files live. The data subdirectory is here
+# because mongodb.conf lives in /var/lib/mongodb/ and we don't want a volume to
+# override it.
+export MONGODB_DATADIR=/var/lib/mongodb/data
+
+# Configuration settings.
+export MONGODB_NOPREALLOC=${MONGODB_NOPREALLOC:-true}
+export MONGODB_SMALLFILES=${MONGODB_SMALLFILES:-true}
+export MONGODB_QUIET=${MONGODB_QUIET:-true}
+
+
+export MONGODB_KEYFILE_SOURCE_PATH="/var/run/secrets/mongo/keyfile"
+export MONGODB_KEYFILE_PATH="${HOME}/keyfile"
+
+function usage() {
+  echo "You must specify the following environment variables:"
+  echo "  MONGODB_USER"
+  echo "  MONGODB_PASSWORD"
+  echo "  MONGODB_DATABASE"
+  echo "  MONGODB_ADMIN_PASSWORD"
+  echo "Optional variables:"
+  echo "  MONGODB_REPLICA_NAME"
+  echo "  MONGODB_INITIAL_REPLICA_COUNT"
+  echo "MongoDB settings:"
+  echo "  MONGODB_NOPREALLOC (default: true)"
+  echo "  MONGODB_SMALLFILES (default: true)"
+  echo "  MONGODB_QUIET (default: true)"
+  exit 1
+}
+
+# Make sure env variables don't propagate to mongod process.
+function unset_env_vars() {
+  unset MONGODB_USER MONGODB_PASSWORD MONGODB_DATABASE MONGODB_ADMIN_PASSWORD
+}
+
+function cleanup() {
+  if [ -n "${MONGODB_REPLICA_NAME-}" ]; then
+    mongo_remove
+  fi
+  echo "=> Shutting down MongoDB server ..."
+  if pgrep mongod; then
+    pkill -2 mongod
+  fi
+  wait_for_mongo_down
+  exit 0
+}
+
+echo "
+
+
+Notice: This image is supported only for upgrade from centos/mongodb-26-centos7 to centos/mongodb-32-centos7.
+
+
+"
+
+if [ $# -gt 0 ] && [ "$1" == "initiate" ]; then
+  if ! [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE && -v MONGODB_ADMIN_PASSWORD ]]; then
+    usage
+  fi
+  setup_keyfile
+  exec ${CONTAINER_SCRIPTS_PATH}/initiate_replica.sh
+fi
+
+# Generate config file for MongoDB
+envsubst < ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template > $MONGODB_CONFIG_PATH
+
+# Need to cache the container address for the cleanup
+cache_container_addr
+mongo_common_args="-f $MONGODB_CONFIG_PATH --oplogSize 64"
+if [ -z "${MONGODB_REPLICA_NAME-}" ]; then
+  if ! [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE && -v MONGODB_ADMIN_PASSWORD ]]; then
+    usage
+  fi
+  # Run the MongoDB in 'standalone' mode
+  mongod $mongo_common_args &
+  wait_for_mongo_up
+  js_command="db.system.users.count({'user':'admin', 'db':'admin'})"
+  if [ "$(mongo admin --quiet --eval "$js_command")" == "1" ]; then
+    echo "=> Admin user is already created. Resetting password ..."
+    mongo_reset_admin
+  else
+    mongo_create_admin
+  fi
+  js_command="db.system.users.count({'user':'${MONGODB_USER}', 'db':'${MONGODB_DATABASE}'})"
+  if [ "$(mongo admin --quiet --eval "$js_command")" == "1" ]; then
+    echo "=> MONGODB_USER user is already created. Resetting password ..."
+    mongo_reset_user
+  else
+    mongo_create_user
+  fi
+  # Restart the MongoDB daemon to bind on all interfaces
+  mongod $mongo_common_args --shutdown
+  wait_for_mongo_down
+  unset_env_vars
+  exec mongod $mongo_common_args --auth
+else
+  setup_keyfile
+  # Run the MongoDB in 'clustered' mode with --replSet
+  if [ ! -v MONGODB_NO_SUPERVISOR ]; then
+    run_mongod_supervisor
+    trap 'cleanup' SIGINT SIGTERM
+  fi
+  # Run `unset_env_vars` and `mongod` in a subshell because
+  # MONGODB_ADMIN_PASSWORD should still be defined when the trapped call to
+  # `cleanup` references it.
+  (
+    unset_env_vars
+    mongod $mongo_common_args --replSet "${MONGODB_REPLICA_NAME}" \
+      --keyFile "${MONGODB_KEYFILE_PATH}"
+  ) &
+  wait
+fi

--- a/3.0-upg/root/usr/libexec/fix-permissions
+++ b/3.0-upg/root/usr/libexec/fix-permissions
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Fix permissions on the given directory to allow group read/write of 
+# regular files and execute of directories.
+find $1 -exec chgrp 0 {} \;
+find $1 -exec chmod g+rw {} \;
+find $1 -type d -exec chmod g+x {} +

--- a/3.0-upg/root/usr/share/container-scripts/mongodb/common.sh
+++ b/3.0-upg/root/usr/share/container-scripts/mongodb/common.sh
@@ -1,0 +1,261 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Used for wait_for_mongo_* functions
+MAX_ATTEMPTS=60
+SLEEP_TIME=1
+
+export MONGODB_CONFIG_PATH=/etc/mongod.conf
+export MONGODB_PID_FILE=/var/lib/mongodb/mongodb.pid
+export MONGODB_KEYFILE_PATH=/var/lib/mongodb/keyfile
+export CONTAINER_PORT=27017
+
+# container_addr returns the current container external IP address
+function container_addr() {
+  echo -n $(cat ${HOME}/.address)
+}
+
+# mongo_addr returns the IP:PORT of the currently running MongoDB instance
+function mongo_addr() {
+  echo -n "$(container_addr):${CONTAINER_PORT}"
+}
+
+# cache_container_addr waits till the container gets the external IP address and
+# cache it to disk
+function cache_container_addr() {
+  echo -n "=> Waiting for container IP address ..."
+  local i
+  for i in $(seq "$MAX_ATTEMPTS"); do
+    if ip -oneline -4 addr show up scope global | grep -Eo '[0-9]{,3}(\.[0-9]{,3}){3}' > "${HOME}"/.address; then
+      echo " $(mongo_addr)"
+      return 0
+    fi
+    sleep $SLEEP_TIME
+  done
+  echo "Failed to get Docker container IP address." && exit 1
+}
+
+# wait_for_mongo_up waits until the mongo server accepts incomming connections
+function wait_for_mongo_up() {
+  _wait_for_mongo 1 "$@"
+}
+
+# wait_for_mongo_down waits until the mongo server is down
+function wait_for_mongo_down() {
+  _wait_for_mongo 0 "$@"
+}
+
+# wait_for_mongo waits until the mongo server is up/down
+# $1 - 0 or 1 - to specify for what to wait (0 - down, 1 - up)
+# $2 - host where to connect (localhost by default)
+function _wait_for_mongo() {
+  local operation=${1:-1}
+  local message="up"
+  if [[ ${operation} -eq 0 ]]; then
+    message="down"
+  fi
+
+  local mongo_cmd="mongo admin --host ${2:-localhost} --port ${CONTAINER_PORT} "
+
+  local i
+  for i in $(seq $MAX_ATTEMPTS); do
+    echo "=> ${2:-} Waiting for MongoDB daemon ${message}"
+    if ([[ ${operation} -eq 1 ]] && ${mongo_cmd} --eval "quit()" &>/dev/null) || ([[ ${operation} -eq 0 ]] && ! ${mongo_cmd} --eval "quit()" &>/dev/null); then
+      echo "=> MongoDB daemon is ${message}"
+      return 0
+    fi
+    sleep ${SLEEP_TIME}
+  done
+  echo "=> Giving up: MongoDB daemon is not ${message}!"
+  return 1
+}
+
+# endpoints returns list of IP addresses with other instances of MongoDB
+# To get list of endpoints, you need to have headless Service named 'mongodb'.
+# NOTE: This won't work with standalone Docker container.
+function endpoints() {
+  service_name=${MONGODB_SERVICE_NAME:-mongodb}
+  dig ${service_name} A +search +short 2>/dev/null
+}
+
+# build_mongo_config builds the MongoDB replicaSet config used for the cluster
+# initialization.
+# Takes a list of space-separated member IPs as the first argument.
+function build_mongo_config() {
+  local current_endpoints
+  current_endpoints="$1"
+  local members
+  members="{ _id: 0, host: \"$(mongo_addr)\"},"
+  local member_id
+  member_id=1
+  local container_addr
+  container_addr="$(container_addr)"
+  local node
+  for node in ${current_endpoints}; do
+    if [ "$node" != "$container_addr" ]; then
+      members+="{ _id: ${member_id}, host: \"${node}:${CONTAINER_PORT}\"},"
+      let member_id++
+    fi
+  done
+  echo -n "var config={ _id: \"${MONGODB_REPLICA_NAME}\", members: [ ${members%,} ] }"
+}
+
+# mongo_initiate initiates the replica set.
+# Takes a list of space-separated member IPs as the first argument.
+function mongo_initiate() {
+  local mongo_wait
+  mongo_wait="while (rs.status().startupStatus || (rs.status().hasOwnProperty(\"myState\") && rs.status().myState != 1)) { printjson( rs.status() ); sleep(1000); }; printjson( rs.status() );"
+  config=$(build_mongo_config "$1")
+  echo "=> Initiating MongoDB replica using: ${config}"
+  mongo admin --eval "${config};rs.initiate(config);${mongo_wait}"
+}
+
+# get the address of the current primary member
+function mongo_primary_member_addr() {
+  local rc=0
+
+  endpoints | grep -v "$(container_addr)" |
+  (
+    while read mongo_node; do
+      cmd_output="$(mongo admin -u admin -p "$MONGODB_ADMIN_PASSWORD" --host "$mongo_node:$CONTAINER_PORT" --eval 'print(rs.isMaster().primary)' --quiet || true)"
+
+      # Trying to find IP:PORT in output and filter out error message because mongo prints it to stdout
+      ip_and_port_regexp='[0-9]\+\.[0-9]\+\.[0-9]\+\.[0-9]\+:[0-9]\+'
+      if addr="$(echo "$cmd_output" | grep -x "$ip_and_port_regexp")"; then
+        echo -n "$addr"
+        exit 0
+      fi
+
+      echo >&2 "Cannot get address of primary from $mongo_node node: $cmd_output"
+    done
+
+    exit 1
+  ) || rc=$?
+
+  if [ $rc -ne 0 ]; then
+    echo >&2 "Cannot get address of primary node: after checking all nodes we don't have the address"
+    return 1
+  fi
+}
+
+# mongo_remove removes the current MongoDB from the cluster
+function mongo_remove() {
+  local primary_addr
+  # if we cannot determine the IP address of the primary, exit without an error
+  # to allow callers to proceed with their logic
+  primary_addr="$(mongo_primary_member_addr || true)"
+  if [ -z "$primary_addr" ]; then
+    return
+  fi
+
+  local mongo_addr
+  mongo_addr="$(mongo_addr)"
+
+  echo "=> Removing ${mongo_addr} on ${primary_addr} ..."
+  mongo admin -u admin -p "${MONGODB_ADMIN_PASSWORD}" \
+    --host "${primary_addr}" --eval "rs.remove('${mongo_addr}');" || true
+}
+
+# mongo_add advertise the current container to other mongo replicas
+function mongo_add() {
+  local primary_addr
+  # if we cannot determine the IP address of the primary, exit without an error
+  # to allow callers to proceed with their logic
+  primary_addr="$(mongo_primary_member_addr || true)"
+  if [ -z "$primary_addr" ]; then
+    return
+  fi
+
+  local mongo_addr
+  mongo_addr="$(mongo_addr)"
+
+  echo "=> Adding ${mongo_addr} to ${primary_addr} ..."
+  mongo admin -u admin -p "${MONGODB_ADMIN_PASSWORD}" \
+    --host "${primary_addr}" --eval "rs.add('${mongo_addr}');"
+}
+
+# run_mongod_supervisor runs the MongoDB replica supervisor that manages
+# registration of the new members to the MongoDB replica cluster
+function run_mongod_supervisor() {
+  ${CONTAINER_SCRIPTS_PATH}/replica_supervisor.sh 2>&1 &
+}
+
+# mongo_create_admin creates the MongoDB admin user with password: MONGODB_ADMIN_PASSWORD
+# $1 - login parameters for mongo (optional)
+# $2 - host where to connect (localhost by default)
+function mongo_create_admin() {
+  if [[ -z "${MONGODB_ADMIN_PASSWORD:-}" ]]; then
+    echo "=> MONGODB_ADMIN_PASSWORD is not set. Authentication can not be set up."
+    exit 1
+  fi
+
+  # Set admin password
+  local js_command="db.createUser({user: 'admin', pwd: '${MONGODB_ADMIN_PASSWORD}', roles: ['dbAdminAnyDatabase', 'userAdminAnyDatabase' , 'readWriteAnyDatabase','clusterAdmin' ]});"
+  if ! mongo admin ${1:-} --host ${2:-"localhost"} --eval "${js_command}"; then
+    echo "=> Failed to create MongoDB admin user."
+    exit 1
+  fi
+}
+
+# mongo_create_user creates the MongoDB database user: MONGODB_USER,
+# with password: MONGDOB_PASSWORD, inside database: MONGODB_DATABASE
+# $1 - login parameters for mongo (optional)
+# $2 - host where to connect (localhost by default)
+function mongo_create_user() {
+  # Ensure input variables exists
+  if [[ -z "${MONGODB_USER:-}" ]]; then
+    echo "=> MONGODB_USER is not set. Failed to create MongoDB user: ${MONGODB_USER}"
+    exit 1
+  fi
+  if [[ -z "${MONGODB_PASSWORD:-}" ]]; then
+    echo "=> MONGODB_PASSWORD is not set. Failed to create MongoDB user: ${MONGODB_USER}"
+    exit 1
+  fi
+  if [[ -z "${MONGODB_DATABASE:-}" ]]; then
+    echo "=> MONGODB_DATABASE is not set. Failed to create MongoDB user: ${MONGODB_USER}"
+    exit 1
+  fi
+
+  # Create database user
+  local js_command="db.getSiblingDB('${MONGODB_DATABASE}').createUser({user: '${MONGODB_USER}', pwd: '${MONGODB_PASSWORD}', roles: [ 'readWrite' ]});"
+  if ! mongo admin ${1:-} --host ${2:-"localhost"} --eval "${js_command}"; then
+    echo "=> Failed to create MongoDB user: ${MONGODB_USER}"
+    exit 1
+  fi
+}
+
+# mongo_reset_user sets the MongoDB MONGODB_USER's password to match MONGODB_PASSWORD
+function mongo_reset_user() {
+  if [[ -n "${MONGODB_USER:-}" && -n "${MONGODB_PASSWORD:-}" && -n "${MONGODB_DATABASE:-}" ]]; then
+    local js_command="db.changeUserPassword('${MONGODB_USER}', '${MONGODB_PASSWORD}')"
+    if ! mongo ${MONGODB_DATABASE} --eval "${js_command}"; then
+      echo "=> Failed to reset password of MongoDB user: ${MONGODB_USER}"
+      exit 1
+    fi
+  fi
+}
+
+# mongo_reset_admin sets the MongoDB admin password to match MONGODB_ADMIN_PASSWORD
+function mongo_reset_admin() {
+  if [[ -n "${MONGODB_ADMIN_PASSWORD:-}" ]]; then
+    local js_command="db.changeUserPassword('admin', '${MONGODB_ADMIN_PASSWORD}')"
+    if ! mongo admin --eval "${js_command}"; then
+      echo "=> Failed to reset password of MongoDB user: ${MONGODB_USER}"
+      exit 1
+    fi
+  fi
+}
+
+# setup_keyfile fixes the bug in mounting the Kubernetes 'Secret' volume that
+# mounts the secret files with 'too open' permissions.
+function setup_keyfile() {
+  if [ -z "${MONGODB_KEYFILE_VALUE-}" ]; then
+    echo "ERROR: You have to provide the 'keyfile' value in MONGODB_KEYFILE_VALUE"
+    exit 1
+  fi
+  echo ${MONGODB_KEYFILE_VALUE} > ${MONGODB_KEYFILE_PATH}
+  chmod 0600 ${MONGODB_KEYFILE_PATH}
+}

--- a/3.0-upg/root/usr/share/container-scripts/mongodb/initiate_replica.sh
+++ b/3.0-upg/root/usr/share/container-scripts/mongodb/initiate_replica.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source ${CONTAINER_SCRIPTS_PATH}/common.sh
+
+current_endpoints=$(endpoints)
+if [ -n "${MONGODB_INITIAL_REPLICA_COUNT:-}" ]; then
+  echo -n "=> Waiting for $MONGODB_INITIAL_REPLICA_COUNT MongoDB endpoints ..."
+  while [[ "$(echo "${current_endpoints}" | wc -l)" -lt ${MONGODB_INITIAL_REPLICA_COUNT} ]]; do
+    sleep 2
+    current_endpoints=$(endpoints)
+  done
+else
+  echo "Attention: MONGODB_INITIAL_REPLICA_COUNT is not set and it could lead to a improperly configured replica set."
+  echo "To fix this, set MONGODB_INITIAL_REPLICA_COUNT variable to the number of members in the replica set in"
+  echo "the configuration of post deployment hook."
+
+  echo -n "=> Waiting for MongoDB endpoints ..."
+  while [ -z "${current_endpoints}" ]; do
+    sleep 2
+    current_endpoints=$(endpoints)
+  done
+fi
+echo "${current_endpoints}"
+
+# Let initialize the first member of the cluster
+mongo_node="$(echo -n ${current_endpoints} | cut -d ' ' -f 1):${CONTAINER_PORT}"
+
+echo "=> Waiting for all endpoints to accept connections..."
+for node in ${current_endpoints}; do
+  wait_for_mongo_up ${node} &>/dev/null
+done
+
+echo "=> Initiating the replSet ${MONGODB_REPLICA_NAME} ..."
+# Start the MongoDB without authentication to initialize and kick-off the cluster:
+# This MongoDB server is just temporary and will be removed later in this
+# script.
+export MONGODB_REPLICA_NAME
+MONGODB_NO_SUPERVISOR=1 MONGODB_NO_AUTH=1 run-mongod mongod &
+wait_for_mongo_up
+
+# This will perform the 'rs.initiate()' command on the current MongoDB.
+mongo_initiate "${current_endpoints}"
+
+echo "=> Creating MongoDB users ..."
+mongo_create_admin
+mongo_create_user "-u admin -p ${MONGODB_ADMIN_PASSWORD}"
+
+echo "=> Waiting for replication to finish ..."
+# TODO: Replace this with polling or a Mongo script that will check if all
+#       members of the cluster are now properly replicated (user accounts are
+#       created on all members).
+sleep 10
+
+# Some commands will force MongoDB client to re-connect. This is not working
+# well in combination with '--eval'. In that case the 'mongo' command will fail
+# with return code 254.
+echo "=> Initiate Pod giving up the PRIMARY role ..."
+mongo admin -u admin -p "${MONGODB_ADMIN_PASSWORD}" --quiet --eval "rs.stepDown(120);" &>/dev/null || true
+
+# Wait till the new PRIMARY member is elected
+echo "=> Waiting for the new PRIMARY to be elected ..."
+mongo admin -u admin -p "${MONGODB_ADMIN_PASSWORD}" --quiet --host ${mongo_node} --eval "var done=false;while(done==false){var members=rs.status().members;for(i=0;i<members.length;i++){if(members[i].stateStr=='PRIMARY' && members[i].name!='$(mongo_addr)'){done=true}};sleep(500)};" &>/dev/null
+
+# Remove the initialization container MongoDB from cluster and shutdown
+echo "=> The new PRIMARY member is $(mongo_primary_member_addr), shutting down current member ..."
+mongo_remove
+
+mongod -f ${MONGODB_CONFIG_PATH} --shutdown &>/dev/null
+wait_for_mongo_down
+
+echo "=> Successfully initialized replSet"

--- a/3.0-upg/root/usr/share/container-scripts/mongodb/mongodb.conf.template
+++ b/3.0-upg/root/usr/share/container-scripts/mongodb/mongodb.conf.template
@@ -1,0 +1,21 @@
+# mongodb.conf
+
+port = 27017
+pidfilepath = ${MONGODB_PID_FILE}
+
+# Set this value to designate a directory for the mongod instance to store its data.
+# Default: /var/lib/mongodb/data
+dbpath = ${MONGODB_DATADIR}
+
+# Disable data file preallocation. Default: true
+noprealloc = ${MONGODB_NOPREALLOC}
+
+# Set MongoDB to use a smaller default data file size. Default: true
+smallfiles = ${MONGODB_SMALLFILES}
+
+# Runs MongoDB in a quiet mode that attempts to limit the amount of output.
+# Default: true
+quiet = ${MONGODB_QUIET}
+
+# Disable the HTTP interface (Defaults to localhost:28017).
+nohttpinterface = true

--- a/3.0-upg/root/usr/share/container-scripts/mongodb/replica_supervisor.sh
+++ b/3.0-upg/root/usr/share/container-scripts/mongodb/replica_supervisor.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+#
+# This script registers the current container into MongoDB replica set and
+# unregisters it when the container is terminated.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source ${CONTAINER_SCRIPTS_PATH}/common.sh
+
+echo "=> Waiting for local MongoDB to accept connections ..."
+wait_for_mongo_up
+set -x
+# Add the current container to the replSet
+mongo_add

--- a/3.0-upg/root/usr/share/container-scripts/mongodb/scl_enable
+++ b/3.0-upg/root/usr/share/container-scripts/mongodb/scl_enable
@@ -1,0 +1,3 @@
+# This will make scl collection binaries work out of box.
+unset BASH_ENV PROMPT_COMMAND ENV
+source scl_source enable ${ENABLED_COLLECTIONS}

--- a/3.0-upg/test/run
+++ b/3.0-upg/test/run
@@ -1,0 +1,288 @@
+#!/bin/bash
+#
+# Test the MongoDB image.
+#
+# IMAGE_NAME specifies a name of the candidate image used for testing.
+# The image has to be available before this script is executed.
+#
+
+set -exo nounset
+shopt -s nullglob
+
+IMAGE_NAME=${IMAGE_NAME-centos/mongodb-30-upg-centos7-candidate}
+
+CIDFILE_DIR=$(mktemp --suffix=mongodb_test_cidfiles -d)
+
+function cleanup() {
+    for cidfile in $CIDFILE_DIR/* ; do
+        CONTAINER=$(cat $cidfile)
+
+        echo "Stopping and removing container $CONTAINER..."
+        docker stop $CONTAINER
+        docker rm $CONTAINER
+        rm $cidfile
+        echo "Done."
+    done
+    rmdir $CIDFILE_DIR
+}
+trap cleanup EXIT SIGINT
+
+function get_cid() {
+    local id="$1" ; shift || return 1
+    echo -n $(cat "$CIDFILE_DIR/$id")
+}
+
+function get_container_ip() {
+    local id="$1" ; shift
+    docker inspect --format='{{.NetworkSettings.IPAddress}}' $(get_cid "$id")
+}
+
+function mongo_cmd() {
+    docker run --rm $IMAGE_NAME mongo "$DB" --host $CONTAINER_IP -u "$USER" -p "$PASS" --eval "${@}"
+}
+
+function mongo_admin_cmd() {
+    docker run --rm $IMAGE_NAME mongo admin --host $CONTAINER_IP -u admin -p "$ADMIN_PASS" --eval "${@}"
+}
+
+function mongo_cmd_local() {
+    local name="$1" ; shift
+    docker exec $(get_cid $name) bash -c "mongo $@"
+}
+
+function test_connection() {
+    local name=$1 ; shift
+    CONTAINER_IP=$(get_container_ip $name)
+    echo "  Testing MongoDB connection to $CONTAINER_IP..."
+    local max_attempts=20
+    local sleep_time=2
+    for i in $(seq $max_attempts); do
+        echo "    Trying to connect..."
+        set +e
+        mongo_cmd "db.getSiblingDB('test_database');"
+        status=$?
+        set -e
+        if [ $status -eq 0 ]; then
+            echo "  Success!"
+            return 0
+        fi
+        sleep $sleep_time
+    done
+    echo "  Giving up: Failed to connect. Logs:"
+    docker logs $(get_cid $name)
+    return 1
+}
+
+test_scl_usage() {
+    local name="$1"
+    local run_cmd="$2"
+    local expected="$3"
+
+    echo "  Testing the image SCL enable"
+    out=$(docker run --rm ${IMAGE_NAME} /bin/bash -c "${run_cmd}")
+    if ! echo "${out}" | grep -q "${expected}"; then
+        echo "ERROR[/bin/bash -c "${run_cmd}"] Expected '${expected}', got '${out}'"
+        return 1
+    fi
+    out=$(docker exec $(get_cid $name) /bin/bash -c "${run_cmd}" 2>&1)
+    if ! echo "${out}" | grep -q "${expected}"; then
+        echo "ERROR[exec /bin/bash -c "${run_cmd}"] Expected '${expected}', got '${out}'"
+        return 1
+    fi
+    out=$(docker exec $(get_cid $name) /bin/sh -ic "${run_cmd}" 2>&1)
+    if ! echo "${out}" | grep -q "${expected}"; then
+        echo "ERROR[exec /bin/sh -ic "${run_cmd}"] Expected '${expected}', got '${out}'"
+        return 1
+    fi
+}
+
+function test_mongo() {
+    echo "  Testing MongoDB"
+    if [ -v ADMIN_PASS ]; then
+        echo "  Testing Admin user privileges"
+        mongo_admin_cmd "db=db.getSiblingDB('${DB}');db.removeUser('${USER}');"
+        mongo_admin_cmd "db=db.getSiblingDB('${DB}');db.createUser({user:'${USER}',pwd:'${PASS}',roles:['readWrite','userAdmin','dbAdmin']});"
+        mongo_admin_cmd "db=db.getSiblingDB('${DB}');db.testData.insert({x:0});"
+        mongo_cmd "db.createUser({user:'test_user2',pwd:'test_password2',roles:['readWrite']});"
+    fi
+    echo "  Testing user privileges"
+    mongo_cmd "db.testData.insert({ y : 1 });"
+    mongo_cmd "db.testData.insert({ z : 2 });"
+    mongo_cmd "db.testData.find().forEach(printjson);"
+    mongo_cmd "db.testData.count();"
+    mongo_cmd "db.testData.drop();"
+    mongo_cmd "db.dropDatabase();"
+    echo "  Success!"
+}
+
+function test_config_option() {
+    local env_var=$1 ; shift
+    local setting=$1 ; shift
+    local value=$1 ; shift
+
+    local name="configuration_${setting}"
+
+    # If $value is a string, it needs to be in simple quotes ''.
+    DOCKER_ARGS="
+-e MONGODB_DATABASE=db
+-e MONGODB_USER=user
+-e MONGODB_PASSWORD=password
+-e MONGODB_ADMIN_PASSWORD=adminPassword
+-e $env_var=${value//\'/}
+"
+    create_container ${name} ${DOCKER_ARGS}
+
+    # need to set these because `mongo_cmd` relies on global variables
+    USER=user
+    PASS=password
+    DB=db
+
+    test_connection ${name}
+
+    # If nothing is found, grep returns 1 and test fails.
+    docker exec $(get_cid $name) bash -c "cat /etc/mongod.conf" | grep -q "$setting = $value"
+
+    docker stop $(get_cid ${name})
+}
+
+function run_configuration_tests() {
+    echo "  Testing image configuration settings"
+    test_config_option MONGODB_NOPREALLOC noprealloc true
+    test_config_option MONGODB_SMALLFILES smallfiles true
+    test_config_option MONGODB_QUIET quiet true
+    echo "  Success!"
+}
+
+wait_for_cid() {
+  local max_attempts=10
+  local sleep_time=1
+  local attempt=1
+  local result=1
+  while [ $attempt -le $max_attempts ]; do
+    [ -f $cid_file ] && [ -s $cid_file ] && break
+    echo "Waiting for container start..."
+    attempt=$(( $attempt + 1 ))
+    sleep $sleep_time
+  done
+}
+
+function create_container() {
+    local name=$1 ; shift
+    local cargs=${CONTAINER_ARGS:-}
+    cid_file="$CIDFILE_DIR/$name"
+    # create container with a cidfile in a directory for cleanup
+    docker run --cidfile $cid_file -d $cargs "$@" $IMAGE_NAME
+    echo "Created container $(cat $cid_file)"
+    wait_for_cid
+}
+
+function assert_login_access() {
+    local USER=$1 ; shift
+    local PASS=$1 ; shift
+    local success=$1 ; shift
+
+    if mongo_cmd 'db.version()' ; then
+        if $success ; then
+            echo "    $USER($PASS) access granted as expected"
+            return
+        fi
+    else
+        if ! $success ; then
+            echo "    $USER($PASS) access denied as expected"
+            return
+        fi
+    fi
+    echo "    $USER($PASS) login assertion failed"
+    exit 1
+}
+
+function run_tests() {
+    local name=$1 ; shift
+    envs="-e MONGODB_USER=$USER -e MONGODB_PASSWORD=$PASS -e MONGODB_DATABASE=$DB"
+    if [ -v ADMIN_PASS ]; then
+        envs="$envs -e MONGODB_ADMIN_PASSWORD=$ADMIN_PASS"
+    fi
+    create_container $name $envs
+    CONTAINER_IP=$(get_container_ip $name)
+    test_connection $name
+    echo "  Testing scl usage"
+    test_scl_usage $name 'mongo --version' '3.0'
+    test_mongo $name
+    mongo_cmd_local $name <<< ""
+}
+
+function run_change_password_test() {
+    local name="change_password"
+
+    local database='db'
+    local user='user'
+    local password='password'
+    local admin_password='adminPassword'
+
+    local volume_dir
+    volume_dir=`mktemp -d --tmpdir mongodb-testdata.XXXXX`
+    chmod a+rwx ${volume_dir}
+
+    DOCKER_ARGS="
+-e MONGODB_DATABASE=${database}
+-e MONGODB_USER=${user}
+-e MONGODB_PASSWORD=${password}
+-e MONGODB_ADMIN_PASSWORD=${admin_password}
+-v ${volume_dir}:/var/lib/mongodb/data:Z
+"
+    create_container ${name} ${DOCKER_ARGS}
+
+    # need to set these because `mongo_cmd` relies on global variables
+    USER=${user}
+    PASS=${password}
+    DB=${database}
+
+    # need this to wait for the container to start up
+    CONTAINER_IP=$(get_container_ip ${name})
+    test_connection ${name}
+
+    echo "  Testing login"
+
+    assert_login_access ${user} ${password} true
+    DB='admin' assert_login_access 'admin' ${admin_password} true
+
+    echo "  Changing passwords"
+
+    docker stop $(get_cid ${name})
+    DOCKER_ARGS="
+-e MONGODB_DATABASE=${database}
+-e MONGODB_USER=${user}
+-e MONGODB_PASSWORD=NEW_${password}
+-e MONGODB_ADMIN_PASSWORD=NEW_${admin_password}
+-v ${volume_dir}:/var/lib/mongodb/data:Z
+"
+    create_container "${name}_NEW" ${DOCKER_ARGS}
+
+    # need to set this because `mongo_cmd` relies on global variables
+    PASS="NEW_${password}"
+
+    # need this to wait for the container to start up
+    CONTAINER_IP=$(get_container_ip "${name}_NEW")
+    test_connection "${name}_NEW"
+
+    echo "  Testing login with new passwords"
+
+    assert_login_access ${user} "NEW_${password}" true
+    assert_login_access ${user} ${password} false
+
+    DB='admin' assert_login_access 'admin' "NEW_${admin_password}" true
+    DB='admin' assert_login_access 'admin' ${admin_password} false
+
+    # need to remove volume_dir with sudo because of permissions of files written
+    # by the Docker container
+    sudo rm -rf ${volume_dir}
+
+    echo "  Success!"
+}
+
+# Tests.
+run_configuration_tests
+USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin
+# Test with random uid in container
+CONTAINER_ARGS="-u 12345" USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin_altuid
+run_change_password_test

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Variables are documented in hack/build.sh.
 BASE_IMAGE_NAME = mongodb
-VERSIONS = 2.4 2.6 3.2
+VERSIONS = 2.4 2.6 3.0-upg 3.2
 OPENSHIFT_NAMESPACES = 2.4
 
 # Include common Makefile code.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Versions
 MongoDB versions currently provided are:
 * mongodb-2.4
 * mongodb-2.6
+* mongodb-3.0-upg
+* mongodb-3.2
 
 RHEL versions currently supported are:
 * RHEL7
@@ -64,6 +66,11 @@ see [usage documentation](2.4/README.md).
 For information about usage of Dockerfile for MongoDB 2.6,
 see [usage documentation](2.6/README.md).
 
+For information about usage of Dockerfile for MongoDB 3.0-upg,
+see [usage documentation](3.0-upg/README.md).
+
+For information about usage of Dockerfile for MongoDB 3.2,
+see [usage documentation](3.2/README.md).
 
 Test
 ---------------------------------


### PR DESCRIPTION
This PR adds a new versions of container: centos/mongodb-30-upg-centos7 (name came from https://github.com/sclorg/mongodb-container/pull/127#issuecomment-218879835)

Added notice about that this image is supported only for upgrade from centos/mongodb-26-centos7 to centos/mongodb-32-centos7 (added in README.md and printed after container start).

Only small changes from 2.6 version - [26-to-30-upg-diff.txt](https://github.com/sclorg/mongodb-container/files/434200/26-to-30-upg-diff.txt)

@hhorak @bparees Please take a look and merge.
