### PR TITLE
Minor improvements

### DIFF
--- a/2.4/root/usr/bin/run-mongod
+++ b/2.4/root/usr/bin/run-mongod
@@ -12,9 +12,6 @@ function usage() {
   echo "  MONGODB_PASSWORD"
   echo "  MONGODB_DATABASE"
   echo "  MONGODB_ADMIN_PASSWORD"
-  echo "Optional variables:"
-  echo "  MONGODB_REPLICA_NAME"
-  echo "  MONGODB_INITIAL_REPLICA_COUNT"
   echo "MongoDB settings:"
   echo "  MONGODB_NOPREALLOC (default: true)"
   echo "  MONGODB_SMALLFILES (default: true)"
@@ -28,9 +25,6 @@ function unset_env_vars() {
 }
 
 function cleanup() {
-  if [ -n "${MONGODB_REPLICA_NAME-}" ]; then
-    mongo_remove
-  fi
   echo "=> Shutting down MongoDB server ..."
   if pgrep mongod; then
     pkill -2 mongod
@@ -47,8 +41,6 @@ if [ ! -s $MONGODB_CONFIG_PATH ]; then
   envsubst < ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template > $MONGODB_CONFIG_PATH
 fi
 
-# Need to cache the container address for the cleanup
-cache_container_addr
 mongo_common_args="-f $MONGODB_CONFIG_PATH"
 if ! [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE && -v MONGODB_ADMIN_PASSWORD ]]; then
   usage

--- a/2.4/root/usr/bin/run-mongod-replication
+++ b/2.4/root/usr/bin/run-mongod-replication
@@ -17,6 +17,7 @@ function usage() {
   echo "  MONGODB_PASSWORD"
   echo "  MONGODB_DATABASE"
   echo "  MONGODB_ADMIN_PASSWORD"
+  echo "  MONGODB_KEYFILE_VALUE"
   echo "  MONGODB_REPLICA_NAME"
   echo "Optional variables:"
   echo "  MONGODB_INITIAL_REPLICA_COUNT"

--- a/2.4/root/usr/share/container-scripts/mongodb/common.sh
+++ b/2.4/root/usr/share/container-scripts/mongodb/common.sh
@@ -193,7 +193,7 @@ function mongo_create_admin() {
 function mongo_create_user() {
   # Ensure input variables exists
   if [[ -z "${MONGODB_USER:-}" ]]; then
-    echo "=> MONGODB_USER is not set. Failed to create MongoDB user: ${MONGODB_USER}"
+    echo "=> MONGODB_USER is not set. Failed to create MongoDB user"
     exit 1
   fi
   if [[ -z "${MONGODB_PASSWORD:-}" ]]; then

--- a/2.6/root/usr/bin/run-mongod
+++ b/2.6/root/usr/bin/run-mongod
@@ -12,9 +12,6 @@ function usage() {
   echo "  MONGODB_PASSWORD"
   echo "  MONGODB_DATABASE"
   echo "  MONGODB_ADMIN_PASSWORD"
-  echo "Optional variables:"
-  echo "  MONGODB_REPLICA_NAME"
-  echo "  MONGODB_INITIAL_REPLICA_COUNT"
   echo "MongoDB settings:"
   echo "  MONGODB_NOPREALLOC (default: true)"
   echo "  MONGODB_SMALLFILES (default: true)"
@@ -28,9 +25,6 @@ function unset_env_vars() {
 }
 
 function cleanup() {
-  if [ -n "${MONGODB_REPLICA_NAME-}" ]; then
-    mongo_remove
-  fi
   echo "=> Shutting down MongoDB server ..."
   if pgrep mongod; then
     pkill -2 mongod
@@ -47,8 +41,6 @@ if [ ! -s $MONGODB_CONFIG_PATH ]; then
   envsubst < ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template > $MONGODB_CONFIG_PATH
 fi
 
-# Need to cache the container address for the cleanup
-cache_container_addr
 mongo_common_args="-f $MONGODB_CONFIG_PATH"
 if ! [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE && -v MONGODB_ADMIN_PASSWORD ]]; then
   usage

--- a/2.6/root/usr/bin/run-mongod-replication
+++ b/2.6/root/usr/bin/run-mongod-replication
@@ -17,6 +17,7 @@ function usage() {
   echo "  MONGODB_PASSWORD"
   echo "  MONGODB_DATABASE"
   echo "  MONGODB_ADMIN_PASSWORD"
+  echo "  MONGODB_KEYFILE_VALUE"
   echo "  MONGODB_REPLICA_NAME"
   echo "Optional variables:"
   echo "  MONGODB_INITIAL_REPLICA_COUNT"

--- a/2.6/root/usr/share/container-scripts/mongodb/common.sh
+++ b/2.6/root/usr/share/container-scripts/mongodb/common.sh
@@ -192,7 +192,7 @@ function mongo_create_admin() {
 function mongo_create_user() {
   # Ensure input variables exists
   if [[ -z "${MONGODB_USER:-}" ]]; then
-    echo "=> MONGODB_USER is not set. Failed to create MongoDB user: ${MONGODB_USER}"
+    echo "=> MONGODB_USER is not set. Failed to create MongoDB user"
     exit 1
   fi
   if [[ -z "${MONGODB_PASSWORD:-}" ]]; then

--- a/3.0-upg/root/usr/bin/run-mongod
+++ b/3.0-upg/root/usr/bin/run-mongod
@@ -12,9 +12,6 @@ function usage() {
   echo "  MONGODB_PASSWORD"
   echo "  MONGODB_DATABASE"
   echo "  MONGODB_ADMIN_PASSWORD"
-  echo "Optional variables:"
-  echo "  MONGODB_REPLICA_NAME"
-  echo "  MONGODB_INITIAL_REPLICA_COUNT"
   echo "MongoDB settings:"
   echo "  MONGODB_NOPREALLOC (default: true)"
   echo "  MONGODB_SMALLFILES (default: true)"
@@ -28,9 +25,6 @@ function unset_env_vars() {
 }
 
 function cleanup() {
-  if [ -n "${MONGODB_REPLICA_NAME-}" ]; then
-    mongo_remove
-  fi
   echo "=> Shutting down MongoDB server ..."
   if pgrep mongod; then
     pkill -2 mongod
@@ -55,8 +49,6 @@ if [ ! -s $MONGODB_CONFIG_PATH ]; then
   envsubst < ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template > $MONGODB_CONFIG_PATH
 fi
 
-# Need to cache the container address for the cleanup
-cache_container_addr
 mongo_common_args="-f $MONGODB_CONFIG_PATH"
 if ! [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE && -v MONGODB_ADMIN_PASSWORD ]]; then
   usage

--- a/3.0-upg/root/usr/bin/run-mongod-replication
+++ b/3.0-upg/root/usr/bin/run-mongod-replication
@@ -17,6 +17,7 @@ function usage() {
   echo "  MONGODB_PASSWORD"
   echo "  MONGODB_DATABASE"
   echo "  MONGODB_ADMIN_PASSWORD"
+  echo "  MONGODB_KEYFILE_VALUE"
   echo "  MONGODB_REPLICA_NAME"
   echo "Optional variables:"
   echo "  MONGODB_INITIAL_REPLICA_COUNT"

--- a/3.0-upg/root/usr/share/container-scripts/mongodb/common.sh
+++ b/3.0-upg/root/usr/share/container-scripts/mongodb/common.sh
@@ -192,7 +192,7 @@ function mongo_create_admin() {
 function mongo_create_user() {
   # Ensure input variables exists
   if [[ -z "${MONGODB_USER:-}" ]]; then
-    echo "=> MONGODB_USER is not set. Failed to create MongoDB user: ${MONGODB_USER}"
+    echo "=> MONGODB_USER is not set. Failed to create MongoDB user"
     exit 1
   fi
   if [[ -z "${MONGODB_PASSWORD:-}" ]]; then

--- a/3.2/root/usr/bin/run-mongod
+++ b/3.2/root/usr/bin/run-mongod
@@ -12,9 +12,6 @@ function usage() {
   echo "  MONGODB_PASSWORD"
   echo "  MONGODB_DATABASE"
   echo "  MONGODB_ADMIN_PASSWORD"
-  echo "Optional variables:"
-  echo "  MONGODB_REPLICA_NAME"
-  echo "  MONGODB_INITIAL_REPLICA_COUNT"
   echo "MongoDB settings:"
   echo "  MONGODB_NOPREALLOC (default: true)"
   echo "  MONGODB_SMALLFILES (default: true)"
@@ -28,9 +25,6 @@ function unset_env_vars() {
 }
 
 function cleanup() {
-  if [ -n "${MONGODB_REPLICA_NAME-}" ]; then
-    mongo_remove
-  fi
   echo "=> Shutting down MongoDB server ..."
   if pgrep mongod; then
     pkill -2 mongod
@@ -47,8 +41,6 @@ if [ ! -s $MONGODB_CONFIG_PATH ]; then
   envsubst < ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template > $MONGODB_CONFIG_PATH
 fi
 
-# Need to cache the container address for the cleanup
-cache_container_addr
 mongo_common_args="-f $MONGODB_CONFIG_PATH"
 if ! [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE && -v MONGODB_ADMIN_PASSWORD ]]; then
   usage

--- a/3.2/root/usr/bin/run-mongod-replication
+++ b/3.2/root/usr/bin/run-mongod-replication
@@ -17,6 +17,7 @@ function usage() {
   echo "  MONGODB_PASSWORD"
   echo "  MONGODB_DATABASE"
   echo "  MONGODB_ADMIN_PASSWORD"
+  echo "  MONGODB_KEYFILE_VALUE"
   echo "  MONGODB_REPLICA_NAME"
   echo "Optional variables:"
   echo "  MONGODB_INITIAL_REPLICA_COUNT"

--- a/3.2/root/usr/share/container-scripts/mongodb/common.sh
+++ b/3.2/root/usr/share/container-scripts/mongodb/common.sh
@@ -192,7 +192,7 @@ function mongo_create_admin() {
 function mongo_create_user() {
   # Ensure input variables exists
   if [[ -z "${MONGODB_USER:-}" ]]; then
-    echo "=> MONGODB_USER is not set. Failed to create MongoDB user: ${MONGODB_USER}"
+    echo "=> MONGODB_USER is not set. Failed to create MongoDB user"
     exit 1
   fi
   if [[ -z "${MONGODB_PASSWORD:-}" ]]; then


### PR DESCRIPTION
- `run-mongod(usage)`: remove unused optional variables from the output
- `run-mongod(cleanup)`: don't try to remove instance from the replica set
- `run-mongod-replication(usage)`: add `MONGODB_KEYFILE_VALUE` to the list
  of required parameters
- `common.sh(mongo_create_user)`: don't try to show value of empty variable

PTAL @bparees @omron93 
