### PR TITLE
Replica set example that uses PetSet

### DIFF
--- a/3.2/root/usr/bin/run-mongod-pet
+++ b/3.2/root/usr/bin/run-mongod-pet
@@ -1,0 +1,75 @@
+#!/bin/bash
+#
+# Run mongod in a PetSet-based replica set. See
+# https://github.com/sclorg/mongodb-container/blob/master/examples/petset/README.md
+# for a description of how this is intended to work.
+#
+# Note that this differs from the `run-mongodb-replication` script in at least
+# these aspects:
+# - It does not attempt to remove the host from the replica set configuration
+#   when it is terminating. That is by design, because, in a PetSet, when a
+#   pod/container terminates and is restarted by OpenShift, it will always have
+#   the same hostname. Removing hosts from the configuration affects replica set
+#   elections and can impact the replica set stability.
+# - The original replication example uses MONGODB_INITIAL_REPLICA_COUNT to wait
+#   for a certain number of pods to come up and then initializes the replica set.
+#   This example, instead, initializes the replica set when the first pod starts.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source ${CONTAINER_SCRIPTS_PATH}/common.sh
+
+function usage() {
+  echo "You must specify the following environment variables:"
+  echo "  MONGODB_USER"
+  echo "  MONGODB_PASSWORD"
+  echo "  MONGODB_DATABASE"
+  echo "  MONGODB_ADMIN_PASSWORD"
+  echo "  MONGODB_KEYFILE_VALUE"
+  echo "  MONGODB_REPLICA_NAME"
+  echo "Optional variables:"
+  echo "  MONGODB_SERVICE_NAME (default: mongodb)"
+  echo "MongoDB settings:"
+  echo "  MONGODB_NOPREALLOC (default: true)"
+  echo "  MONGODB_SMALLFILES (default: true)"
+  echo "  MONGODB_QUIET (default: true)"
+  exit 1
+}
+
+function cleanup() {
+  echo "=> Shutting down MongoDB server ..."
+  pkill -INT mongod || :
+  wait_for_mongo_down
+  exit 0
+}
+
+trap 'cleanup' SIGINT SIGTERM
+
+# If user provides own config file use it and do not generate new one
+if [ ! -s "${MONGODB_CONFIG_PATH}" ]; then
+  # Generate config file for MongoDB
+  envsubst < "${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template" > "${MONGODB_CONFIG_PATH}"
+fi
+
+if ! [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE && -v MONGODB_ADMIN_PASSWORD && -v MONGODB_KEYFILE_VALUE && -v MONGODB_REPLICA_NAME ]]; then
+  usage
+fi
+
+mongo_common_args="-f ${MONGODB_CONFIG_PATH}"
+
+# Attention: setup_keyfile may modify value of mongo_common_args!
+setup_keyfile
+
+${CONTAINER_SCRIPTS_PATH}/init-petset-replset.sh &
+
+# TODO: capture exit code of `init-petset-replset.sh` and exit with an error if
+# the initialization failed, so that the container will be restarted and the
+# user can gain more visibility that there is a problem in a way other than just
+# inspecting log messages.
+
+# Make sure env variables don't propagate to mongod process.
+unset MONGODB_USER MONGODB_PASSWORD MONGODB_DATABASE MONGODB_ADMIN_PASSWORD
+mongod ${mongo_common_args} --replSet "${MONGODB_REPLICA_NAME}" &
+wait

--- a/3.2/root/usr/share/container-scripts/mongodb/common.sh
+++ b/3.2/root/usr/share/container-scripts/mongodb/common.sh
@@ -259,3 +259,8 @@ function setup_keyfile() {
   chmod 0600 ${MONGODB_KEYFILE_PATH}
   mongo_common_args+=" --keyFile ${MONGODB_KEYFILE_PATH}"
 }
+
+# info prints a message prefixed by date and time.
+function info() {
+  printf "=> [%s] %s\n" "$(date +'%a %b %d %T')" "$*"
+}

