### PR TITLE
Minor improvements

### DIFF
--- a/2.4/root/usr/bin/run-mongod
+++ b/2.4/root/usr/bin/run-mongod
@@ -19,11 +19,6 @@ function usage() {
   exit 1
 }
 
-# Make sure env variables don't propagate to mongod process.
-function unset_env_vars() {
-  unset MONGODB_USER MONGODB_PASSWORD MONGODB_DATABASE MONGODB_ADMIN_PASSWORD
-}
-
 function cleanup() {
   echo "=> Shutting down MongoDB server ..."
   if pgrep mongod; then
@@ -66,5 +61,7 @@ fi
 # Restart the MongoDB daemon to bind on all interfaces
 mongod $mongo_common_args --shutdown
 wait_for_mongo_down
-unset_env_vars
+
+# Make sure env variables don't propagate to mongod process.
+unset MONGODB_USER MONGODB_PASSWORD MONGODB_DATABASE MONGODB_ADMIN_PASSWORD
 exec mongod $mongo_common_args --auth

--- a/2.4/root/usr/bin/run-mongod-replication
+++ b/2.4/root/usr/bin/run-mongod-replication
@@ -51,7 +51,7 @@ fi
 # Need to cache the container address for the cleanup
 cache_container_addr
 mongo_common_args="-f $MONGODB_CONFIG_PATH"
-if ! [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE && -v MONGODB_ADMIN_PASSWORD && -v MONGODB_REPLICA_NAME ]]; then
+if ! [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE && -v MONGODB_ADMIN_PASSWORD && -v MONGODB_KEYFILE_VALUE && -v MONGODB_REPLICA_NAME ]]; then
     usage
 fi
 

--- a/2.4/root/usr/bin/run-mongod-replication
+++ b/2.4/root/usr/bin/run-mongod-replication
@@ -28,11 +28,6 @@ function usage() {
   exit 1
 }
 
-# Make sure env variables don't propagate to mongod process.
-function unset_env_vars() {
-  unset MONGODB_USER MONGODB_PASSWORD MONGODB_DATABASE MONGODB_ADMIN_PASSWORD
-}
-
 function cleanup() {
   if [ -n "${MONGODB_REPLICA_NAME-}" ]; then
     mongo_remove
@@ -66,11 +61,12 @@ setup_keyfile
 # Run the supervisor in background to manage replset
 ${CONTAINER_SCRIPTS_PATH}/replset_supervisor.sh "${1:-}" &
 
-# Run `unset_env_vars` and `mongod` in a subshell because
-# MONGODB_ADMIN_PASSWORD should still be defined when the trapped call to
-# `cleanup` references it.
+# Run `mongod` in a subshell because MONGODB_ADMIN_PASSWORD should still be
+# defined when the trapped call to `cleanup` references it.
 (
-  unset_env_vars
+  # Make sure env variables don't propagate to mongod process.
+  unset MONGODB_USER MONGODB_PASSWORD MONGODB_DATABASE MONGODB_ADMIN_PASSWORD
+
   mongod $mongo_common_args --replSet "${MONGODB_REPLICA_NAME}"
 ) &
 wait

--- a/2.6/root/usr/bin/run-mongod
+++ b/2.6/root/usr/bin/run-mongod
@@ -19,11 +19,6 @@ function usage() {
   exit 1
 }
 
-# Make sure env variables don't propagate to mongod process.
-function unset_env_vars() {
-  unset MONGODB_USER MONGODB_PASSWORD MONGODB_DATABASE MONGODB_ADMIN_PASSWORD
-}
-
 function cleanup() {
   echo "=> Shutting down MongoDB server ..."
   if pgrep mongod; then
@@ -66,5 +61,7 @@ fi
 # Restart the MongoDB daemon to bind on all interfaces
 mongod $mongo_common_args --shutdown
 wait_for_mongo_down
-unset_env_vars
+
+# Make sure env variables don't propagate to mongod process.
+unset MONGODB_USER MONGODB_PASSWORD MONGODB_DATABASE MONGODB_ADMIN_PASSWORD
 exec mongod $mongo_common_args --auth

--- a/2.6/root/usr/bin/run-mongod-replication
+++ b/2.6/root/usr/bin/run-mongod-replication
@@ -51,7 +51,7 @@ fi
 # Need to cache the container address for the cleanup
 cache_container_addr
 mongo_common_args="-f $MONGODB_CONFIG_PATH"
-if ! [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE && -v MONGODB_ADMIN_PASSWORD && -v MONGODB_REPLICA_NAME ]]; then
+if ! [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE && -v MONGODB_ADMIN_PASSWORD && -v MONGODB_KEYFILE_VALUE && -v MONGODB_REPLICA_NAME ]]; then
     usage
 fi
 

