### PR TITLE
Fix replication

### DIFF
--- a/2.4/root/usr/bin/run-mongod-replication
+++ b/2.4/root/usr/bin/run-mongod-replication
@@ -63,7 +63,7 @@ fi
 setup_keyfile
 
 # Run the supervisor in background to manage replset
-${CONTAINER_SCRIPTS_PATH}/replset_supervisor.sh "${1:-}" "$$" &
+${CONTAINER_SCRIPTS_PATH}/replset_supervisor.sh "${1:-}" &
 
 # Run `unset_env_vars` and `mongod` in a subshell because
 # MONGODB_ADMIN_PASSWORD should still be defined when the trapped call to

--- a/2.4/root/usr/share/container-scripts/mongodb/replset_supervisor.sh
+++ b/2.4/root/usr/share/container-scripts/mongodb/replset_supervisor.sh
@@ -8,7 +8,6 @@ source ${CONTAINER_SCRIPTS_PATH}/common.sh
 
 # Initiate replicaset and exit
 if [[ "$1" == "initiate" ]]; then
-  main_process_id=$2
   current_endpoints=$(endpoints)
   if [ -n "${MONGODB_INITIAL_REPLICA_COUNT:-}" ]; then
     echo -n "=> Waiting for $MONGODB_INITIAL_REPLICA_COUNT MongoDB endpoints ..."
@@ -36,6 +35,9 @@ if [[ "$1" == "initiate" ]]; then
   for node in ${current_endpoints}; do
     wait_for_mongo_up ${node} &>/dev/null
   done
+
+  echo "=> Waiting for local MongoDB to accept connections ..."
+  wait_for_mongo_up &>/dev/null
 
   echo "=> Initiating the replSet ${MONGODB_REPLICA_NAME} ..."
   # This will perform the 'rs.initiate()' command on the current MongoDB.
@@ -69,9 +71,6 @@ if [[ "$1" == "initiate" ]]; then
   wait_for_mongo_down
 
   echo "=> Successfully initialized replSet"
-
-  # Exit this pod
-  kill ${main_process_id}
 
 # Try to add node into replicaset
 else

--- a/2.6/root/usr/bin/run-mongod-replication
+++ b/2.6/root/usr/bin/run-mongod-replication
@@ -63,7 +63,7 @@ fi
 setup_keyfile
 
 # Run the supervisor in background to manage replset
-${CONTAINER_SCRIPTS_PATH}/replset_supervisor.sh "${1:-}" "$$" &
+${CONTAINER_SCRIPTS_PATH}/replset_supervisor.sh "${1:-}" &
 
 # Run `unset_env_vars` and `mongod` in a subshell because
 # MONGODB_ADMIN_PASSWORD should still be defined when the trapped call to

--- a/2.6/root/usr/share/container-scripts/mongodb/replset_supervisor.sh
+++ b/2.6/root/usr/share/container-scripts/mongodb/replset_supervisor.sh
@@ -8,7 +8,6 @@ source ${CONTAINER_SCRIPTS_PATH}/common.sh
 
 # Initiate replicaset and exit
 if [[ "$1" == "initiate" ]]; then
-  main_process_id=$2
   current_endpoints=$(endpoints)
   if [ -n "${MONGODB_INITIAL_REPLICA_COUNT:-}" ]; then
     echo -n "=> Waiting for $MONGODB_INITIAL_REPLICA_COUNT MongoDB endpoints ..."
@@ -36,6 +35,9 @@ if [[ "$1" == "initiate" ]]; then
   for node in ${current_endpoints}; do
     wait_for_mongo_up ${node} &>/dev/null
   done
+
+  echo "=> Waiting for local MongoDB to accept connections ..."
+  wait_for_mongo_up &>/dev/null
 
   echo "=> Initiating the replSet ${MONGODB_REPLICA_NAME} ..."
   # This will perform the 'rs.initiate()' command on the current MongoDB.
@@ -69,9 +71,6 @@ if [[ "$1" == "initiate" ]]; then
   wait_for_mongo_down
 
   echo "=> Successfully initialized replSet"
-
-  # Exit this pod
-  kill ${main_process_id}
 
 # Try to add node into replicaset
 else

--- a/3.0-upg/root/usr/bin/run-mongod-replication
+++ b/3.0-upg/root/usr/bin/run-mongod-replication
@@ -63,7 +63,7 @@ fi
 setup_keyfile
 
 # Run the supervisor in background to manage replset
