### PR TITLE
[WIP] Allow local replicaset without kubernetes.

### DIFF
--- a/2.4/root/usr/bin/run-mongod-replication
+++ b/2.4/root/usr/bin/run-mongod-replication
@@ -67,6 +67,7 @@ ${CONTAINER_SCRIPTS_PATH}/init-replset.sh "${1:-}" &
 
 # Run `mongod` in a subshell because MONGODB_ADMIN_PASSWORD should still be
 # defined when the trapped call to `cleanup` references it.
+set -m
 (
   # Make sure env variables don't propagate to mongod process.
   unset MONGODB_USER MONGODB_PASSWORD MONGODB_DATABASE MONGODB_ADMIN_PASSWORD

--- a/2.4/root/usr/bin/run-mongod-replication
+++ b/2.4/root/usr/bin/run-mongod-replication
@@ -36,6 +36,8 @@ function cleanup() {
   echo "=> Shutting down MongoDB server ..."
   pkill -INT mongod || :
   wait_for_mongo_down
+
+  ps -p ${supervisor_pid:-} && kill ${supervisor_pid}
   exit 0
 }
 
@@ -58,16 +60,19 @@ fi
 setup_keyfile
 
 # Initialize the replica set or add member in the background.
-${CONTAINER_SCRIPTS_PATH}/init-replset.sh "${1:-}" &
+${CONTAINER_SCRIPTS_PATH}/init-replset.sh "${1:-}" & supervisor_pid=$!
 
 # TODO: capture exit code of `init-replset.sh` and exit with an error if the
 # initialization failed, so that the container will be restarted and the user
 # can gain more visibility that there is a problem in a way other than just
 # inspecting log messages.
 
+# Don't pass signals to background processes - to succesfully remove local `mongod`
+# from replset in `cleanup()` mongod has to be running (to get addresses of other members).
+# Background processes are killed in `cleanup`.
+set -m
 # Run `mongod` in a subshell because MONGODB_ADMIN_PASSWORD should still be
 # defined when the trapped call to `cleanup` references it.
-set -m
 (
   # Make sure env variables don't propagate to mongod process.
   unset MONGODB_USER MONGODB_PASSWORD MONGODB_DATABASE MONGODB_ADMIN_PASSWORD

--- a/2.4/root/usr/share/container-scripts/mongodb/common.sh
+++ b/2.4/root/usr/share/container-scripts/mongodb/common.sh
@@ -86,8 +86,12 @@ function _wait_for_mongo() {
 # To get list of endpoints, you need to have headless Service named 'mongodb'.
 # NOTE: This won't work with standalone Docker container.
 function endpoints() {
-  service_name=${MONGODB_SERVICE_NAME:-mongodb}
-  dig ${service_name} A +search +short 2>/dev/null
+  if [ -n "${MONGODB_REPLICA_MEMBERS+x}" ]; then
+    echo "${MONGODB_REPLICA_MEMBERS} $(container_addr)"
+  else
+    service_name=${MONGODB_SERVICE_NAME:-mongodb}
+    dig ${service_name} A +search +short 2>/dev/null
+  fi
 }
 
 # build_mongo_config builds the MongoDB replicaSet config used for the cluster

--- a/2.4/test/run
+++ b/2.4/test/run
@@ -387,12 +387,13 @@ function wait_for_secondary() {
 }
 
 function wait_for_connection() {
-    local name
-    name=$1
     local host
-    host=$2
+    host=$1
 
-    while ! mongo_cmd_local ${name} "admin --host ${host} --eval 'quit()'"; do
+    DB=admin
+    CONTAINER_IP=${host}
+
+    while ! docker run --rm $IMAGE_NAME mongo "$DB" --host ${host} --eval 'quit()'; do
       sleep 5
     done
 }
@@ -410,6 +411,11 @@ function run_local_replication_test() {
 -e MONGODB_KEYFILE_VALUE=xxxxxxxxxxxx
 -e MONGODB_SMALLFILES=true"
 
+    # need to set these because `mongo_cmd` relies on global variables
+    USER=admin
+    PASS=adminPassword
+    DB=admin
+
     docker run -d --cidfile $CIDFILE_DIR/replset0 ${BASE_ARGS} -e MONGODB_REPLICA_MEMBERS="" $IMAGE_NAME run-mongod-replication
     docker run -d --cidfile $CIDFILE_DIR/replset1 ${BASE_ARGS} -e MONGODB_REPLICA_MEMBERS="$(get_container_ip replset0)" $IMAGE_NAME run-mongod-replication
     docker run -d --cidfile $CIDFILE_DIR/replset2 ${BASE_ARGS} -e MONGODB_REPLICA_MEMBERS="$(get_container_ip replset0) $(get_container_ip replset1)" $IMAGE_NAME run-mongod-replication
@@ -420,9 +426,9 @@ function run_local_replication_test() {
     insert_and_wait_for_replication "rs0/$(get_container_ip replset1),$(get_container_ip replset2)" "{a:5, b:10}"
 
     # Testing stored documents in each node
-    [ "$(mongo_cmd_local replset0 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "1" ]
-    [ "$(mongo_cmd_local replset1 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "1" ]
-    [ "$(mongo_cmd_local replset2 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "1" ]
+    [ "$(CONTAINER_IP=$(get_container_ip replset0) mongo_cmd 'rs.slaveOk(); printjson(db.getSiblingDB("test_db").data.count())' | tail -n 1)" == "1" ]
+    [ "$(CONTAINER_IP=$(get_container_ip replset1) mongo_cmd 'rs.slaveOk(); printjson(db.getSiblingDB("test_db").data.count())' | tail -n 1)" == "1" ]
+    [ "$(CONTAINER_IP=$(get_container_ip replset2) mongo_cmd 'rs.slaveOk(); printjson(db.getSiblingDB("test_db").data.count())' | tail -n 1)" == "1" ]
 
     # Stopping and removing second container
     docker stop $(get_cid replset1)
@@ -430,21 +436,21 @@ function run_local_replication_test() {
     # Adding new container
     docker run -d --cidfile $CIDFILE_DIR/replset3 ${BASE_ARGS} -e MONGODB_REPLICA_MEMBERS="$(get_container_ip replset0) $(get_container_ip replset2)" $IMAGE_NAME run-mongod-replication
     # Wait for new member and whole replset to accept connections
-    wait_for_connection "replset3" "localhost"
-    wait_for_connection "replset0" "rs0/$(get_container_ip replset0),$(get_container_ip replset2)"
+    wait_for_connection "$(get_container_ip replset3)"
+    wait_for_connection "rs0/$(get_container_ip replset0),$(get_container_ip replset2)"
 
     # Testing that replset still have 3 members
-    [ $(mongo_cmd_local replset0 "--host rs0/$(get_container_ip replset0),$(get_container_ip replset2) -u admin -p adminPassword admin --eval 'print(rs.status().members.length)'" | tail -n 1) == "3" ]
+    [ "$(CONTAINER_IP=rs0/$(get_container_ip replset0),$(get_container_ip replset2) mongo_cmd 'print(rs.status().members.length)' | tail -n 1)" == "3" ]
 
     # Storing document into replset and wait replication to finish ..."
     insert_and_wait_for_replication "rs0/$(get_container_ip replset0),$(get_container_ip replset2)" "{a:10, c:1}"
 
-    wait_for_connection "replset0" "rs0/$(get_container_ip replset0),$(get_container_ip replset2)"
+    wait_for_connection "rs0/$(get_container_ip replset0),$(get_container_ip replset2)"
 
     # Testing stored documents in each node
-    [ "$(mongo_cmd_local replset0 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "2" ]
-    [ "$(mongo_cmd_local replset2 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "2" ]
-    [ "$(mongo_cmd_local replset3 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "2" ]
+    [ "$(CONTAINER_IP=$(get_container_ip replset0) mongo_cmd 'rs.slaveOk(); printjson(db.getSiblingDB("test_db").data.count())' | tail -n 1)" == "2" ]
+    [ "$(CONTAINER_IP=$(get_container_ip replset2) mongo_cmd 'rs.slaveOk(); printjson(db.getSiblingDB("test_db").data.count())' | tail -n 1)" == "2" ]
+    [ "$(CONTAINER_IP=$(get_container_ip replset3) mongo_cmd 'rs.slaveOk(); printjson(db.getSiblingDB("test_db").data.count())' | tail -n 1)" == "2" ]
 
     echo "  Success!"
 }

--- a/2.4/test/run
+++ b/2.4/test/run
@@ -345,7 +345,8 @@ function insert_and_wait_for_replication() {
     # Storing document into replset and wait replication to finish
     CONTAINER_IP="${host}" ADMIN_PASS="adminPassword" \
     mongo_admin_cmd "db.getSiblingDB('test_db').data.insert(${data});
-        while(true) {
+        var i = 60;
+        while(i > 0) {
           var status=rs.status();
           var optime=status.members[0].optime;
           var ok=true;
@@ -358,6 +359,7 @@ function insert_and_wait_for_replication() {
             print('REPLICATED')
             break;
           }
+          i--;
         }"
 }
 
@@ -366,7 +368,8 @@ function wait_for_secondary() {
     host=$1
 
     CONTAINER_IP="${host}" ADMIN_PASS="adminPassword" \
-    mongo_admin_cmd "while(true) {
+    mongo_admin_cmd "var i = 60;
+        while(i > 0) {
           var status=rs.status();
           var ok=true;
           for(var i=1; i < status.members.length; i++) {
@@ -378,6 +381,7 @@ function wait_for_secondary() {
             print('ALL MEMBERS ARE PRIMARY OR SECONDARY')
             break;
           }
+          i--;
         }
         printjson(rs.status())"
 }

--- a/2.4/test/run
+++ b/2.4/test/run
@@ -336,6 +336,115 @@ noprealloc = true" > $config_file
     echo "  Success!"
 }
 
+function insert_and_wait_for_replication() {
+    local host
+    host=$1
+    local data
+    data=$2
+
+    # Storing document into replset and wait replication to finish
+    CONTAINER_IP="${host}" ADMIN_PASS="adminPassword" \
+    mongo_admin_cmd "db.getSiblingDB('test_db').data.insert(${data});
+        while(true) {
+          var status=rs.status();
+          var optime=status.members[0].optime;
+          var ok=true;
+          for(var i=1; i < status.members.length; i++) {
+            if(optime.tojson() != status.members[i].optime.tojson()) {
+              ok=false
+            }
+          };
+          if(ok == true) {
+            print('REPLICATED')
+            break;
+          }
+        }"
+}
+
+function wait_for_secondary() {
+    local host
+    host=$1
+
+    CONTAINER_IP="${host}" ADMIN_PASS="adminPassword" \
+    mongo_admin_cmd "while(true) {
+          var status=rs.status();
+          var ok=true;
+          for(var i=1; i < status.members.length; i++) {
+            if(status.state == 1 || status.state == 2) {
+              ok=false
+            }
+          };
+          if(ok == true) {
+            print('ALL MEMBERS ARE PRIMARY OR SECONDARY')
+            break;
+          }
+        }
+        printjson(rs.status())"
+}
+
+function wait_for_connection() {
+    local name
+    name=$1
+    local host
+    host=$2
+
+    while ! mongo_cmd_local ${name} "admin --host ${host} --eval 'quit()'"; do
+      sleep 5
+    done
+}
+
+
+function run_local_replication_test() {
+    echo "Testing replication on local docker"
+    #Initializing replicaset
+    BASE_ARGS="
+-e MONGODB_DATABASE=db
+-e MONGODB_USER=user
+-e MONGODB_PASSWORD=password
+-e MONGODB_ADMIN_PASSWORD=adminPassword
+-e MONGODB_REPLICA_NAME=rs0
+-e MONGODB_KEYFILE_VALUE=xxxxxxxxxxxx
+-e MONGODB_SMALLFILES=true"
+
+    docker run -d --cidfile $CIDFILE_DIR/replset0 ${BASE_ARGS} -e MONGODB_REPLICA_MEMBERS="" $IMAGE_NAME run-mongod-replication
+    docker run -d --cidfile $CIDFILE_DIR/replset1 ${BASE_ARGS} -e MONGODB_REPLICA_MEMBERS="$(get_container_ip replset0)" $IMAGE_NAME run-mongod-replication
+    docker run -d --cidfile $CIDFILE_DIR/replset2 ${BASE_ARGS} -e MONGODB_REPLICA_MEMBERS="$(get_container_ip replset0) $(get_container_ip replset1)" $IMAGE_NAME run-mongod-replication
+    sleep 15
+    docker run --cidfile $CIDFILE_DIR/initiate ${BASE_ARGS} -e MONGODB_REPLICA_MEMBERS="$(get_container_ip replset0) $(get_container_ip replset1) $(get_container_ip replset2)" $IMAGE_NAME run-mongod-replication initiate
+
+    # Storing document into replset and wait replication to finish ...
+    insert_and_wait_for_replication "rs0/$(get_container_ip replset1),$(get_container_ip replset2)" "{a:5, b:10}"
+
+    # Testing stored documents in each node
+    [ "$(mongo_cmd_local replset0 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "1" ]
+    [ "$(mongo_cmd_local replset1 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "1" ]
+    [ "$(mongo_cmd_local replset2 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "1" ]
+
+    # Stopping and removing second container
+    docker stop $(get_cid replset1)
+
+    # Adding new container
+    docker run -d --cidfile $CIDFILE_DIR/replset3 ${BASE_ARGS} -e MONGODB_REPLICA_MEMBERS="$(get_container_ip replset0) $(get_container_ip replset2)" $IMAGE_NAME run-mongod-replication
+    # Wait for new member and whole replset to accept connections
+    wait_for_connection "replset3" "localhost"
+    wait_for_connection "replset0" "rs0/$(get_container_ip replset0),$(get_container_ip replset2)"
+
+    # Testing that replset still have 3 members
+    [ $(mongo_cmd_local replset0 "--host rs0/$(get_container_ip replset0),$(get_container_ip replset2) -u admin -p adminPassword admin --eval 'print(rs.status().members.length)'" | tail -n 1) == "3" ]
+
+    # Storing document into replset and wait replication to finish ..."
+    insert_and_wait_for_replication "rs0/$(get_container_ip replset0),$(get_container_ip replset2)" "{a:10, c:1}"
+
+    wait_for_connection "replset0" "rs0/$(get_container_ip replset0),$(get_container_ip replset2)"
+
+    # Testing stored documents in each node
+    [ "$(mongo_cmd_local replset0 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "2" ]
+    [ "$(mongo_cmd_local replset2 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "2" ]
+    [ "$(mongo_cmd_local replset3 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "2" ]
+
+    echo "  Success!"
+}
+
 # Tests.
 run_configuration_tests
 USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin
@@ -343,3 +452,5 @@ USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin
 CONTAINER_ARGS="-u 12345" USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin_altuid
 run_change_password_test
 run_mount_config_test
+
+run_local_replication_test

--- a/2.6/root/usr/bin/run-mongod-replication
+++ b/2.6/root/usr/bin/run-mongod-replication
@@ -67,6 +67,7 @@ ${CONTAINER_SCRIPTS_PATH}/init-replset.sh "${1:-}" &
 
 # Run `mongod` in a subshell because MONGODB_ADMIN_PASSWORD should still be
 # defined when the trapped call to `cleanup` references it.
+set -m
 (
   # Make sure env variables don't propagate to mongod process.
   unset MONGODB_USER MONGODB_PASSWORD MONGODB_DATABASE MONGODB_ADMIN_PASSWORD

--- a/2.6/root/usr/bin/run-mongod-replication
+++ b/2.6/root/usr/bin/run-mongod-replication
@@ -36,6 +36,8 @@ function cleanup() {
   echo "=> Shutting down MongoDB server ..."
   pkill -INT mongod || :
   wait_for_mongo_down
+
+  ps -p ${supervisor_pid:-} && kill ${supervisor_pid}
   exit 0
 }
 
@@ -58,16 +60,19 @@ fi
 setup_keyfile
 
 # Initialize the replica set or add member in the background.
-${CONTAINER_SCRIPTS_PATH}/init-replset.sh "${1:-}" &
+${CONTAINER_SCRIPTS_PATH}/init-replset.sh "${1:-}" & supervisor_pid=$!
 
 # TODO: capture exit code of `init-replset.sh` and exit with an error if the
 # initialization failed, so that the container will be restarted and the user
 # can gain more visibility that there is a problem in a way other than just
 # inspecting log messages.
 
+# Don't pass signals to background processes - to succesfully remove local `mongod`
+# from replset in `cleanup()` mongod has to be running (to get addresses of other members).
+# Background processes are killed in `cleanup`.
+set -m
 # Run `mongod` in a subshell because MONGODB_ADMIN_PASSWORD should still be
 # defined when the trapped call to `cleanup` references it.
-set -m
 (
   # Make sure env variables don't propagate to mongod process.
   unset MONGODB_USER MONGODB_PASSWORD MONGODB_DATABASE MONGODB_ADMIN_PASSWORD

--- a/2.6/root/usr/share/container-scripts/mongodb/common.sh
+++ b/2.6/root/usr/share/container-scripts/mongodb/common.sh
@@ -85,8 +85,12 @@ function _wait_for_mongo() {
 # To get list of endpoints, you need to have headless Service named 'mongodb'.
 # NOTE: This won't work with standalone Docker container.
 function endpoints() {
-  service_name=${MONGODB_SERVICE_NAME:-mongodb}
-  dig ${service_name} A +search +short 2>/dev/null
+  if [ -n "${MONGODB_REPLICA_MEMBERS+x}" ]; then
+    echo "${MONGODB_REPLICA_MEMBERS} $(container_addr)"
+  else
+    service_name=${MONGODB_SERVICE_NAME:-mongodb}
+    dig ${service_name} A +search +short 2>/dev/null
+  fi
 }
 
 # build_mongo_config builds the MongoDB replicaSet config used for the cluster

--- a/2.6/test/run
+++ b/2.6/test/run
@@ -372,12 +372,13 @@ function wait_for_secondary() {
 }
 
 function wait_for_connection() {
-    local name
-    name=$1
     local host
-    host=$2
+    host=$1
 
-    while ! mongo_cmd_local ${name} "admin --host ${host} --eval 'quit()'"; do
+    DB=admin
+    CONTAINER_IP=${host}
+
+    while ! docker run --rm $IMAGE_NAME mongo "$DB" --host ${host} --eval 'quit()'; do
       sleep 5
     done
 }
@@ -395,6 +396,11 @@ function run_local_replication_test() {
 -e MONGODB_KEYFILE_VALUE=xxxxxxxxxxxx
 -e MONGODB_SMALLFILES=true"
 
+    # need to set these because `mongo_cmd` relies on global variables
+    USER=admin
+    PASS=adminPassword
+    DB=admin
+
     docker run -d --cidfile $CIDFILE_DIR/replset0 ${BASE_ARGS} -e MONGODB_REPLICA_MEMBERS="" $IMAGE_NAME run-mongod-replication
     docker run -d --cidfile $CIDFILE_DIR/replset1 ${BASE_ARGS} -e MONGODB_REPLICA_MEMBERS="$(get_container_ip replset0)" $IMAGE_NAME run-mongod-replication
     docker run -d --cidfile $CIDFILE_DIR/replset2 ${BASE_ARGS} -e MONGODB_REPLICA_MEMBERS="$(get_container_ip replset0) $(get_container_ip replset1)" $IMAGE_NAME run-mongod-replication
@@ -405,9 +411,9 @@ function run_local_replication_test() {
     insert_and_wait_for_replication "rs0/$(get_container_ip replset1),$(get_container_ip replset2)" "{a:5, b:10}"
 
     # Testing stored documents in each node
-    [ "$(mongo_cmd_local replset0 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "1" ]
-    [ "$(mongo_cmd_local replset1 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "1" ]
-    [ "$(mongo_cmd_local replset2 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "1" ]
+    [ "$(CONTAINER_IP=$(get_container_ip replset0) mongo_cmd 'rs.slaveOk(); printjson(db.getSiblingDB("test_db").data.count())' | tail -n 1)" == "1" ]
+    [ "$(CONTAINER_IP=$(get_container_ip replset1) mongo_cmd 'rs.slaveOk(); printjson(db.getSiblingDB("test_db").data.count())' | tail -n 1)" == "1" ]
+    [ "$(CONTAINER_IP=$(get_container_ip replset2) mongo_cmd 'rs.slaveOk(); printjson(db.getSiblingDB("test_db").data.count())' | tail -n 1)" == "1" ]
 
     # Stopping and removing second container
     docker stop $(get_cid replset1)
@@ -415,21 +421,21 @@ function run_local_replication_test() {
     # Adding new container
     docker run -d --cidfile $CIDFILE_DIR/replset3 ${BASE_ARGS} -e MONGODB_REPLICA_MEMBERS="$(get_container_ip replset0) $(get_container_ip replset2)" $IMAGE_NAME run-mongod-replication
     # Wait for new member and whole replset to accept connections
-    wait_for_connection "replset3" "localhost"
-    wait_for_connection "replset0" "rs0/$(get_container_ip replset0),$(get_container_ip replset2)"
+    wait_for_connection "$(get_container_ip replset3)"
+    wait_for_connection "rs0/$(get_container_ip replset0),$(get_container_ip replset2)"
 
     # Testing that replset still have 3 members
-    [ $(mongo_cmd_local replset0 "--host rs0/$(get_container_ip replset0),$(get_container_ip replset2) -u admin -p adminPassword admin --eval 'print(rs.status().members.length)'" | tail -n 1) == "3" ]
+    [ "$(CONTAINER_IP=rs0/$(get_container_ip replset0),$(get_container_ip replset2) mongo_cmd 'print(rs.status().members.length)' | tail -n 1)" == "3" ]
 
     # Storing document into replset and wait replication to finish ..."
     insert_and_wait_for_replication "rs0/$(get_container_ip replset0),$(get_container_ip replset2)" "{a:10, c:1}"
 
-    wait_for_connection "replset0" "rs0/$(get_container_ip replset0),$(get_container_ip replset2)"
+    wait_for_connection "rs0/$(get_container_ip replset0),$(get_container_ip replset2)"
 
     # Testing stored documents in each node
-    [ "$(mongo_cmd_local replset0 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "2" ]
-    [ "$(mongo_cmd_local replset2 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "2" ]
-    [ "$(mongo_cmd_local replset3 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "2" ]
+    [ "$(CONTAINER_IP=$(get_container_ip replset0) mongo_cmd 'rs.slaveOk(); printjson(db.getSiblingDB("test_db").data.count())' | tail -n 1)" == "2" ]
+    [ "$(CONTAINER_IP=$(get_container_ip replset2) mongo_cmd 'rs.slaveOk(); printjson(db.getSiblingDB("test_db").data.count())' | tail -n 1)" == "2" ]
+    [ "$(CONTAINER_IP=$(get_container_ip replset3) mongo_cmd 'rs.slaveOk(); printjson(db.getSiblingDB("test_db").data.count())' | tail -n 1)" == "2" ]
 
     echo "  Success!"
 }

--- a/2.6/test/run
+++ b/2.6/test/run
@@ -321,6 +321,115 @@ noprealloc = true" > $config_file
     echo "  Success!"
 }
 
+function insert_and_wait_for_replication() {
+    local host
+    host=$1
+    local data
+    data=$2
+
+    # Storing document into replset and wait replication to finish
+    CONTAINER_IP="${host}" ADMIN_PASS="adminPassword" \
+    mongo_admin_cmd "db.getSiblingDB('test_db').data.insert(${data});
+        while(true) {
+          var status=rs.status();
+          var optime=status.members[0].optime;
+          var ok=true;
+          for(var i=1; i < status.members.length; i++) {
+            if(optime.tojson() != status.members[i].optime.tojson()) {
+              ok=false
+            }
+          };
+          if(ok == true) {
+            print('REPLICATED')
+            break;
+          }
+        }"
+}
+
+function wait_for_secondary() {
+    local host
+    host=$1
+
+    CONTAINER_IP="${host}" ADMIN_PASS="adminPassword" \
+    mongo_admin_cmd "while(true) {
+          var status=rs.status();
+          var ok=true;
+          for(var i=1; i < status.members.length; i++) {
+            if(status.state == 1 || status.state == 2) {
+              ok=false
+            }
+          };
+          if(ok == true) {
+            print('ALL MEMBERS ARE PRIMARY OR SECONDARY')
+            break;
+          }
+        }
+        printjson(rs.status())"
+}
+
+function wait_for_connection() {
+    local name
+    name=$1
+    local host
+    host=$2
+
+    while ! mongo_cmd_local ${name} "admin --host ${host} --eval 'quit()'"; do
+      sleep 5
+    done
+}
+
+
+function run_local_replication_test() {
+    echo "Testing replication on local docker"
+    #Initializing replicaset
+    BASE_ARGS="
+-e MONGODB_DATABASE=db
+-e MONGODB_USER=user
+-e MONGODB_PASSWORD=password
+-e MONGODB_ADMIN_PASSWORD=adminPassword
+-e MONGODB_REPLICA_NAME=rs0
+-e MONGODB_KEYFILE_VALUE=xxxxxxxxxxxx
+-e MONGODB_SMALLFILES=true"
+
+    docker run -d --cidfile $CIDFILE_DIR/replset0 ${BASE_ARGS} -e MONGODB_REPLICA_MEMBERS="" $IMAGE_NAME run-mongod-replication
+    docker run -d --cidfile $CIDFILE_DIR/replset1 ${BASE_ARGS} -e MONGODB_REPLICA_MEMBERS="$(get_container_ip replset0)" $IMAGE_NAME run-mongod-replication
+    docker run -d --cidfile $CIDFILE_DIR/replset2 ${BASE_ARGS} -e MONGODB_REPLICA_MEMBERS="$(get_container_ip replset0) $(get_container_ip replset1)" $IMAGE_NAME run-mongod-replication
+    sleep 15
+    docker run --cidfile $CIDFILE_DIR/initiate ${BASE_ARGS} -e MONGODB_REPLICA_MEMBERS="$(get_container_ip replset0) $(get_container_ip replset1) $(get_container_ip replset2)" $IMAGE_NAME run-mongod-replication initiate
+
+    # Storing document into replset and wait replication to finish ...
+    insert_and_wait_for_replication "rs0/$(get_container_ip replset1),$(get_container_ip replset2)" "{a:5, b:10}"
+
+    # Testing stored documents in each node
+    [ "$(mongo_cmd_local replset0 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "1" ]
+    [ "$(mongo_cmd_local replset1 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "1" ]
+    [ "$(mongo_cmd_local replset2 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "1" ]
+
+    # Stopping and removing second container
+    docker stop $(get_cid replset1)
+
+    # Adding new container
+    docker run -d --cidfile $CIDFILE_DIR/replset3 ${BASE_ARGS} -e MONGODB_REPLICA_MEMBERS="$(get_container_ip replset0) $(get_container_ip replset2)" $IMAGE_NAME run-mongod-replication
+    # Wait for new member and whole replset to accept connections
+    wait_for_connection "replset3" "localhost"
+    wait_for_connection "replset0" "rs0/$(get_container_ip replset0),$(get_container_ip replset2)"
+
+    # Testing that replset still have 3 members
+    [ $(mongo_cmd_local replset0 "--host rs0/$(get_container_ip replset0),$(get_container_ip replset2) -u admin -p adminPassword admin --eval 'print(rs.status().members.length)'" | tail -n 1) == "3" ]
+
+    # Storing document into replset and wait replication to finish ..."
+    insert_and_wait_for_replication "rs0/$(get_container_ip replset0),$(get_container_ip replset2)" "{a:10, c:1}"
+
+    wait_for_connection "replset0" "rs0/$(get_container_ip replset0),$(get_container_ip replset2)"
+
+    # Testing stored documents in each node
+    [ "$(mongo_cmd_local replset0 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "2" ]
+    [ "$(mongo_cmd_local replset2 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "2" ]
+    [ "$(mongo_cmd_local replset3 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "2" ]
+
+    echo "  Success!"
+}
+
 # Tests.
 run_configuration_tests
 USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin
@@ -328,3 +437,5 @@ USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin
 CONTAINER_ARGS="-u 12345" USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin_altuid
 run_change_password_test
 run_mount_config_test
+
+run_local_replication_test

--- a/2.6/test/run
+++ b/2.6/test/run
@@ -330,7 +330,8 @@ function insert_and_wait_for_replication() {
     # Storing document into replset and wait replication to finish
     CONTAINER_IP="${host}" ADMIN_PASS="adminPassword" \
     mongo_admin_cmd "db.getSiblingDB('test_db').data.insert(${data});
-        while(true) {
+        var i = 60;
+        while(i > 0) {
           var status=rs.status();
           var optime=status.members[0].optime;
           var ok=true;
@@ -343,6 +344,7 @@ function insert_and_wait_for_replication() {
             print('REPLICATED')
             break;
           }
+          i--;
         }"
 }
 
@@ -351,7 +353,8 @@ function wait_for_secondary() {
     host=$1
 
     CONTAINER_IP="${host}" ADMIN_PASS="adminPassword" \
-    mongo_admin_cmd "while(true) {
+    mongo_admin_cmd "var i = 60;
+        while(i > 0) {
           var status=rs.status();
           var ok=true;
           for(var i=1; i < status.members.length; i++) {
@@ -363,6 +366,7 @@ function wait_for_secondary() {
             print('ALL MEMBERS ARE PRIMARY OR SECONDARY')
             break;
           }
+          i--;
         }
         printjson(rs.status())"
 }

--- a/3.0-upg/root/usr/bin/run-mongod-replication
+++ b/3.0-upg/root/usr/bin/run-mongod-replication
@@ -67,6 +67,7 @@ ${CONTAINER_SCRIPTS_PATH}/init-replset.sh "${1:-}" &
 
 # Run `mongod` in a subshell because MONGODB_ADMIN_PASSWORD should still be
 # defined when the trapped call to `cleanup` references it.
+set -m
 (
   # Make sure env variables don't propagate to mongod process.
   unset MONGODB_USER MONGODB_PASSWORD MONGODB_DATABASE MONGODB_ADMIN_PASSWORD

--- a/3.0-upg/root/usr/bin/run-mongod-replication
+++ b/3.0-upg/root/usr/bin/run-mongod-replication
@@ -36,6 +36,8 @@ function cleanup() {
   echo "=> Shutting down MongoDB server ..."
   pkill -INT mongod || :
   wait_for_mongo_down
+
+  ps -p ${supervisor_pid:-} && kill ${supervisor_pid}
   exit 0
 }
 
@@ -58,16 +60,19 @@ fi
 setup_keyfile
 
 # Initialize the replica set or add member in the background.
-${CONTAINER_SCRIPTS_PATH}/init-replset.sh "${1:-}" &
+${CONTAINER_SCRIPTS_PATH}/init-replset.sh "${1:-}" & supervisor_pid=$!
 
 # TODO: capture exit code of `init-replset.sh` and exit with an error if the
 # initialization failed, so that the container will be restarted and the user
 # can gain more visibility that there is a problem in a way other than just
 # inspecting log messages.
 
+# Don't pass signals to background processes - to succesfully remove local `mongod`
+# from replset in `cleanup()` mongod has to be running (to get addresses of other members).
+# Background processes are killed in `cleanup`.
+set -m
 # Run `mongod` in a subshell because MONGODB_ADMIN_PASSWORD should still be
 # defined when the trapped call to `cleanup` references it.
-set -m
 (
   # Make sure env variables don't propagate to mongod process.
   unset MONGODB_USER MONGODB_PASSWORD MONGODB_DATABASE MONGODB_ADMIN_PASSWORD

--- a/3.0-upg/root/usr/share/container-scripts/mongodb/common.sh
+++ b/3.0-upg/root/usr/share/container-scripts/mongodb/common.sh
@@ -85,8 +85,12 @@ function _wait_for_mongo() {
 # To get list of endpoints, you need to have headless Service named 'mongodb'.
 # NOTE: This won't work with standalone Docker container.
 function endpoints() {
-  service_name=${MONGODB_SERVICE_NAME:-mongodb}
-  dig ${service_name} A +search +short 2>/dev/null
+  if [ -n "${MONGODB_REPLICA_MEMBERS+x}" ]; then
+    echo "${MONGODB_REPLICA_MEMBERS} $(container_addr)"
+  else
+    service_name=${MONGODB_SERVICE_NAME:-mongodb}
+    dig ${service_name} A +search +short 2>/dev/null
+  fi
 }
 
 # build_mongo_config builds the MongoDB replicaSet config used for the cluster

--- a/3.0-upg/test/run
+++ b/3.0-upg/test/run
@@ -372,12 +372,13 @@ function wait_for_secondary() {
 }
 
 function wait_for_connection() {
-    local name
-    name=$1
     local host
-    host=$2
+    host=$1
 
-    while ! mongo_cmd_local ${name} "admin --host ${host} --eval 'quit()'"; do
+    DB=admin
+    CONTAINER_IP=${host}
+
+    while ! docker run --rm $IMAGE_NAME mongo "$DB" --host ${host} --eval 'quit()'; do
       sleep 5
     done
 }
@@ -395,6 +396,11 @@ function run_local_replication_test() {
 -e MONGODB_KEYFILE_VALUE=xxxxxxxxxxxx
 -e MONGODB_SMALLFILES=true"
 
+    # need to set these because `mongo_cmd` relies on global variables
+    USER=admin
+    PASS=adminPassword
+    DB=admin
+
     docker run -d --cidfile $CIDFILE_DIR/replset0 ${BASE_ARGS} -e MONGODB_REPLICA_MEMBERS="" $IMAGE_NAME run-mongod-replication
     docker run -d --cidfile $CIDFILE_DIR/replset1 ${BASE_ARGS} -e MONGODB_REPLICA_MEMBERS="$(get_container_ip replset0)" $IMAGE_NAME run-mongod-replication
     docker run -d --cidfile $CIDFILE_DIR/replset2 ${BASE_ARGS} -e MONGODB_REPLICA_MEMBERS="$(get_container_ip replset0) $(get_container_ip replset1)" $IMAGE_NAME run-mongod-replication
@@ -405,9 +411,9 @@ function run_local_replication_test() {
     insert_and_wait_for_replication "rs0/$(get_container_ip replset1),$(get_container_ip replset2)" "{a:5, b:10}"
 
     # Testing stored documents in each node
-    [ "$(mongo_cmd_local replset0 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "1" ]
-    [ "$(mongo_cmd_local replset1 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "1" ]
-    [ "$(mongo_cmd_local replset2 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "1" ]
+    [ "$(CONTAINER_IP=$(get_container_ip replset0) mongo_cmd 'rs.slaveOk(); printjson(db.getSiblingDB("test_db").data.count())' | tail -n 1)" == "1" ]
+    [ "$(CONTAINER_IP=$(get_container_ip replset1) mongo_cmd 'rs.slaveOk(); printjson(db.getSiblingDB("test_db").data.count())' | tail -n 1)" == "1" ]
+    [ "$(CONTAINER_IP=$(get_container_ip replset2) mongo_cmd 'rs.slaveOk(); printjson(db.getSiblingDB("test_db").data.count())' | tail -n 1)" == "1" ]
 
     # Stopping and removing second container
     docker stop $(get_cid replset1)
@@ -415,21 +421,21 @@ function run_local_replication_test() {
     # Adding new container
     docker run -d --cidfile $CIDFILE_DIR/replset3 ${BASE_ARGS} -e MONGODB_REPLICA_MEMBERS="$(get_container_ip replset0) $(get_container_ip replset2)" $IMAGE_NAME run-mongod-replication
     # Wait for new member and whole replset to accept connections
-    wait_for_connection "replset3" "localhost"
-    wait_for_connection "replset0" "rs0/$(get_container_ip replset0),$(get_container_ip replset2)"
+    wait_for_connection "$(get_container_ip replset3)"
+    wait_for_connection "rs0/$(get_container_ip replset0),$(get_container_ip replset2)"
 
     # Testing that replset still have 3 members
-    [ $(mongo_cmd_local replset0 "--host rs0/$(get_container_ip replset0),$(get_container_ip replset2) -u admin -p adminPassword admin --eval 'print(rs.status().members.length)'" | tail -n 1) == "3" ]
+    [ "$(CONTAINER_IP=rs0/$(get_container_ip replset0),$(get_container_ip replset2) mongo_cmd 'print(rs.status().members.length)' | tail -n 1)" == "3" ]
 
     # Storing document into replset and wait replication to finish ..."
     insert_and_wait_for_replication "rs0/$(get_container_ip replset0),$(get_container_ip replset2)" "{a:10, c:1}"
 
-    wait_for_connection "replset0" "rs0/$(get_container_ip replset0),$(get_container_ip replset2)"
+    wait_for_connection "rs0/$(get_container_ip replset0),$(get_container_ip replset2)"
 
     # Testing stored documents in each node
-    [ "$(mongo_cmd_local replset0 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "2" ]
-    [ "$(mongo_cmd_local replset2 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "2" ]
-    [ "$(mongo_cmd_local replset3 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "2" ]
+    [ "$(CONTAINER_IP=$(get_container_ip replset0) mongo_cmd 'rs.slaveOk(); printjson(db.getSiblingDB("test_db").data.count())' | tail -n 1)" == "2" ]
+    [ "$(CONTAINER_IP=$(get_container_ip replset2) mongo_cmd 'rs.slaveOk(); printjson(db.getSiblingDB("test_db").data.count())' | tail -n 1)" == "2" ]
+    [ "$(CONTAINER_IP=$(get_container_ip replset3) mongo_cmd 'rs.slaveOk(); printjson(db.getSiblingDB("test_db").data.count())' | tail -n 1)" == "2" ]
 
     echo "  Success!"
 }

--- a/3.0-upg/test/run
+++ b/3.0-upg/test/run
@@ -321,6 +321,115 @@ noprealloc = true" > $config_file
     echo "  Success!"
 }
 
+function insert_and_wait_for_replication() {
+    local host
+    host=$1
+    local data
+    data=$2
+
+    # Storing document into replset and wait replication to finish
+    CONTAINER_IP="${host}" ADMIN_PASS="adminPassword" \
+    mongo_admin_cmd "db.getSiblingDB('test_db').data.insert(${data});
+        while(true) {
+          var status=rs.status();
+          var optime=status.members[0].optime;
+          var ok=true;
+          for(var i=1; i < status.members.length; i++) {
+            if(optime.tojson() != status.members[i].optime.tojson()) {
+              ok=false
+            }
+          };
+          if(ok == true) {
+            print('REPLICATED')
+            break;
+          }
+        }"
+}
+
+function wait_for_secondary() {
+    local host
+    host=$1
+
+    CONTAINER_IP="${host}" ADMIN_PASS="adminPassword" \
+    mongo_admin_cmd "while(true) {
+          var status=rs.status();
+          var ok=true;
+          for(var i=1; i < status.members.length; i++) {
+            if(status.state == 1 || status.state == 2) {
+              ok=false
+            }
+          };
+          if(ok == true) {
+            print('ALL MEMBERS ARE PRIMARY OR SECONDARY')
+            break;
+          }
+        }
+        printjson(rs.status())"
+}
+
+function wait_for_connection() {
+    local name
+    name=$1
+    local host
+    host=$2
+
+    while ! mongo_cmd_local ${name} "admin --host ${host} --eval 'quit()'"; do
+      sleep 5
+    done
+}
+
+
+function run_local_replication_test() {
+    echo "Testing replication on local docker"
+    #Initializing replicaset
+    BASE_ARGS="
+-e MONGODB_DATABASE=db
+-e MONGODB_USER=user
+-e MONGODB_PASSWORD=password
+-e MONGODB_ADMIN_PASSWORD=adminPassword
+-e MONGODB_REPLICA_NAME=rs0
+-e MONGODB_KEYFILE_VALUE=xxxxxxxxxxxx
+-e MONGODB_SMALLFILES=true"
+
+    docker run -d --cidfile $CIDFILE_DIR/replset0 ${BASE_ARGS} -e MONGODB_REPLICA_MEMBERS="" $IMAGE_NAME run-mongod-replication
+    docker run -d --cidfile $CIDFILE_DIR/replset1 ${BASE_ARGS} -e MONGODB_REPLICA_MEMBERS="$(get_container_ip replset0)" $IMAGE_NAME run-mongod-replication
+    docker run -d --cidfile $CIDFILE_DIR/replset2 ${BASE_ARGS} -e MONGODB_REPLICA_MEMBERS="$(get_container_ip replset0) $(get_container_ip replset1)" $IMAGE_NAME run-mongod-replication
+    sleep 15
+    docker run --cidfile $CIDFILE_DIR/initiate ${BASE_ARGS} -e MONGODB_REPLICA_MEMBERS="$(get_container_ip replset0) $(get_container_ip replset1) $(get_container_ip replset2)" $IMAGE_NAME run-mongod-replication initiate
+
+    # Storing document into replset and wait replication to finish ...
+    insert_and_wait_for_replication "rs0/$(get_container_ip replset1),$(get_container_ip replset2)" "{a:5, b:10}"
+
+    # Testing stored documents in each node
+    [ "$(mongo_cmd_local replset0 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "1" ]
+    [ "$(mongo_cmd_local replset1 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "1" ]
+    [ "$(mongo_cmd_local replset2 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "1" ]
+
+    # Stopping and removing second container
+    docker stop $(get_cid replset1)
+
+    # Adding new container
+    docker run -d --cidfile $CIDFILE_DIR/replset3 ${BASE_ARGS} -e MONGODB_REPLICA_MEMBERS="$(get_container_ip replset0) $(get_container_ip replset2)" $IMAGE_NAME run-mongod-replication
+    # Wait for new member and whole replset to accept connections
+    wait_for_connection "replset3" "localhost"
+    wait_for_connection "replset0" "rs0/$(get_container_ip replset0),$(get_container_ip replset2)"
+
+    # Testing that replset still have 3 members
+    [ $(mongo_cmd_local replset0 "--host rs0/$(get_container_ip replset0),$(get_container_ip replset2) -u admin -p adminPassword admin --eval 'print(rs.status().members.length)'" | tail -n 1) == "3" ]
+
+    # Storing document into replset and wait replication to finish ..."
+    insert_and_wait_for_replication "rs0/$(get_container_ip replset0),$(get_container_ip replset2)" "{a:10, c:1}"
+
+    wait_for_connection "replset0" "rs0/$(get_container_ip replset0),$(get_container_ip replset2)"
+
+    # Testing stored documents in each node
+    [ "$(mongo_cmd_local replset0 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "2" ]
+    [ "$(mongo_cmd_local replset2 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "2" ]
+    [ "$(mongo_cmd_local replset3 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "2" ]
+
+    echo "  Success!"
+}
+
 # Tests.
 run_configuration_tests
 USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin
@@ -328,3 +437,5 @@ USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin
 CONTAINER_ARGS="-u 12345" USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin_altuid
 run_change_password_test
 run_mount_config_test
+
+run_local_replication_test

--- a/3.0-upg/test/run
+++ b/3.0-upg/test/run
@@ -330,7 +330,8 @@ function insert_and_wait_for_replication() {
     # Storing document into replset and wait replication to finish
     CONTAINER_IP="${host}" ADMIN_PASS="adminPassword" \
     mongo_admin_cmd "db.getSiblingDB('test_db').data.insert(${data});
-        while(true) {
+        var i = 60;
+        while(i > 0) {
           var status=rs.status();
           var optime=status.members[0].optime;
           var ok=true;
@@ -343,6 +344,7 @@ function insert_and_wait_for_replication() {
             print('REPLICATED')
             break;
           }
+          i--;
         }"
 }
 
@@ -351,7 +353,8 @@ function wait_for_secondary() {
     host=$1
 
     CONTAINER_IP="${host}" ADMIN_PASS="adminPassword" \
-    mongo_admin_cmd "while(true) {
+    mongo_admin_cmd "var i = 60;
+        while(i > 0) {
           var status=rs.status();
           var ok=true;
           for(var i=1; i < status.members.length; i++) {
@@ -363,6 +366,7 @@ function wait_for_secondary() {
             print('ALL MEMBERS ARE PRIMARY OR SECONDARY')
             break;
           }
+          i--;
         }
         printjson(rs.status())"
 }

--- a/3.2/root/usr/bin/run-mongod-replication
+++ b/3.2/root/usr/bin/run-mongod-replication
@@ -65,6 +65,7 @@ ${CONTAINER_SCRIPTS_PATH}/init-replset.sh "${1:-}" &
 
 # Run `mongod` in a subshell because MONGODB_ADMIN_PASSWORD should still be
 # defined when the trapped call to `cleanup` references it.
+set -m
 (
   # Make sure env variables don't propagate to mongod process.
   unset MONGODB_USER MONGODB_PASSWORD MONGODB_DATABASE MONGODB_ADMIN_PASSWORD

--- a/3.2/root/usr/bin/run-mongod-replication
+++ b/3.2/root/usr/bin/run-mongod-replication
@@ -34,6 +34,8 @@ function cleanup() {
   echo "=> Shutting down MongoDB server ..."
   pkill -INT mongod || :
   wait_for_mongo_down
+
+  ps -p ${supervisor_pid:-} && kill ${supervisor_pid}
   exit 0
 }
 
@@ -56,16 +58,19 @@ fi
 setup_keyfile
 
 # Initialize the replica set or add member in the background.
-${CONTAINER_SCRIPTS_PATH}/init-replset.sh "${1:-}" &
+${CONTAINER_SCRIPTS_PATH}/init-replset.sh "${1:-}" & supervisor_pid=$!
 
 # TODO: capture exit code of `init-replset.sh` and exit with an error if the
 # initialization failed, so that the container will be restarted and the user
 # can gain more visibility that there is a problem in a way other than just
 # inspecting log messages.
 
+# Don't pass signals to background processes - to succesfully remove local `mongod`
+# from replset in `cleanup()` mongod has to be running (to get addresses of other members).
+# Background processes are killed in `cleanup`.
+set -m
 # Run `mongod` in a subshell because MONGODB_ADMIN_PASSWORD should still be
 # defined when the trapped call to `cleanup` references it.
-set -m
 (
   # Make sure env variables don't propagate to mongod process.
   unset MONGODB_USER MONGODB_PASSWORD MONGODB_DATABASE MONGODB_ADMIN_PASSWORD

--- a/3.2/root/usr/share/container-scripts/mongodb/common.sh
+++ b/3.2/root/usr/share/container-scripts/mongodb/common.sh
@@ -83,8 +83,12 @@ function _wait_for_mongo() {
 # To get list of endpoints, you need to have headless Service named 'mongodb'.
 # NOTE: This won't work with standalone Docker container.
 function endpoints() {
-  service_name=${MONGODB_SERVICE_NAME:-mongodb}
-  dig ${service_name} A +search +short 2>/dev/null
+  if [ -n "${MONGODB_REPLICA_MEMBERS+x}" ]; then
+    echo "${MONGODB_REPLICA_MEMBERS} $(container_addr)"
+  else
+    service_name=${MONGODB_SERVICE_NAME:-mongodb}
+    dig ${service_name} A +search +short 2>/dev/null
+  fi
 }
 
 # build_mongo_config builds the MongoDB replicaSet config used for the cluster

--- a/3.2/test/run
+++ b/3.2/test/run
@@ -317,6 +317,115 @@ unixSocketPrefix = /var/lib/mongodb" > $config_file
     echo "  Success!"
 }
 
+function insert_and_wait_for_replication() {
+    local host
+    host=$1
+    local data
+    data=$2
+
+    # Storing document into replset and wait replication to finish
+    CONTAINER_IP="${host}" ADMIN_PASS="adminPassword" \
+    mongo_admin_cmd "db.getSiblingDB('test_db').data.insert(${data});
+        while(true) {
+          var status=rs.status();
+          var optime=status.members[0].optime;
+          var ok=true;
+          for(var i=1; i < status.members.length; i++) {
+            if(optime.tojson() != status.members[i].optime.tojson()) {
+              ok=false
+            }
+          };
+          if(ok == true) {
+            print('REPLICATED')
+            break;
+          }
+        }"
+}
+
+function wait_for_secondary() {
+    local host
+    host=$1
+
+    CONTAINER_IP="${host}" ADMIN_PASS="adminPassword" \
+    mongo_admin_cmd "while(true) {
+          var status=rs.status();
+          var ok=true;
+          for(var i=1; i < status.members.length; i++) {
+            if(status.state == 1 || status.state == 2) {
+              ok=false
+            }
+          };
+          if(ok == true) {
+            print('ALL MEMBERS ARE PRIMARY OR SECONDARY')
+            break;
+          }
+        }
+        printjson(rs.status())"
+}
+
+function wait_for_connection() {
+    local name
+    name=$1
+    local host
+    host=$2
+
+    while ! mongo_cmd_local ${name} "admin --host ${host} --eval 'quit()'"; do
+      sleep 5
+    done
+}
+
+
+function run_local_replication_test() {
+    echo "Testing replication on local docker"
+    #Initializing replicaset
+    BASE_ARGS="
+-e MONGODB_DATABASE=db
+-e MONGODB_USER=user
+-e MONGODB_PASSWORD=password
+-e MONGODB_ADMIN_PASSWORD=adminPassword
+-e MONGODB_REPLICA_NAME=rs0
+-e MONGODB_KEYFILE_VALUE=xxxxxxxxxxxx
+-e MONGODB_SMALLFILES=true"
+
+    docker run -d --cidfile $CIDFILE_DIR/replset0 ${BASE_ARGS} -e MONGODB_REPLICA_MEMBERS="" $IMAGE_NAME run-mongod-replication
+    docker run -d --cidfile $CIDFILE_DIR/replset1 ${BASE_ARGS} -e MONGODB_REPLICA_MEMBERS="$(get_container_ip replset0)" $IMAGE_NAME run-mongod-replication
+    docker run -d --cidfile $CIDFILE_DIR/replset2 ${BASE_ARGS} -e MONGODB_REPLICA_MEMBERS="$(get_container_ip replset0) $(get_container_ip replset1)" $IMAGE_NAME run-mongod-replication
+    sleep 15
+    docker run --cidfile $CIDFILE_DIR/initiate ${BASE_ARGS} -e MONGODB_REPLICA_MEMBERS="$(get_container_ip replset0) $(get_container_ip replset1) $(get_container_ip replset2)" $IMAGE_NAME run-mongod-replication initiate
+
+    # Storing document into replset and wait replication to finish ...
+    insert_and_wait_for_replication "rs0/$(get_container_ip replset1),$(get_container_ip replset2)" "{a:5, b:10}"
+
+    # Testing stored documents in each node
+    [ "$(mongo_cmd_local replset0 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "1" ]
+    [ "$(mongo_cmd_local replset1 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "1" ]
+    [ "$(mongo_cmd_local replset2 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "1" ]
+
+    # Stopping and removing second container
+    docker stop $(get_cid replset1)
+
+    # Adding new container
+    docker run -d --cidfile $CIDFILE_DIR/replset3 ${BASE_ARGS} -e MONGODB_REPLICA_MEMBERS="$(get_container_ip replset0) $(get_container_ip replset2)" $IMAGE_NAME run-mongod-replication
+    # Wait for new member and whole replset to accept connections
+    wait_for_connection "replset3" "localhost"
+    wait_for_connection "replset0" "rs0/$(get_container_ip replset0),$(get_container_ip replset2)"
+
+    # Testing that replset still have 3 members
+    [ $(mongo_cmd_local replset0 "--host rs0/$(get_container_ip replset0),$(get_container_ip replset2) -u admin -p adminPassword admin --eval 'print(rs.status().members.length)'" | tail -n 1) == "3" ]
+
+    # Storing document into replset and wait replication to finish ..."
+    insert_and_wait_for_replication "rs0/$(get_container_ip replset0),$(get_container_ip replset2)" "{a:10, c:1}"
+
+    wait_for_connection "replset0" "rs0/$(get_container_ip replset0),$(get_container_ip replset2)"
+
+    # Testing stored documents in each node
+    [ "$(mongo_cmd_local replset0 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "2" ]
+    [ "$(mongo_cmd_local replset2 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "2" ]
+    [ "$(mongo_cmd_local replset3 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "2" ]
+
+    echo "  Success!"
+}
+
 # Tests.
 run_configuration_tests
 USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin
@@ -324,3 +433,5 @@ USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin
 CONTAINER_ARGS="-u 12345" USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin_altuid
 run_change_password_test
 run_mount_config_test
+
+run_local_replication_test

--- a/3.2/test/run
+++ b/3.2/test/run
@@ -332,7 +332,7 @@ function insert_and_wait_for_replication() {
           var optime=status.members[0].optime;
           var ok=true;
           for(var i=1; i < status.members.length; i++) {
-            if(optime.tojson() != status.members[i].optime.tojson()) {
+            if(optime.ts.tojson() != status.members[i].optime.ts.tojson()) {
               ok=false
             }
           };
@@ -368,12 +368,13 @@ function wait_for_secondary() {
 }
 
 function wait_for_connection() {
-    local name
-    name=$1
     local host
-    host=$2
+    host=$1
 
-    while ! mongo_cmd_local ${name} "admin --host ${host} --eval 'quit()'"; do
+    DB=admin
+    CONTAINER_IP=${host}
+
+    while ! docker run --rm $IMAGE_NAME mongo "$DB" --host ${host} --eval 'quit()'; do
       sleep 5
     done
 }
@@ -391,6 +392,11 @@ function run_local_replication_test() {
 -e MONGODB_KEYFILE_VALUE=xxxxxxxxxxxx
 -e MONGODB_SMALLFILES=true"
 
+    # need to set these because `mongo_cmd` relies on global variables
+    USER=admin
+    PASS=adminPassword
+    DB=admin
+
     docker run -d --cidfile $CIDFILE_DIR/replset0 ${BASE_ARGS} -e MONGODB_REPLICA_MEMBERS="" $IMAGE_NAME run-mongod-replication
     docker run -d --cidfile $CIDFILE_DIR/replset1 ${BASE_ARGS} -e MONGODB_REPLICA_MEMBERS="$(get_container_ip replset0)" $IMAGE_NAME run-mongod-replication
     docker run -d --cidfile $CIDFILE_DIR/replset2 ${BASE_ARGS} -e MONGODB_REPLICA_MEMBERS="$(get_container_ip replset0) $(get_container_ip replset1)" $IMAGE_NAME run-mongod-replication
@@ -401,9 +407,9 @@ function run_local_replication_test() {
     insert_and_wait_for_replication "rs0/$(get_container_ip replset1),$(get_container_ip replset2)" "{a:5, b:10}"
 
     # Testing stored documents in each node
-    [ "$(mongo_cmd_local replset0 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "1" ]
-    [ "$(mongo_cmd_local replset1 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "1" ]
-    [ "$(mongo_cmd_local replset2 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "1" ]
+    [ "$(CONTAINER_IP=$(get_container_ip replset0) mongo_cmd 'rs.slaveOk(); printjson(db.getSiblingDB("test_db").data.count())' | tail -n 1)" == "1" ]
+    [ "$(CONTAINER_IP=$(get_container_ip replset1) mongo_cmd 'rs.slaveOk(); printjson(db.getSiblingDB("test_db").data.count())' | tail -n 1)" == "1" ]
+    [ "$(CONTAINER_IP=$(get_container_ip replset2) mongo_cmd 'rs.slaveOk(); printjson(db.getSiblingDB("test_db").data.count())' | tail -n 1)" == "1" ]
 
     # Stopping and removing second container
     docker stop $(get_cid replset1)
@@ -411,21 +417,21 @@ function run_local_replication_test() {
     # Adding new container
     docker run -d --cidfile $CIDFILE_DIR/replset3 ${BASE_ARGS} -e MONGODB_REPLICA_MEMBERS="$(get_container_ip replset0) $(get_container_ip replset2)" $IMAGE_NAME run-mongod-replication
     # Wait for new member and whole replset to accept connections
-    wait_for_connection "replset3" "localhost"
-    wait_for_connection "replset0" "rs0/$(get_container_ip replset0),$(get_container_ip replset2)"
+    wait_for_connection "$(get_container_ip replset3)"
+    wait_for_connection "rs0/$(get_container_ip replset0),$(get_container_ip replset2)"
 
     # Testing that replset still have 3 members
-    [ $(mongo_cmd_local replset0 "--host rs0/$(get_container_ip replset0),$(get_container_ip replset2) -u admin -p adminPassword admin --eval 'print(rs.status().members.length)'" | tail -n 1) == "3" ]
+    [ "$(CONTAINER_IP=rs0/$(get_container_ip replset0),$(get_container_ip replset2) mongo_cmd 'print(rs.status().members.length)' | tail -n 1)" == "3" ]
 
     # Storing document into replset and wait replication to finish ..."
     insert_and_wait_for_replication "rs0/$(get_container_ip replset0),$(get_container_ip replset2)" "{a:10, c:1}"
 
-    wait_for_connection "replset0" "rs0/$(get_container_ip replset0),$(get_container_ip replset2)"
+    wait_for_connection "rs0/$(get_container_ip replset0),$(get_container_ip replset2)"
 
     # Testing stored documents in each node
-    [ "$(mongo_cmd_local replset0 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "2" ]
-    [ "$(mongo_cmd_local replset2 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "2" ]
-    [ "$(mongo_cmd_local replset3 '-u admin -p adminPassword admin --eval "rs.slaveOk(); printjson(db.getSiblingDB(\"test_db\").data.count())"' | tail -n 1)" == "2" ]
+    [ "$(CONTAINER_IP=$(get_container_ip replset0) mongo_cmd 'rs.slaveOk(); printjson(db.getSiblingDB("test_db").data.count())' | tail -n 1)" == "2" ]
+    [ "$(CONTAINER_IP=$(get_container_ip replset2) mongo_cmd 'rs.slaveOk(); printjson(db.getSiblingDB("test_db").data.count())' | tail -n 1)" == "2" ]
+    [ "$(CONTAINER_IP=$(get_container_ip replset3) mongo_cmd 'rs.slaveOk(); printjson(db.getSiblingDB("test_db").data.count())' | tail -n 1)" == "2" ]
 
     echo "  Success!"
 }

--- a/3.2/test/run
+++ b/3.2/test/run
@@ -326,7 +326,8 @@ function insert_and_wait_for_replication() {
     # Storing document into replset and wait replication to finish
     CONTAINER_IP="${host}" ADMIN_PASS="adminPassword" \
     mongo_admin_cmd "db.getSiblingDB('test_db').data.insert(${data});
-        while(true) {
+        var i = 60;
+        while(i > 0) {
           var status=rs.status();
           var optime=status.members[0].optime;
           var ok=true;
@@ -339,6 +340,7 @@ function insert_and_wait_for_replication() {
             print('REPLICATED')
             break;
           }
+          i--;
         }"
 }
 
@@ -347,7 +349,8 @@ function wait_for_secondary() {
     host=$1
 
     CONTAINER_IP="${host}" ADMIN_PASS="adminPassword" \
-    mongo_admin_cmd "while(true) {
+    mongo_admin_cmd "var i = 60;
+        while(i > 0) {
           var status=rs.status();
           var ok=true;
           for(var i=1; i < status.members.length; i++) {
@@ -359,6 +362,7 @@ function wait_for_secondary() {
             print('ALL MEMBERS ARE PRIMARY OR SECONDARY')
             break;
           }
+          i--;
         }
         printjson(rs.status())"
 }

--- a/examples/replset-docker/README.md
+++ b/examples/replset-docker/README.md
@@ -1,0 +1,81 @@
+# MongoDB Replication Example Using a Docker
+
+This [MongoDB replication](https://docs.mongodb.com/manual/replication/) example
+uses a [Docker engine](http://docker.com) to run replica set members. This platform
+do not provide any deployment automation and it is used mainly for developing and testing.
+
+## Getting Started
+
+You will need an Docker engine where you can run containers. If you want to avoid running all replset members on one host, you can also use [Docker Swarm](https://docs.docker.com/swarm/).
+
+## Example Working Scenarios
+
+This section describes how this example is designed to work.
+
+### Initial Deployment: 3-member Replica Set
+
+To create replica set with three members you can use this script:
+
+```bash
+function get_ip() {
+    local id="$1" ; shift
+    docker inspect --format='{{.NetworkSettings.IPAddress}}' ${id}
+}
+
+REPLICATION_ARGS="
+-e MONGODB_DATABASE=db
+-e MONGODB_USER=user
+-e MONGODB_PASSWORD=password
+-e MONGODB_ADMIN_PASSWORD=adminPassword
+-e MONGODB_REPLICA_NAME=rs0
+-e MONGODB_KEYFILE_VALUE=xxxxxxxxxxxx
+-e MONGODB_SMALLFILES=true"
+
+docker run -d --name replset0 ${BASE_ARGS} --hostname initialize -e MONGODB_REPLICA_MEMBERS="" $IMAGE_NAME run-mongod-replication
+docker run -d --name replset1 ${BASE_ARGS} -e MONGODB_REPLICA_MEMBERS="$(get_ip replset0)" $IMAGE_NAME run-mongod-replication
+docker run -d --name replset2 ${BASE_ARGS} -e MONGODB_REPLICA_MEMBERS="$(get_ip replset0) $(get_ip replset1)" $IMAGE_NAME run-mongod-replication
+```
+
+`run-mongod-replication` command have to be run in container and in `MONGODB_REPLICA_MEMBERS` environment variable it should contain as much of replica set members addresses as possible.
+
+And later from one of the containers you can also login into MongoDB:
+
+```console
+sh-4.2$ mongo $MONGODB_DATABASE -u $MONGODB_USER -p $MONGODB_PASSWORD --host $MONGODB_REPLICA_NAME/localhost
+MongoDB shell version: 3.2.6
+connecting to: sampledb
+rs0:PRIMARY>
+```
+
+Note: You can also use host version of mongo shell, but you have to substitute values of environmental variables yourself.
+
+During the lifetime of your deployment, one or more of those members might crash or fail. In this case, replica set member is removed. It some special cases, replica set configuration might not be updated -- see Known Limitations.
+
+**Note**: for production usage, you should maintain as much separation between
+members as possible. It is recommended to run containers on different hosts.
+
+### Adding member
+
+To add new member into replica set run:
+
+```bash
+docker run -d --name replset3 ${BASE_ARGS} -e MONGODB_REPLICA_MEMBERS="$(get_ip replset0) $(get_ip replset1) $(get_ip replset2)" $IMAGE_NAME run-mongod-replication
+```
+
+New containers is created and it connects to the replica set.
+
+### Removing member
+
+To remove member from replica set stop container:
+
+```bash
+docker stop replset2
+```
+
+The container is removed from replset configuration and terminates.
+
+### Known Limitations
+
+* Adding or removing new members or replica set takes some time (elections, syncing,...), so after your command finished it may take some time until replica set is ready
+//TODO  => suggest to use mongo from container and use functions from common.sh
+* Initializing container knows only one replica set member address (itself). So if mongod server in this container fails, container can't connect to replica set to remove itself from configuration, so in this case replica set configuration might not be cleaned properly.


### PR DESCRIPTION
This PR allows user to create replset using only local docker.

If variable  `MONGODB_REPLICA_MEMBERS` is specified (it could be even empty) run-mongod does not use kubernetes to obtain pods IP addresses and read IPs from this environmental variable.

So creating replset:

```
docker run ... -e MONGODB_REPLICA_NAME=rs0 -e MONGODB_KEYFILE_VALUE=... -e MONGODB_REPLICA_MEMBERS="" centos/mongodb-24-centos7
docker run ... -e MONGODB_REPLICA_NAME=rs0 -e MONGODB_KEYFILE_VALUE=... -e MONGODB_REPLICA_MEMBERS="MEMBER1_IP" centos/mongodb-24-centos7
docker run ... -e MONGODB_REPLICA_NAME=rs0 -e MONGODB_KEYFILE_VALUE=... -e MONGODB_REPLICA_MEMBERS="MEMBER1_IP,MEMBER2_IP" centos/mongodb-24-centos7
docker run ... -e MONGODB_REPLICA_NAME=rs0 -e MONGODB_KEYFILE_VALUE=... -e MONGODB_REPLICA_MEMBERS="MAMBER1_IP,MEMBER2_IP,MEMBER3_IP" centos/mongodb-24-centos7 run-mongod initialize
```

Only initializing member requires IPs of all members, other does not require this (they know own IP) but more IPs members know the better (more robust in case of some problems).

Also test for testing local replset was added.

@php-coder Please, do you remember why did you add `grep -v "$(container_addr)"` to `mongo_primary_member_addr()` in #130 ? (why local mongod IP is excluded?)