--- a/2.6/root/usr/bin/run-mongod-replication
+++ b/2.6/root/usr/bin/run-mongod-replication
@@ -28,11 +28,6 @@ function usage() {
   exit 1
 }
 
-# Make sure env variables don't propagate to mongod process.
-function unset_env_vars() {
-  unset MONGODB_USER MONGODB_PASSWORD MONGODB_DATABASE MONGODB_ADMIN_PASSWORD
-}
-
 function cleanup() {
   if [ -n "${MONGODB_REPLICA_NAME-}" ]; then
     mongo_remove
@@ -66,11 +61,12 @@ setup_keyfile
 # Run the supervisor in background to manage replset
 ${CONTAINER_SCRIPTS_PATH}/replset_supervisor.sh "${1:-}" &
 
-# Run `unset_env_vars` and `mongod` in a subshell because
-# MONGODB_ADMIN_PASSWORD should still be defined when the trapped call to
-# `cleanup` references it.
+# Run `mongod` in a subshell because MONGODB_ADMIN_PASSWORD should still be
+# defined when the trapped call to `cleanup` references it.
 (
-  unset_env_vars
+  # Make sure env variables don't propagate to mongod process.
+  unset MONGODB_USER MONGODB_PASSWORD MONGODB_DATABASE MONGODB_ADMIN_PASSWORD
+
   mongod $mongo_common_args --replSet "${MONGODB_REPLICA_NAME}"
 ) &
 wait

--- a/3.0-upg/root/usr/bin/run-mongod
+++ b/3.0-upg/root/usr/bin/run-mongod
@@ -19,11 +19,6 @@ function usage() {
   exit 1
 }
 
-# Make sure env variables don't propagate to mongod process.
-function unset_env_vars() {
-  unset MONGODB_USER MONGODB_PASSWORD MONGODB_DATABASE MONGODB_ADMIN_PASSWORD
-}
-
 function cleanup() {
   echo "=> Shutting down MongoDB server ..."
   if pgrep mongod; then
@@ -74,5 +69,7 @@ fi
 # Restart the MongoDB daemon to bind on all interfaces
 mongod $mongo_common_args --shutdown
 wait_for_mongo_down
-unset_env_vars
+
+# Make sure env variables don't propagate to mongod process.
+unset MONGODB_USER MONGODB_PASSWORD MONGODB_DATABASE MONGODB_ADMIN_PASSWORD
 exec mongod $mongo_common_args --auth

--- a/3.0-upg/root/usr/bin/run-mongod-replication
+++ b/3.0-upg/root/usr/bin/run-mongod-replication
@@ -51,7 +51,7 @@ fi
 # Need to cache the container address for the cleanup
 cache_container_addr
 mongo_common_args="-f $MONGODB_CONFIG_PATH"
-if ! [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE && -v MONGODB_ADMIN_PASSWORD && -v MONGODB_REPLICA_NAME ]]; then
+if ! [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE && -v MONGODB_ADMIN_PASSWORD && -v MONGODB_KEYFILE_VALUE && -v MONGODB_REPLICA_NAME ]]; then
     usage
 fi
 

--- a/3.0-upg/root/usr/bin/run-mongod-replication
+++ b/3.0-upg/root/usr/bin/run-mongod-replication
@@ -28,11 +28,6 @@ function usage() {
   exit 1
 }
 
