### PR TITLE
Fix removing master from replset.

### DIFF
--- a/3.2/root/usr/bin/run-mongod-replication
+++ b/3.2/root/usr/bin/run-mongod-replication
@@ -28,6 +28,33 @@ function usage() {
 }
 
 function cleanup() {
+  if [ "$(mongo admin -u admin -p ${MONGODB_ADMIN_PASSWORD} --quiet --eval 'rs.isMaster().ismaster')" == "true" ]; then
+
+    # Wait that some SECONDARY is synced with PRIMARY 
+    echo "=> Waiting for syncing SECONDARY ..."
+    replset_wait_sync
+
+    # Some commands will force MongoDB client to re-connect. This is not working
+    # well in combination with '--eval'. In that case the 'mongo' command will fail
+    # with return code 254.
+    echo "=> Giving up the PRIMARY role ..."
+    mongo admin -u admin -p "${MONGODB_ADMIN_PASSWORD}" --quiet --eval "rs.stepDown(120);" &>/dev/null || true
+
+    # Wait till the new PRIMARY member is elected
+    echo "=> Waiting for the new PRIMARY to be elected ..."
+    mongo admin -u admin -p "${MONGODB_ADMIN_PASSWORD}" --quiet \
+     --eval "var i = ${MAX_ATTEMPTS};
+      while(i > 0) {
+        var members=rs.status().members;
+        for(i=0;i<members.length;i++){
+          if(members[i].stateStr=='PRIMARY' && members[i].name!='$(mongo_addr)'){
+            quit(0)
+          }
+        };
+        sleep(${SLEEP_TIME}*1000)
+      };" &>/dev/null
+    echo "=> A new PRIMARY member was elected, removing from replset ..."
+  fi
   if [ -n "${MONGODB_REPLICA_NAME-}" ]; then
     mongo_remove
   fi
@@ -56,13 +83,15 @@ fi
 setup_keyfile
 
 # Initialize the replica set or add member in the background.
-${CONTAINER_SCRIPTS_PATH}/init-replset.sh "${1:-}" &
+${CONTAINER_SCRIPTS_PATH}/init-replset.sh "${1:-}" "$$" &
 
 # TODO: capture exit code of `init-replset.sh` and exit with an error if the
 # initialization failed, so that the container will be restarted and the user
 # can gain more visibility that there is a problem in a way other than just
 # inspecting log messages.
 
+# Don't pass signals to background processes. Background processes are killed in `cleanup`.
+set -m
 # Run `mongod` in a subshell because MONGODB_ADMIN_PASSWORD should still be
 # defined when the trapped call to `cleanup` references it.
 (

--- a/3.2/root/usr/share/container-scripts/mongodb/common.sh
+++ b/3.2/root/usr/share/container-scripts/mongodb/common.sh
@@ -130,6 +130,31 @@ function replset_addr() {
   echo "${MONGODB_REPLICA_NAME}/${current_endpoints//[[:space:]]/,}"
 }
 
+# replse_wait_sync wait for at least two members to be up to date (PRIMARY and one SECONDARY)
+function replset_wait_sync() {
+  local host
+  # if we cannot determine the IP address of the primary, exit without an error
+  # to allow callers to proceed with their logic
+  host="$(replset_addr || true)"
+  if [ -z "$host" ]; then
+    return 1
+  fi
+
+  mongo admin -u admin -p "${MONGODB_ADMIN_PASSWORD}" --host ${host} \
+    --eval "var i = ${MAX_ATTEMPTS};
+    while(i > 0) {
+      var status=rs.status();
+      var primary_optime=status.members.filter(function(el) {return el.state ==1})[0].optime;
+      // Check that at least one member has same optime as PRIMARY (PRIMARY and one SECONDARY ~ >= 2)
+      if(status.members.filter(function(el) {return el.optime.ts.tojson() == primary_optime.ts.tojson()}).length >= 2)
+        quit(0);
+      else
+        sleep(${SLEEP_TIME}*1000);
+      i--;
+    };
+    quit(1);"
+}
+
 # mongo_remove removes the current MongoDB from the cluster
 function mongo_remove() {
   local host


### PR DESCRIPTION
This PR aims to fix 'stepping down server from PRIMARY role'.

When member is going to be removed from replset and this member is PRIMARY, it should check that this won't break replset - that replset is able to vote a new PRIMARY.
In current situation while removing PRIMARY it could happen that not all members of replset are up-to-date and replset user can lost some information.

Code which is now running after post deploy hook successfully initialize replset performs removing PRIMARY from replset. So removing this code from `init-replset.sh` and post-hook kills main scripts and this calls `cleanup()` (there the PRIMARY member is clearly removed).

Also this fixes https://bugzilla.redhat.com/show_bug.cgi?id=1260586

@php-coder @rhcarvalho @bparees Please take a look and review.

EDIT: Updated info after rebase to latest master.