-${CONTAINER_SCRIPTS_PATH}/replset_supervisor.sh "${1:-}" "$$" &
+${CONTAINER_SCRIPTS_PATH}/replset_supervisor.sh "${1:-}" &
 
 # Run `unset_env_vars` and `mongod` in a subshell because
 # MONGODB_ADMIN_PASSWORD should still be defined when the trapped call to

--- a/3.0-upg/root/usr/share/container-scripts/mongodb/replset_supervisor.sh
+++ b/3.0-upg/root/usr/share/container-scripts/mongodb/replset_supervisor.sh
@@ -8,7 +8,6 @@ source ${CONTAINER_SCRIPTS_PATH}/common.sh
 
 # Initiate replicaset and exit
 if [[ "$1" == "initiate" ]]; then
-  main_process_id=$2
   current_endpoints=$(endpoints)
   if [ -n "${MONGODB_INITIAL_REPLICA_COUNT:-}" ]; then
     echo -n "=> Waiting for $MONGODB_INITIAL_REPLICA_COUNT MongoDB endpoints ..."
@@ -36,6 +35,9 @@ if [[ "$1" == "initiate" ]]; then
   for node in ${current_endpoints}; do
     wait_for_mongo_up ${node} &>/dev/null
   done
+
+  echo "=> Waiting for local MongoDB to accept connections ..."
+  wait_for_mongo_up &>/dev/null
 
   echo "=> Initiating the replSet ${MONGODB_REPLICA_NAME} ..."
   # This will perform the 'rs.initiate()' command on the current MongoDB.
@@ -69,9 +71,6 @@ if [[ "$1" == "initiate" ]]; then
   wait_for_mongo_down
 
   echo "=> Successfully initialized replSet"
-
-  # Exit this pod
-  kill ${main_process_id}
 
 # Try to add node into replicaset
 else

--- a/3.2/root/usr/bin/run-mongod-replication
+++ b/3.2/root/usr/bin/run-mongod-replication
@@ -63,7 +63,7 @@ fi
 setup_keyfile
 
 # Run the supervisor in background to manage replset
-${CONTAINER_SCRIPTS_PATH}/replset_supervisor.sh "${1:-}" "$$" &
+${CONTAINER_SCRIPTS_PATH}/replset_supervisor.sh "${1:-}" &
 
 # Run `unset_env_vars` and `mongod` in a subshell because
 # MONGODB_ADMIN_PASSWORD should still be defined when the trapped call to

--- a/3.2/root/usr/share/container-scripts/mongodb/replset_supervisor.sh
+++ b/3.2/root/usr/share/container-scripts/mongodb/replset_supervisor.sh
@@ -8,7 +8,6 @@ source ${CONTAINER_SCRIPTS_PATH}/common.sh
 
 # Initiate replicaset and exit
 if [[ "$1" == "initiate" ]]; then
-  main_process_id=$2
   current_endpoints=$(endpoints)
   if [ -n "${MONGODB_INITIAL_REPLICA_COUNT:-}" ]; then
     echo -n "=> Waiting for $MONGODB_INITIAL_REPLICA_COUNT MongoDB endpoints ..."
@@ -36,6 +35,9 @@ if [[ "$1" == "initiate" ]]; then
   for node in ${current_endpoints}; do
     wait_for_mongo_up ${node} &>/dev/null
   done
+
+  echo "=> Waiting for local MongoDB to accept connections ..."
+  wait_for_mongo_up &>/dev/null
 
   echo "=> Initiating the replSet ${MONGODB_REPLICA_NAME} ..."
   # This will perform the 'rs.initiate()' command on the current MongoDB.
@@ -69,9 +71,6 @@ if [[ "$1" == "initiate" ]]; then
   wait_for_mongo_down
 
   echo "=> Successfully initialized replSet"
-
-  # Exit this pod
-  kill ${main_process_id}
 
 # Try to add node into replicaset
 else


### PR DESCRIPTION
This fixes MongoDB replication that was broken by df104523417431ac013733b5478e483124b048c8 (#177) commit.

Before this change we run the `replset_supervisor.sh` script in the background and after that run the mongodb daemon. Because `replset_supervisor.sh` script connect to mongo it was possible that database wasn't ready yet and script was failing. I updated the script for waiting when mongo will accept connections.

Replica set started working but only for a short time and later it stopped working again because mongo process was killed to early. To fix this I removed the code from `replset_supervisor.sh` script that kills mongo.

Fix #179 

PTAL @bparees 

@omron93 Why did we kill mongo from the `replset_supervisor.sh` script?
