### PR TITLE
Optimize Dockerfile for cache usage

### DIFF
--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -11,15 +11,27 @@ MAINTAINER SoftwareCollections.org <sclorg@redhat.com>
 #  * $MONGODB_DATABASE - Name of the database to create
 #  * $MONGODB_ADMIN_PASSWORD - Password of the MongoDB Admin
 
-ENV MONGODB_VERSION=3.2 \
-    HOME=/var/lib/mongodb
-
 LABEL io.k8s.description="MongoDB is a scalable, high-performance, open source NoSQL database." \
       io.k8s.display-name="MongoDB 3.2" \
       io.openshift.expose-services="27017:mongodb" \
       io.openshift.tags="database,mongodb,rh-mongodb32"
 
+ENV MONGODB_VERSION=3.2 \
+    # Set paths to avoid hard-coding them in scripts.
+    HOME=/var/lib/mongodb \
+    CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mongodb \
+    MONGODB_PREFIX=/opt/rh/rh-mongodb32/root/usr \
+    # Incantations to enable Software Collections on `bash` and `sh -i`.
+    ENABLED_COLLECTIONS=rh-mongodb32 \
+    BASH_ENV="\${CONTAINER_SCRIPTS_PATH}/scl_enable" \
+    ENV="\${CONTAINER_SCRIPTS_PATH}/scl_enable" \
+    PROMPT_COMMAND=". \${CONTAINER_SCRIPTS_PATH}/scl_enable"
+
 EXPOSE 27017
+
+
+ENTRYPOINT ["container-entrypoint"]
+CMD ["run-mongod"]
 
 # Due to the https://bugzilla.redhat.com/show_bug.cgi?id=1206151,
 # the whole /var/lib/mongodb/ dir has to be chown-ed.
@@ -33,26 +45,11 @@ RUN yum install -y centos-release-scl && \
     chmod g+w -R /var/opt/rh/rh-mongodb32/lib/mongodb && \
     chmod -R g+rwx /var/lib/mongodb
 
-# Get prefix path and path to scripts rather than hard-code them in scripts
-ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mongodb \
-    MONGODB_PREFIX=/opt/rh/rh-mongodb32/root/usr \
-    ENABLED_COLLECTIONS=rh-mongodb32
-
-# When bash is started non-interactively, to run a shell script, for example it
-# looks for this variable and source the content of this file. This will enable
-# the SCL for all scripts without need to do 'scl enable'.
-ENV BASH_ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
-    ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
-    PROMPT_COMMAND=". ${CONTAINER_SCRIPTS_PATH}/scl_enable"
+VOLUME ["/var/lib/mongodb/data"]
 
 ADD root /
 
 # Container setup
 RUN touch /etc/mongod.conf && chown mongodb:0 /etc/mongod.conf && /usr/libexec/fix-permissions /etc/mongod.conf
 
-VOLUME ["/var/lib/mongodb/data"]
-
 USER 184
-
-ENTRYPOINT ["container-entrypoint"]
-CMD ["run-mongod"]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,43 @@
 
 This guide aims to help developers working on this repository.
 
+## Making changes to runtime scripts
+
+The Docker images created from this repository contain several runtime scripts
+that are executed from the image entrypoint / default command. These scripts are
+located under `${IMAGE_VERSION}/root/`.
+
+As a suggestion, start making changes to files of a single image version, e.g.,
+the latest one, and then run tests for that image:
+
+```bash
+make test VERSION=3.2 SKIP_SQUASH=1
+```
+
+By default, the last step in the image build process is to squash the output
+image into less layers, optimizing image size for distribution. However, unless
+specifically testing that this squash process is working, you don't need to
+squash images in development, and can save some precious time with consecutive
+rebuilds as you work in the image contents.
+
+The `SKIP_SQUASH=1` option disables image squashing, so that building and
+rebuilding images locally should take less time.
+
+Setting `VERSION=3.2` equally saves development time. Instead of building every
+image version, only the version you are working on will be built.
+
+The tests run via `make test` cover some basic usage patterns of the images.
+Often times, some manual testing is required while making changes to the scripts
+that are copied into the images. For instance, you can build and rebuild a
+specific image (without running tests) with this command:
+
+```bash
+make VERSION=3.2 SKIP_SQUASH=1
+```
+
+When you are done with your changes, you probably want to [change all other
+image versions without copy-paste](#changing-all-images-without-copy-paste).
+
 ## Changing all images without copy-paste
 
 We keep the multiple files for the different image versions in sync. Here is a


### PR DESCRIPTION
Saves lots of developer time running `make` / `docker build`, by
reordering instructions to better use the cache when we make changes to
scripts, and also reduce number of layers leading to a smaller time to
build.

For instance, a developer might run the command below multiple times in
a row while making changes to the scripts that are copied into the
image:

```
make VERSION=3.2 SKIP_SQUASH=1
```
