### PR TITLE
Kill mongod processes ignoring errors

### DIFF
--- a/2.4/root/usr/bin/run-mongod
+++ b/2.4/root/usr/bin/run-mongod
@@ -21,9 +21,7 @@ function usage() {
 
 function cleanup() {
   echo "=> Shutting down MongoDB server ..."
-  if pgrep mongod; then
-    pkill -2 mongod
-  fi
+  pkill -INT mongod || :
   wait_for_mongo_down
   exit 0
 }

--- a/2.6/root/usr/bin/run-mongod
+++ b/2.6/root/usr/bin/run-mongod
@@ -21,9 +21,7 @@ function usage() {
 
 function cleanup() {
   echo "=> Shutting down MongoDB server ..."
-  if pgrep mongod; then
-    pkill -2 mongod
-  fi
+  pkill -INT mongod || :
   wait_for_mongo_down
   exit 0
 }

--- a/3.0-upg/root/usr/bin/run-mongod
+++ b/3.0-upg/root/usr/bin/run-mongod
@@ -21,9 +21,7 @@ function usage() {
 
 function cleanup() {
   echo "=> Shutting down MongoDB server ..."
-  if pgrep mongod; then
-    pkill -2 mongod
-  fi
+  pkill -INT mongod || :
   wait_for_mongo_down
   exit 0
 }

--- a/3.2/root/usr/bin/run-mongod
+++ b/3.2/root/usr/bin/run-mongod
@@ -21,9 +21,7 @@ function usage() {
 
 function cleanup() {
   echo "=> Shutting down MongoDB server ..."
-  if pgrep mongod; then
-    pkill -2 mongod
-  fi
+  pkill -INT mongod || :
   wait_for_mongo_down
   exit 0
 }


### PR DESCRIPTION
Problems with previous approach:
- pgrep might find processes, but there is no guarantee pkill will not
  fail for any other reason (e.g. there is a race condition in which
  mongod is terminating, pgrep finds a PID, but pkill doesn't). If pkill
  returns non-zero exit code, the rest of the cleanup function is not
  executed.
- could be fixed in a different way, but for now pgrep was
  unnecessarily spitting out PIDs to stdout.