--- a/3.2/root/usr/share/container-scripts/mongodb/init-petset-replset.sh
+++ b/3.2/root/usr/share/container-scripts/mongodb/init-petset-replset.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source "${CONTAINER_SCRIPTS_PATH}/common.sh"
+
+# This is a full hostname that will be added to replica set
+# (for example, "replica-2.mongodb.myproject.svc.cluster.local")
+readonly MEMBER_HOST="$(hostname -f)"
+
+# Description of possible statuses: https://docs.mongodb.com/manual/reference/replica-states/
+readonly WAIT_PRIMARY_STATUS='
+  while (rs.status().startupStatus || (rs.status().hasOwnProperty("myState") && rs.status().myState != 1)) {
+    printjson(rs.status());
+    sleep(1000);
+  };
+  printjson(rs.status());
+'
+readonly WAIT_PRIMARY_OR_SECONDARY_STATUS="
+  var mbrs;
+  while (!mbrs || mbrs.length == 0 || !(mbrs[0].state == 1 || mbrs[0].state == 2)) {
+    printjson(rs.status());
+    sleep(1000);
+    mbrs = rs.status().members.filter(function(el) {
+      return el.name.indexOf(\"${MEMBER_HOST}:\") > -1;
+    });
+  };
+  print(mbrs[0].stateStr);
+"
+
+# Outputs available endpoints (hostnames) to stdout.
+# This also includes hostname of the current pod.
+#
+# Uses the following global variables:
+# - MONGODB_SERVICE_NAME (optional, defaults to 'mongodb')
+function find_endpoints() {
+  local service_name="${MONGODB_SERVICE_NAME:-mongodb}"
+
+  # Extract host names from lines like this: "10 33 0 mongodb-2.mongodb.myproject.svc.cluster.local."
+  dig "${service_name}" SRV +search +short | cut -d' ' -f4 | rev | cut -c2- | rev
+}
+
+# TODO: unify this and `mongo_initiate` from common.sh
+# Initializes the replica set configuration. It is safe to call this function if
+# a replica set is already configured.
+#
+# Arguments:
+# - $1: host address[:port]
+#
+# Uses the following global variables:
+# - MONGODB_REPLICA_NAME
+# - MONGODB_ADMIN_PASSWORD
+# - WAIT_PRIMARY_STATUS
+function initiate() {
+  local host="$1"
+
+  if mongo --eval "quit(db.isMaster().setName == '${MONGODB_REPLICA_NAME}' ? 0 : 1)" --quiet; then
+    info "Replica set '${MONGODB_REPLICA_NAME}' already exists, skipping initialization"
+    return
+  fi
+
+  local config="{_id: '${MONGODB_REPLICA_NAME}', members: [{_id: 0, host: '${host}'}]}"
+
+  info "Initiating MongoDB replica using: ${config}"
+  mongo admin --eval "rs.initiate(${config});${WAIT_PRIMARY_STATUS}" --quiet
+
+  info "Creating MongoDB users ..."
+  mongo_create_admin
+  mongo_create_user "-u admin -p ${MONGODB_ADMIN_PASSWORD}"
+
+  info "Successfully initialized replica set"
+}
+
+# Adds a host to the replica set configuration. It is safe to call this function
+# if the host is already in the configuration.
+#
+# Arguments:
+# - $1: host address[:port]
+#
+# Global variables:
+# - MAX_ATTEMPTS
+# - SLEEP_TIME
+# - MONGODB_REPLICA_NAME
+# - MONGODB_ADMIN_PASSWORD
+# - WAIT_PRIMARY_OR_SECONDARY_STATUS
+function add_member() {
+  local host="$1"
+  info "Adding ${host} to replica set ..."
+
+  local script
+  script="
+    for (var i = 0; i < ${MAX_ATTEMPTS}; i++) {
+      var ret = rs.add('${host}');
+      if (ret.ok) {
+        quit(0);
+      }
+      // ignore error if host is already in the configuration
+      if (ret.code == 103) {
+        quit(0);
+      }
+      sleep(${SLEEP_TIME});
+    }
+    printjson(ret);
+    quit(1);
+  "
+
+  # TODO: replace this with a call to `replset_addr` from common.sh, once it returns host names.
+  local endpoints
+  endpoints="$(find_endpoints | paste -s -d,)"
+
+  if [ -z "${endpoints}" ]; then
+    info "ERROR: couldn't add host to replica set!"
+    info "CAUSE: DNS lookup for '${MONGODB_SERVICE_NAME:-mongodb}' returned no results."
+    return 1
+  fi
+
+  local replset_addr
+  replset_addr="${MONGODB_REPLICA_NAME}/${endpoints}"
+
+  if ! mongo admin -u admin -p "${MONGODB_ADMIN_PASSWORD}" --host "${replset_addr}" --eval "${script}" --quiet; then
+    info "ERROR: couldn't add host to replica set!"
+    return 1
+  fi
+
+  info "Successfully added to replica set"
+  info "Waiting for PRIMARY/SECONDARY status ..."
+
+  local rs_status_out
+  rs_status_out="$(mongo admin -u admin -p "${MONGODB_ADMIN_PASSWORD}" --host "${replset_addr}" --eval "${WAIT_PRIMARY_OR_SECONDARY_STATUS}" --quiet || :)"
+
+  if ! echo "${rs_status_out}" | grep -xqs '\(SECONDARY\|PRIMARY\)'; then
+    info "ERROR: failed waiting for PRIMARY/SECONDARY status. Command output was:"
+    echo "${rs_status_out}"
+    echo "==> End of the error output <=="
+    return 1
+  fi
+
+  info "Successfully joined replica set"
+}
+
+info "Waiting for local MongoDB to accept connections ..."
+wait_for_mongo_up &>/dev/null
+
+# PetSet pods are named with a predictable name, following the pattern:
+#   $(petset name)-$(zero-based index)
+# MEMBER_ID is computed by removing the prefix matching "*-", i.e.:
+#  "mongodb-0" -> "0"
+#  "mongodb-1" -> "1"
+#  "mongodb-2" -> "2"
+readonly MEMBER_ID="${HOSTNAME##*-}"
+
+# Initialize replica set only if we're the first member
+if [ "${MEMBER_ID}" = '0' ]; then
+  initiate "${MEMBER_HOST}"
+else
+  add_member "${MEMBER_HOST}"
+fi

--- a/examples/petset/README.md
+++ b/examples/petset/README.md
@@ -1,0 +1,183 @@
+# MongoDB Replication Example Using a PetSet
+
+This [MongoDB replication](https://docs.mongodb.com/manual/replication/) example
+uses a [PetSet](http://kubernetes.io/docs/user-guide/petset/) to manage replica
+set members.
+
+It is supported by an example [OpenShift
+template](https://docs.openshift.org/latest/dev_guide/templates.html) and
+scripts that automate replica set initiation, baked in the
+[centos/mongodb-32-centos7](https://hub.docker.com/r/centos/mongodb-32-centos7/)
+image (and its RHEL variant) built from this source repository.
+
+## Getting Started
+
+You will need an OpenShift cluster where you can deploy a template. If you don't
+have an existing OpenShift installation yet, the easiest way to get started and
+try out this example is using the
+[`oc cluster up`](https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md)
+command.
+
+This tutorial assumes you have the `oc` tool, are logged in and have 3
+pre-created persistent volumes (or configured [persistent volume
+provisioning](https://docs.openshift.org/latest/install_config/persistent_storage/dynamically_provisioning_pvs.html)).
+
+In the context of a project where you want to create a MongoDB cluster, run
+`oc new-app` passing the template file as an argument:
+
+```bash
+oc new-app https://raw.githubusercontent.com/sclorg/mongodb-container/master/examples/petset/mongodb-petset-persistent.yaml
+```
+
+The command above will create a MongoDB cluster with 3 replica set members.
+
+To list all pods:
+
+```console
+$ oc get pods -l name=mongodb
+NAME        READY     STATUS    RESTARTS   AGE
+mongodb-0   1/1       Running   0          50m
+mongodb-1   1/1       Running   0          50m
+mongodb-2   1/1       Running   0          49m
+```
+
+To see logs from the particular pod:
+
+```console
+$ oc logs mongodb-0
+```
+
+To log in to the pod:
+
+```console
+$ oc rsh mongodb-0
+sh-4.2$
+```
+
+And later from one of the pods you can also login into MongoDB:
+
+```console
+sh-4.2$ mongo $MONGODB_DATABASE -u $MONGODB_USER -p $MONGODB_PASSWORD
+MongoDB shell version: 3.2.6
+connecting to: sampledb
+rs0:PRIMARY>
+```
+
+## Example Working Scenarios
+
+This section describes how this example is designed to work.
+
+### Initial Deployment: 3-member Replica Set
+
+After creating a cluster with the example template, we have a replica set with 3
+members. That should be enough for most cases, as described in the
+[official MongoDB documentation](https://docs.mongodb.com/manual/tutorial/deploy-replica-set/#overview).
+
+During the lifetime of your OpenShift project, one or more of those members
+might crash or fail. OpenShift automatically restarts unhealthy pods
+(containers), and so will restart replica set members as necessary.
+
+While a replica set member is down or being restarted, you may be in one of
+these scenarios:
+
+1. PRIMARY member is down
+
+    In this case, the other two members shall elect a new PRIMARY. Until then,
+    reads should NOT be affected, while writes will fail. After a successful
+    election, writes and reads will succeed normally.
+
+2. One SECONDARY member is down
+
+    Reads and writes should be unaffected. Depending on the `oplogSize`
+    configuration and the write rate, the third member might fail to join back
+    the replica set, requiring manual intervention to re-sync its copy of the
+    database.
+
+3. Any two members are down
+
+    When a three-member replica set member cannot reach any other member, it
+    will step down from the PRIMARY role if it had it. In this case, reads might
+    be served by a SECONDARY, and writes will fail. As soon as one more member
+    is back up, an election will pick a new PRIMARY and reads and writes will
+    succeed normally.
+
+4. All members are down
+
+    In this extreme case, obviously reads and writes will fail. Once two or more
+    members are back up, an election will reestablish the replica set to have a
+    PRIMARY and a SECONDARY, such that reads and writes will succeed normally.
+
+**Note**: for production usage, you should maintain as much separation between
+members as possible. It is recommended to use one or more of the
+[node selection features](http://kubernetes.io/docs/user-guide/node-selection/)
+to schedule PetSet pods into different nodes, and to provide them storage backed
+by independent volumes.
+
+### Scaling Up
+
+MongoDB recommends an odd number of members in a replica set. An admin may
+decide to have, for instance, 5 members in the replica set. Given that there are
+sufficient available persistent volumes, or a dynamic storage provisioner is
+present, scaling up is done with the `oc scale` command:
+
+```bash
+oc scale --replicas=5 petset/mongodb
+```
+
+New pods (containers) are created and they connect to the replica set, updating
+its configuration.
+
+With five members, the scenarios described in the previous section should work
+similarly, though now there is an added resilience to tolerate up to 2 members
+being simultaneously unavailable.
+
+**Note**: scaling up an existing database might require manual intervention. If
+the database size is greater than the `oplogSize` configuration, a manual
+initial sync of the new members will be required. Please consult the MongoDB
+replication manual for more information.
+
+### Scaling Down
+
+An admin may decide to scale down a replica set to save resources or for any
+other reason. For instance, it is possible to go from 5 to 3 members, or from 3
+to 1 member.
+
+While scaling up might be done without manual intervention when the
+preconditions are met (storage availability, size of existing database and
+`oplogSize`), scaling down always require manual intervention.
+
+To scaling down, start with setting the new number of replicas, e.g.:
+
+```bash
+oc scale --replicas=3 petset/mongodb
+```
+
+Note that if the new number of replicas still constitutes a majority of the
+previous number, it is guaranteed that the replica set may elect a new PRIMARY
+in case one of the pods that was deleted had that role. For example, that is the
+case when going from 5 to 3 members.
+
+On the other hand, scaling down to a lower number will temporarily render the
+replica set to have only SECONDARY members and be in read-only mode. That would
+be the case when scaling from 5 down to 1 member.
+
+The next step is to update the replica set configuration to
+[remove members](https://docs.mongodb.com/manual/tutorial/remove-replica-set-member/)
+that no longer exist. This may be improved in the future, a possible
+implementation being setting a PreStop pod hook that inspects the number of
+replicas (exposed via the downward API) and determines that the pod is being
+removed from the PetSet, and not being restarted for some other reason.
+
+Finally, the volumes used by the decommissioned pods may be manually purged.
+Follow the [PetSet documentation](http://kubernetes.io/docs/user-guide/petset/#deleting-a-pet-set)
+for more details on how to clean up after scaling down.
+
+### Known Limitations
+
+* Only MongoDB 3.2 is supported.
+* You have to manually update replica set configuration in case of scaling down.
+* Changing a user's and admin's password is a manual process: it requires
+  updating values of environment variables in the PetSet configuration,
+  changing password in the database and restarting all the pods one by one.
+
+See also [PetSet limitations](http://kubernetes.io/docs/user-guide/petset/#alpha-limitations).

--- a/examples/petset/mongodb-petset-persistent.yaml
+++ b/examples/petset/mongodb-petset-persistent.yaml
@@ -1,0 +1,147 @@
+kind: Template
+apiVersion: v1
+metadata:
+  name: mongodb-petset-replication
+  annotations:
+    description: "MongoDB Replication Example (based on PetSet). You must have persistent volumes available in your cluster to use this template."
+    iconClass: "icon-mongodb"
+    tags: "database,mongodb,replication"
+parameters:
+  - name: MONGODB_USER
+    displayName: "MongoDB Connection Username"
+    description: "Username for MongoDB user that will be used for accessing the database."
+    generate: expression
+    from: "[a-zA-Z0-9]{3}"
+    required: true
+
+  - name: MONGODB_PASSWORD
+    displayName: "MongoDB Connection Password"
+    description: "Password for the MongoDB connection user."
+    generate: expression
+    from: "[a-zA-Z0-9]{16}"
+    required: true
+
+  - name: MONGODB_DATABASE
+    displayName: "MongoDB Database Name"
+    description: "Name of the MongoDB database accessed."
+    value: sampledb
+    required: true
+
+  - name: MONGODB_ADMIN_PASSWORD
+    displayName: "MongoDB Admin Password"
+    description: "Password for the database admin user."
+    generate: expression
+    from: "[a-zA-Z0-9]{16}"
+    required: true
+
+  - name: MONGODB_REPLICA_NAME
+    displayName: "Replica Set Name"
+    description: "The name of the replica set."
+    value: rs0
+    required: true
+
+  - name: MONGODB_KEYFILE_VALUE
+    displayName: "Keyfile Content"
+    description: "The value of the MongoDB keyfile (https://docs.mongodb.com/manual/core/security-internal-authentication/#internal-auth-keyfile)."
+    generate: expression
+    from: "[a-zA-Z0-9]{255}"
+    required: true
+
+  - name: MONGODB_IMAGE
+    displayName: "MongoDB Docker Image"
+    description: "A reference to a supported MongoDB Docker image."
+    value: "centos/mongodb-32-centos7"
+    required: true
+
+  - name: MONGODB_SERVICE_NAME
+    displayName: "OpenShift Service Name"
+    description: "The name of the OpenShift Service exposed for the database."
+    value: mongodb
+    required: true
+
+  - name: VOLUME_CAPACITY
+    displayName: "Volume Capacity"
+    description: "Volume space available for data, e.g. 512Mi, 2Gi."
+    value: "1Gi"
+    required: true
+
+  - name: MEMORY_LIMIT
+    displayName: "Memory Limit"
+    description: "Maximum amount of memory the container can use."
+    value: "512Mi"
+
+objects:
+  # A headless service to create DNS records
+  - kind: Service
+    apiVersion: v1
+    metadata:
+      name: "${MONGODB_SERVICE_NAME}"
+    spec:
+      clusterIP: None
+      # the list of ports that are exposed by this service
+      ports:
+        - name: mongodb
+          port: 27017
+      # will route traffic to pods having labels matching this selector
+      selector:
+        name: "${MONGODB_SERVICE_NAME}"
+
+  - kind: PetSet
+    apiVersion: apps/v1alpha1
+    metadata:
+      name: "${MONGODB_SERVICE_NAME}"
+    spec:
+      # pets get DNS/hostnames that follow the pattern: ${metadata.name}-NUM.${spec.serviceName}.default.svc.cluster.local
+      serviceName: "${MONGODB_SERVICE_NAME}"
+      replicas: 3
+      # describes the pod that will be created if insufficient replicas are detected
+      template:
+        metadata:
+          # this label will be used for count running pods
+          labels:
+            name: "${MONGODB_SERVICE_NAME}"
+          annotations:
+            # 'false' pauses a petset after creation of each pet, to avoid it we set it to 'true'
+            pod.alpha.kubernetes.io/initialized: "true"
+        spec:
+          containers:
+            - name: mongo-container
+              image: "${MONGODB_IMAGE}"
+              ports:
+                - containerPort: 27017
+              args:
+                - "run-mongod-pet"
+              volumeMounts:
+                - name: mongo-data
+                  mountPath: "/var/lib/mongodb/data"
+              env:
+                - name: MONGODB_USER
+                  value: "${MONGODB_USER}"
+                - name: MONGODB_PASSWORD
+                  value: "${MONGODB_PASSWORD}"
+                - name: MONGODB_DATABASE
+                  value: "${MONGODB_DATABASE}"
+                - name: MONGODB_ADMIN_PASSWORD
+                  value: "${MONGODB_ADMIN_PASSWORD}"
+                - name: MONGODB_REPLICA_NAME
+                  value: "${MONGODB_REPLICA_NAME}"
+                - name: MONGODB_KEYFILE_VALUE
+                  value: "${MONGODB_KEYFILE_VALUE}"
+                - name: MONGODB_SERVICE_NAME
+                  value: "${MONGODB_SERVICE_NAME}"
+              resources:
+                limits:
+                  memory: "${MEMORY_LIMIT}"
+      volumeClaimTemplates:
+        - metadata:
+            name: mongo-data
+            annotations:
+              # Uncomment this if using dynamic volume provisioning.
+              # https://docs.openshift.org/latest/install_config/persistent_storage/dynamically_provisioning_pvs.html
+              # volume.alpha.kubernetes.io/storage-class: anything
+          spec:
+            # the volume can be mounted as read-write by a single node
+            accessModes: [ ReadWriteOnce ]
+            resources:
+              requests:
+                storage: "${VOLUME_CAPACITY}"


### PR DESCRIPTION
**UPDATE**: PR will be merged as https://github.com/sclorg/mongodb-container/pull/206

This PR adds a new template with MongoDB replica set that uses PetSet.

Here is the quote from "Design Assumptions" of PetSets:

> **No generic cluster lifecycle** - Rather than design a general purpose lifecycle for clustered software, focus on ensuring the information necessary for the software to function is available. For example, rather than providing a "post-creation" hook invoked when the cluster is complete, provide the necessary information to the "first" (or last) pod to determine the identity of the remaining cluster members and allow it to manage its own initialization.

Based on that, I've changed how we're initializing replica set -- instead of using a hook pod that runs at the end of deployment, we're initializing a replica set with a single member on the first node. All other nodes join to replica set during startup.

This also simplifies code and removes 2 extra elections that we had before (see #140). Now the first node is PRIMARY and we don't do any elections during first run of replica set.

Trello card: https://trello.com/c/jPGXhxlJ/694-3-mongodb-replica-set-example-with-persistent-storage

@bparees @rhcarvalho @omron93 I would like to hear your feedback.

Fixes #114 

Left to do:
- [x] fix todo in scripts
- [x] fix todo in docs
- [x] explain new scheme of changing password
- [x] ~~add readiness/liveness probes~~ (resolution: readiness probe breaks all the things, so I put it off)