-# Make sure env variables don't propagate to mongod process.
-function unset_env_vars() {
-  unset MONGODB_USER MONGODB_PASSWORD MONGODB_DATABASE MONGODB_ADMIN_PASSWORD
-}
-
 function cleanup() {
   if [ -n "${MONGODB_REPLICA_NAME-}" ]; then
     mongo_remove
@@ -66,11 +61,12 @@ setup_keyfile
 # Run the supervisor in background to manage replset
 ${CONTAINER_SCRIPTS_PATH}/replset_supervisor.sh "${1:-}" &
 
-# Run `unset_env_vars` and `mongod` in a subshell because
-# MONGODB_ADMIN_PASSWORD should still be defined when the trapped call to
-# `cleanup` references it.
+# Run `mongod` in a subshell because MONGODB_ADMIN_PASSWORD should still be
+# defined when the trapped call to `cleanup` references it.
 (
-  unset_env_vars
+  # Make sure env variables don't propagate to mongod process.
+  unset MONGODB_USER MONGODB_PASSWORD MONGODB_DATABASE MONGODB_ADMIN_PASSWORD
+
   mongod $mongo_common_args --replSet "${MONGODB_REPLICA_NAME}"
 ) &
 wait

--- a/3.2/root/usr/bin/run-mongod
+++ b/3.2/root/usr/bin/run-mongod
@@ -19,11 +19,6 @@ function usage() {
   exit 1
 }
 
-# Make sure env variables don't propagate to mongod process.
-function unset_env_vars() {
-  unset MONGODB_USER MONGODB_PASSWORD MONGODB_DATABASE MONGODB_ADMIN_PASSWORD
-}
-
 function cleanup() {
   echo "=> Shutting down MongoDB server ..."
   if pgrep mongod; then
@@ -66,5 +61,7 @@ fi
 # Restart the MongoDB daemon to bind on all interfaces
 mongod $mongo_common_args --shutdown
 wait_for_mongo_down
-unset_env_vars
+
+# Make sure env variables don't propagate to mongod process.
+unset MONGODB_USER MONGODB_PASSWORD MONGODB_DATABASE MONGODB_ADMIN_PASSWORD
 exec mongod $mongo_common_args --auth

--- a/3.2/root/usr/bin/run-mongod-replication
+++ b/3.2/root/usr/bin/run-mongod-replication
@@ -51,7 +51,7 @@ fi
 # Need to cache the container address for the cleanup
 cache_container_addr
 mongo_common_args="-f $MONGODB_CONFIG_PATH"
-if ! [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE && -v MONGODB_ADMIN_PASSWORD && -v MONGODB_REPLICA_NAME ]]; then
+if ! [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE && -v MONGODB_ADMIN_PASSWORD && -v MONGODB_KEYFILE_VALUE && -v MONGODB_REPLICA_NAME ]]; then
     usage
 fi
 

--- a/3.2/root/usr/bin/run-mongod-replication
+++ b/3.2/root/usr/bin/run-mongod-replication
@@ -28,11 +28,6 @@ function usage() {
   exit 1
 }
 
-# Make sure env variables don't propagate to mongod process.
-function unset_env_vars() {
-  unset MONGODB_USER MONGODB_PASSWORD MONGODB_DATABASE MONGODB_ADMIN_PASSWORD
-}
-
 function cleanup() {
   if [ -n "${MONGODB_REPLICA_NAME-}" ]; then
     mongo_remove
@@ -66,11 +61,12 @@ setup_keyfile
 # Run the supervisor in background to manage replset
 ${CONTAINER_SCRIPTS_PATH}/replset_supervisor.sh "${1:-}" &
 
-# Run `unset_env_vars` and `mongod` in a subshell because
-# MONGODB_ADMIN_PASSWORD should still be defined when the trapped call to
-# `cleanup` references it.
+# Run `mongod` in a subshell because MONGODB_ADMIN_PASSWORD should still be
+# defined when the trapped call to `cleanup` references it.
 (
-  unset_env_vars
+  # Make sure env variables don't propagate to mongod process.
+  unset MONGODB_USER MONGODB_PASSWORD MONGODB_DATABASE MONGODB_ADMIN_PASSWORD
+
   mongod $mongo_common_args --replSet "${MONGODB_REPLICA_NAME}"
 ) &
 wait


### PR DESCRIPTION
- `run-mongod-replication(unset_env_vars)`: inline function
- `run-mongod(unset_env_vars)`: inline function
- `run-mongod-replication`: fail fast if `MONGODB_KEYFILE_VALUE` isn't defined

PTAL @bparees @omron93
