### PR TITLE
Improve error reporting

### DIFF
--- a/2.4/root/usr/share/container-scripts/mongodb/common.sh
+++ b/2.4/root/usr/share/container-scripts/mongodb/common.sh
@@ -44,7 +44,7 @@ function cache_container_addr() {
     fi
     sleep $SLEEP_TIME
   done
-  echo "Failed to get Docker container IP address." && exit 1
+  echo >&2 "Failed to get Docker container IP address." && exit 1
 }
 
 # wait_for_mongo_up waits until the mongo server accepts incomming connections
@@ -174,14 +174,14 @@ function mongo_add() {
 # $2 - host where to connect (localhost by default)
 function mongo_create_admin() {
   if [[ -z "${MONGODB_ADMIN_PASSWORD:-}" ]]; then
-    echo "=> MONGODB_ADMIN_PASSWORD is not set. Authentication can not be set up."
+    echo >&2 "=> MONGODB_ADMIN_PASSWORD is not set. Authentication can not be set up."
     exit 1
   fi
 
   # Set admin password
   local js_command="db.addUser({user: 'admin', pwd: '${MONGODB_ADMIN_PASSWORD}', roles: ['dbAdminAnyDatabase', 'userAdminAnyDatabase' , 'readWriteAnyDatabase','clusterAdmin' ]});"
   if ! mongo admin ${1:-} --host ${2:-"localhost"} --eval "${js_command}"; then
-    echo "=> Failed to create MongoDB admin user."
+    echo >&2 "=> Failed to create MongoDB admin user."
     exit 1
   fi
 }
@@ -193,22 +193,22 @@ function mongo_create_admin() {
 function mongo_create_user() {
   # Ensure input variables exists
   if [[ -z "${MONGODB_USER:-}" ]]; then
-    echo "=> MONGODB_USER is not set. Failed to create MongoDB user"
+    echo >&2 "=> MONGODB_USER is not set. Failed to create MongoDB user"
     exit 1
   fi
   if [[ -z "${MONGODB_PASSWORD:-}" ]]; then
-    echo "=> MONGODB_PASSWORD is not set. Failed to create MongoDB user: ${MONGODB_USER}"
+    echo >&2 "=> MONGODB_PASSWORD is not set. Failed to create MongoDB user: ${MONGODB_USER}"
     exit 1
   fi
   if [[ -z "${MONGODB_DATABASE:-}" ]]; then
-    echo "=> MONGODB_DATABASE is not set. Failed to create MongoDB user: ${MONGODB_USER}"
+    echo >&2 "=> MONGODB_DATABASE is not set. Failed to create MongoDB user: ${MONGODB_USER}"
     exit 1
   fi
 
   # Create database user
   local js_command="db.getSiblingDB('${MONGODB_DATABASE}').addUser({user: '${MONGODB_USER}', pwd: '${MONGODB_PASSWORD}', roles: [ 'readWrite' ]});"
   if ! mongo admin ${1:-} --host ${2:-"localhost"} --eval "${js_command}"; then
-    echo "=> Failed to create MongoDB user: ${MONGODB_USER}"
+    echo >&2 "=> Failed to create MongoDB user: ${MONGODB_USER}"
     exit 1
   fi
 }
@@ -218,7 +218,7 @@ function mongo_reset_user() {
   if [[ -n "${MONGODB_USER:-}" && -n "${MONGODB_PASSWORD:-}" && -n "${MONGODB_DATABASE:-}" ]]; then
     local js_command="db.changeUserPassword('${MONGODB_USER}', '${MONGODB_PASSWORD}')"
     if ! mongo ${MONGODB_DATABASE} --eval "${js_command}"; then
-      echo "=> Failed to reset password of MongoDB user: ${MONGODB_USER}"
+      echo >&2 "=> Failed to reset password of MongoDB user: ${MONGODB_USER}"
       exit 1
     fi
   fi
@@ -229,7 +229,7 @@ function mongo_reset_admin() {
   if [[ -n "${MONGODB_ADMIN_PASSWORD:-}" ]]; then
     local js_command="db.changeUserPassword('admin', '${MONGODB_ADMIN_PASSWORD}')"
     if ! mongo admin --eval "${js_command}"; then
-      echo "=> Failed to reset password of MongoDB user: ${MONGODB_USER}"
+      echo >&2 "=> Failed to reset password of MongoDB user: ${MONGODB_USER}"
       exit 1
     fi
   fi
@@ -244,7 +244,7 @@ function setup_keyfile() {
     exit 0
   fi
   if [ -z "${MONGODB_KEYFILE_VALUE-}" ]; then
-    echo "ERROR: You have to provide the 'keyfile' value in MONGODB_KEYFILE_VALUE"
+    echo >&2 "ERROR: You have to provide the 'keyfile' value in MONGODB_KEYFILE_VALUE"
     exit 1
   fi
   local keyfile_dir

--- a/2.4/root/usr/share/container-scripts/mongodb/common.sh
+++ b/2.4/root/usr/share/container-scripts/mongodb/common.sh
@@ -247,6 +247,15 @@ function setup_keyfile() {
     echo "ERROR: You have to provide the 'keyfile' value in MONGODB_KEYFILE_VALUE"
     exit 1
   fi
+  local keyfile_dir
+  keyfile_dir="$(dirname "$MONGODB_KEYFILE_PATH")"
+  if [ ! -w "$keyfile_dir" ]; then
+    echo >&2 "ERROR: Couldn't create ${MONGODB_KEYFILE_PATH}"
+    echo >&2 "CAUSE: current user doesn't have permissions for writing to ${keyfile_dir} directory"
+    echo >&2 "DETAILS: current user id = $(id -u), user groups: $(id -G)"
+    echo >&2 "DETAILS: directory permissions: $(stat -c '%A owned by %u:%g' "${keyfile_dir}")"
+    exit 1
+  fi
   echo ${MONGODB_KEYFILE_VALUE} > ${MONGODB_KEYFILE_PATH}
   chmod 0600 ${MONGODB_KEYFILE_PATH}
   mongo_common_args+=" --keyFile ${MONGODB_KEYFILE_PATH}"

--- a/2.6/root/usr/share/container-scripts/mongodb/common.sh
+++ b/2.6/root/usr/share/container-scripts/mongodb/common.sh
@@ -43,7 +43,7 @@ function cache_container_addr() {
     fi
     sleep $SLEEP_TIME
   done
-  echo "Failed to get Docker container IP address." && exit 1
+  echo >&2 "Failed to get Docker container IP address." && exit 1
 }
 
 # wait_for_mongo_up waits until the mongo server accepts incomming connections
@@ -173,14 +173,14 @@ function mongo_add() {
 # $2 - host where to connect (localhost by default)
 function mongo_create_admin() {
   if [[ -z "${MONGODB_ADMIN_PASSWORD:-}" ]]; then
-    echo "=> MONGODB_ADMIN_PASSWORD is not set. Authentication can not be set up."
+    echo >&2 "=> MONGODB_ADMIN_PASSWORD is not set. Authentication can not be set up."
     exit 1
   fi
 
   # Set admin password
   local js_command="db.createUser({user: 'admin', pwd: '${MONGODB_ADMIN_PASSWORD}', roles: ['dbAdminAnyDatabase', 'userAdminAnyDatabase' , 'readWriteAnyDatabase','clusterAdmin' ]});"
   if ! mongo admin ${1:-} --host ${2:-"localhost"} --eval "${js_command}"; then
-    echo "=> Failed to create MongoDB admin user."
+    echo >&2 "=> Failed to create MongoDB admin user."
     exit 1
   fi
 }
@@ -192,22 +192,22 @@ function mongo_create_admin() {
 function mongo_create_user() {
   # Ensure input variables exists
   if [[ -z "${MONGODB_USER:-}" ]]; then
-    echo "=> MONGODB_USER is not set. Failed to create MongoDB user"
+    echo >&2 "=> MONGODB_USER is not set. Failed to create MongoDB user"
     exit 1
   fi
   if [[ -z "${MONGODB_PASSWORD:-}" ]]; then
     echo "=> MONGODB_PASSWORD is not set. Failed to create MongoDB user: ${MONGODB_USER}"
-    exit 1
+    exit >&2 1
   fi
   if [[ -z "${MONGODB_DATABASE:-}" ]]; then
-    echo "=> MONGODB_DATABASE is not set. Failed to create MongoDB user: ${MONGODB_USER}"
+    echo >&2 "=> MONGODB_DATABASE is not set. Failed to create MongoDB user: ${MONGODB_USER}"
     exit 1
   fi
 
   # Create database user
   local js_command="db.getSiblingDB('${MONGODB_DATABASE}').createUser({user: '${MONGODB_USER}', pwd: '${MONGODB_PASSWORD}', roles: [ 'readWrite' ]});"
   if ! mongo admin ${1:-} --host ${2:-"localhost"} --eval "${js_command}"; then
-    echo "=> Failed to create MongoDB user: ${MONGODB_USER}"
+    echo >&2 "=> Failed to create MongoDB user: ${MONGODB_USER}"
     exit 1
   fi
 }
@@ -217,7 +217,7 @@ function mongo_reset_user() {
   if [[ -n "${MONGODB_USER:-}" && -n "${MONGODB_PASSWORD:-}" && -n "${MONGODB_DATABASE:-}" ]]; then
     local js_command="db.changeUserPassword('${MONGODB_USER}', '${MONGODB_PASSWORD}')"
     if ! mongo ${MONGODB_DATABASE} --eval "${js_command}"; then
-      echo "=> Failed to reset password of MongoDB user: ${MONGODB_USER}"
+      echo >&2 "=> Failed to reset password of MongoDB user: ${MONGODB_USER}"
       exit 1
     fi
   fi
@@ -228,7 +228,7 @@ function mongo_reset_admin() {
   if [[ -n "${MONGODB_ADMIN_PASSWORD:-}" ]]; then
     local js_command="db.changeUserPassword('admin', '${MONGODB_ADMIN_PASSWORD}')"
     if ! mongo admin --eval "${js_command}"; then
-      echo "=> Failed to reset password of MongoDB user: ${MONGODB_USER}"
+      echo >&2 "=> Failed to reset password of MongoDB user: ${MONGODB_USER}"
       exit 1
     fi
   fi
@@ -243,7 +243,7 @@ function setup_keyfile() {
     exit 0
   fi
   if [ -z "${MONGODB_KEYFILE_VALUE-}" ]; then
-    echo "ERROR: You have to provide the 'keyfile' value in MONGODB_KEYFILE_VALUE"
+    echo >&2 "ERROR: You have to provide the 'keyfile' value in MONGODB_KEYFILE_VALUE"
     exit 1
   fi
   local keyfile_dir

--- a/2.6/root/usr/share/container-scripts/mongodb/common.sh
+++ b/2.6/root/usr/share/container-scripts/mongodb/common.sh
@@ -246,6 +246,15 @@ function setup_keyfile() {
     echo "ERROR: You have to provide the 'keyfile' value in MONGODB_KEYFILE_VALUE"
     exit 1
   fi
+  local keyfile_dir
+  keyfile_dir="$(dirname "$MONGODB_KEYFILE_PATH")"
+  if [ ! -w "$keyfile_dir" ]; then
+    echo >&2 "ERROR: Couldn't create ${MONGODB_KEYFILE_PATH}"
+    echo >&2 "CAUSE: current user doesn't have permissions for writing to ${keyfile_dir} directory"
+    echo >&2 "DETAILS: current user id = $(id -u), user groups: $(id -G)"
+    echo >&2 "DETAILS: directory permissions: $(stat -c '%A owned by %u:%g' "${keyfile_dir}")"
+    exit 1
+  fi
   echo ${MONGODB_KEYFILE_VALUE} > ${MONGODB_KEYFILE_PATH}
   chmod 0600 ${MONGODB_KEYFILE_PATH}
   mongo_common_args+=" --keyFile ${MONGODB_KEYFILE_PATH}"

--- a/3.0-upg/root/usr/share/container-scripts/mongodb/common.sh
+++ b/3.0-upg/root/usr/share/container-scripts/mongodb/common.sh
@@ -43,7 +43,7 @@ function cache_container_addr() {
     fi
     sleep $SLEEP_TIME
   done
-  echo "Failed to get Docker container IP address." && exit 1
+  echo >&2 "Failed to get Docker container IP address." && exit 1
 }
 
 # wait_for_mongo_up waits until the mongo server accepts incomming connections
@@ -173,14 +173,14 @@ function mongo_add() {
 # $2 - host where to connect (localhost by default)
 function mongo_create_admin() {
   if [[ -z "${MONGODB_ADMIN_PASSWORD:-}" ]]; then
-    echo "=> MONGODB_ADMIN_PASSWORD is not set. Authentication can not be set up."
+    echo >&2 "=> MONGODB_ADMIN_PASSWORD is not set. Authentication can not be set up."
     exit 1
   fi
 
   # Set admin password
   local js_command="db.createUser({user: 'admin', pwd: '${MONGODB_ADMIN_PASSWORD}', roles: ['dbAdminAnyDatabase', 'userAdminAnyDatabase' , 'readWriteAnyDatabase','clusterAdmin' ]});"
   if ! mongo admin ${1:-} --host ${2:-"localhost"} --eval "${js_command}"; then
-    echo "=> Failed to create MongoDB admin user."
+    echo >&2 "=> Failed to create MongoDB admin user."
     exit 1
   fi
 }
@@ -192,22 +192,22 @@ function mongo_create_admin() {
 function mongo_create_user() {
   # Ensure input variables exists
   if [[ -z "${MONGODB_USER:-}" ]]; then
-    echo "=> MONGODB_USER is not set. Failed to create MongoDB user"
+    echo >&2 "=> MONGODB_USER is not set. Failed to create MongoDB user"
     exit 1
   fi
   if [[ -z "${MONGODB_PASSWORD:-}" ]]; then
     echo "=> MONGODB_PASSWORD is not set. Failed to create MongoDB user: ${MONGODB_USER}"
-    exit 1
+    exit >&2 1
   fi
   if [[ -z "${MONGODB_DATABASE:-}" ]]; then
-    echo "=> MONGODB_DATABASE is not set. Failed to create MongoDB user: ${MONGODB_USER}"
+    echo >&2 "=> MONGODB_DATABASE is not set. Failed to create MongoDB user: ${MONGODB_USER}"
     exit 1
   fi
 
   # Create database user
   local js_command="db.getSiblingDB('${MONGODB_DATABASE}').createUser({user: '${MONGODB_USER}', pwd: '${MONGODB_PASSWORD}', roles: [ 'readWrite' ]});"
   if ! mongo admin ${1:-} --host ${2:-"localhost"} --eval "${js_command}"; then
-    echo "=> Failed to create MongoDB user: ${MONGODB_USER}"
+    echo >&2 "=> Failed to create MongoDB user: ${MONGODB_USER}"
     exit 1
   fi
 }
@@ -217,7 +217,7 @@ function mongo_reset_user() {
   if [[ -n "${MONGODB_USER:-}" && -n "${MONGODB_PASSWORD:-}" && -n "${MONGODB_DATABASE:-}" ]]; then
     local js_command="db.changeUserPassword('${MONGODB_USER}', '${MONGODB_PASSWORD}')"
     if ! mongo ${MONGODB_DATABASE} --eval "${js_command}"; then
-      echo "=> Failed to reset password of MongoDB user: ${MONGODB_USER}"
+      echo >&2 "=> Failed to reset password of MongoDB user: ${MONGODB_USER}"
       exit 1
     fi
   fi
@@ -228,7 +228,7 @@ function mongo_reset_admin() {
   if [[ -n "${MONGODB_ADMIN_PASSWORD:-}" ]]; then
     local js_command="db.changeUserPassword('admin', '${MONGODB_ADMIN_PASSWORD}')"
     if ! mongo admin --eval "${js_command}"; then
-      echo "=> Failed to reset password of MongoDB user: ${MONGODB_USER}"
+      echo >&2 "=> Failed to reset password of MongoDB user: ${MONGODB_USER}"
       exit 1
     fi
   fi
@@ -243,7 +243,7 @@ function setup_keyfile() {
     exit 0
   fi
   if [ -z "${MONGODB_KEYFILE_VALUE-}" ]; then
-    echo "ERROR: You have to provide the 'keyfile' value in MONGODB_KEYFILE_VALUE"
+    echo >&2 "ERROR: You have to provide the 'keyfile' value in MONGODB_KEYFILE_VALUE"
     exit 1
   fi
   local keyfile_dir

--- a/3.0-upg/root/usr/share/container-scripts/mongodb/common.sh
+++ b/3.0-upg/root/usr/share/container-scripts/mongodb/common.sh
@@ -246,6 +246,15 @@ function setup_keyfile() {
     echo "ERROR: You have to provide the 'keyfile' value in MONGODB_KEYFILE_VALUE"
     exit 1
   fi
+  local keyfile_dir
+  keyfile_dir="$(dirname "$MONGODB_KEYFILE_PATH")"
+  if [ ! -w "$keyfile_dir" ]; then
+    echo >&2 "ERROR: Couldn't create ${MONGODB_KEYFILE_PATH}"
+    echo >&2 "CAUSE: current user doesn't have permissions for writing to ${keyfile_dir} directory"
+    echo >&2 "DETAILS: current user id = $(id -u), user groups: $(id -G)"
+    echo >&2 "DETAILS: directory permissions: $(stat -c '%A owned by %u:%g' "${keyfile_dir}")"
+    exit 1
+  fi
   echo ${MONGODB_KEYFILE_VALUE} > ${MONGODB_KEYFILE_PATH}
   chmod 0600 ${MONGODB_KEYFILE_PATH}
   mongo_common_args+=" --keyFile ${MONGODB_KEYFILE_PATH}"

--- a/3.2/root/usr/share/container-scripts/mongodb/common.sh
+++ b/3.2/root/usr/share/container-scripts/mongodb/common.sh
@@ -43,7 +43,7 @@ function cache_container_addr() {
     fi
     sleep $SLEEP_TIME
   done
-  echo "Failed to get Docker container IP address." && exit 1
+  echo >&2 "Failed to get Docker container IP address." && exit 1
 }
 
 # wait_for_mongo_up waits until the mongo server accepts incomming connections
@@ -173,14 +173,14 @@ function mongo_add() {
 # $2 - host where to connect (localhost by default)
 function mongo_create_admin() {
   if [[ -z "${MONGODB_ADMIN_PASSWORD:-}" ]]; then
-    echo "=> MONGODB_ADMIN_PASSWORD is not set. Authentication can not be set up."
+    echo >&2 "=> MONGODB_ADMIN_PASSWORD is not set. Authentication can not be set up."
     exit 1
   fi
 
   # Set admin password
   local js_command="db.createUser({user: 'admin', pwd: '${MONGODB_ADMIN_PASSWORD}', roles: ['dbAdminAnyDatabase', 'userAdminAnyDatabase' , 'readWriteAnyDatabase','clusterAdmin' ]});"
   if ! mongo admin ${1:-} --host ${2:-"localhost"} --eval "${js_command}"; then
-    echo "=> Failed to create MongoDB admin user."
+    echo >&2 "=> Failed to create MongoDB admin user."
     exit 1
   fi
 }
@@ -192,22 +192,22 @@ function mongo_create_admin() {
 function mongo_create_user() {
   # Ensure input variables exists
   if [[ -z "${MONGODB_USER:-}" ]]; then
-    echo "=> MONGODB_USER is not set. Failed to create MongoDB user"
+    echo >&2 "=> MONGODB_USER is not set. Failed to create MongoDB user"
     exit 1
   fi
   if [[ -z "${MONGODB_PASSWORD:-}" ]]; then
     echo "=> MONGODB_PASSWORD is not set. Failed to create MongoDB user: ${MONGODB_USER}"
-    exit 1
+    exit >&2 1
   fi
   if [[ -z "${MONGODB_DATABASE:-}" ]]; then
-    echo "=> MONGODB_DATABASE is not set. Failed to create MongoDB user: ${MONGODB_USER}"
+    echo >&2 "=> MONGODB_DATABASE is not set. Failed to create MongoDB user: ${MONGODB_USER}"
     exit 1
   fi
 
   # Create database user
   local js_command="db.getSiblingDB('${MONGODB_DATABASE}').createUser({user: '${MONGODB_USER}', pwd: '${MONGODB_PASSWORD}', roles: [ 'readWrite' ]});"
   if ! mongo admin ${1:-} --host ${2:-"localhost"} --eval "${js_command}"; then
-    echo "=> Failed to create MongoDB user: ${MONGODB_USER}"
+    echo >&2 "=> Failed to create MongoDB user: ${MONGODB_USER}"
     exit 1
   fi
 }
@@ -217,7 +217,7 @@ function mongo_reset_user() {
   if [[ -n "${MONGODB_USER:-}" && -n "${MONGODB_PASSWORD:-}" && -n "${MONGODB_DATABASE:-}" ]]; then
     local js_command="db.changeUserPassword('${MONGODB_USER}', '${MONGODB_PASSWORD}')"
     if ! mongo ${MONGODB_DATABASE} --eval "${js_command}"; then
-      echo "=> Failed to reset password of MongoDB user: ${MONGODB_USER}"
+      echo >&2 "=> Failed to reset password of MongoDB user: ${MONGODB_USER}"
       exit 1
     fi
   fi
@@ -228,7 +228,7 @@ function mongo_reset_admin() {
   if [[ -n "${MONGODB_ADMIN_PASSWORD:-}" ]]; then
     local js_command="db.changeUserPassword('admin', '${MONGODB_ADMIN_PASSWORD}')"
     if ! mongo admin --eval "${js_command}"; then
-      echo "=> Failed to reset password of MongoDB user: ${MONGODB_USER}"
+      echo >&2 "=> Failed to reset password of MongoDB user: ${MONGODB_USER}"
       exit 1
     fi
   fi
@@ -243,7 +243,7 @@ function setup_keyfile() {
     exit 0
   fi
   if [ -z "${MONGODB_KEYFILE_VALUE-}" ]; then
-    echo "ERROR: You have to provide the 'keyfile' value in MONGODB_KEYFILE_VALUE"
+    echo >&2 "ERROR: You have to provide the 'keyfile' value in MONGODB_KEYFILE_VALUE"
     exit 1
   fi
   local keyfile_dir

--- a/3.2/root/usr/share/container-scripts/mongodb/common.sh
+++ b/3.2/root/usr/share/container-scripts/mongodb/common.sh
@@ -246,6 +246,15 @@ function setup_keyfile() {
     echo "ERROR: You have to provide the 'keyfile' value in MONGODB_KEYFILE_VALUE"
     exit 1
   fi
+  local keyfile_dir
+  keyfile_dir="$(dirname "$MONGODB_KEYFILE_PATH")"
+  if [ ! -w "$keyfile_dir" ]; then
+    echo >&2 "ERROR: Couldn't create ${MONGODB_KEYFILE_PATH}"
+    echo >&2 "CAUSE: current user doesn't have permissions for writing to ${keyfile_dir} directory"
+    echo >&2 "DETAILS: current user id = $(id -u), user groups: $(id -G)"
+    echo >&2 "DETAILS: directory permissions: $(stat -c '%A owned by %u:%g' "${keyfile_dir}")"
+    exit 1
+  fi
   echo ${MONGODB_KEYFILE_VALUE} > ${MONGODB_KEYFILE_PATH}
   chmod 0600 ${MONGODB_KEYFILE_PATH}
   mongo_common_args+=" --keyFile ${MONGODB_KEYFILE_PATH}"


### PR DESCRIPTION
- show detailed error message when MongoDB home directory isn't writable.
  Before:

``` console
$ oc logs po/mongodb-0
/usr/share/container-scripts/mongodb/common.sh: line 250: /var/lib/mongodb/keyfile: Permission denied
```

After:

``` console
$ oc logs po/mongodb-0
ERROR: Couldn't create /var/lib/mongodb/keyfile
CAUSE: current user doesn't have permissions for writing to /var/lib/mongodb directory
DETAILS: current user id = 1000040000, user groups: 0 1000040000
DETAILS: directory permissions: drwxrwxr-x owned by 1000:1000
```
- print errors into stderr

PTAL @bparees @omron93 @rhcarvalho 
