### PR TITLE
Remove call to mongo with no arguments

### DIFF
--- a/2.4/test/run
+++ b/2.4/test/run
@@ -45,11 +45,6 @@ function mongo_admin_cmd() {
     docker run --rm $IMAGE_NAME mongo admin --host $CONTAINER_IP -u admin -p "$ADMIN_PASS" --eval "${@}"
 }
 
-function mongo_cmd_local() {
-    local name="$1" ; shift
-    docker exec $(get_cid $name) bash -c "mongo $@"
-}
-
 function test_connection() {
     local name=$1 ; shift
     CONTAINER_IP=$(get_container_ip $name)
@@ -223,7 +218,6 @@ function run_tests() {
     echo "  Testing scl usage"
     test_scl_usage $name 'mongo --version' '2.4'
     test_mongo $name
-    mongo_cmd_local $name <<< ""
 }
 
 function run_change_password_test() {

--- a/2.6/test/run
+++ b/2.6/test/run
@@ -45,11 +45,6 @@ function mongo_admin_cmd() {
     docker run --rm $IMAGE_NAME mongo admin --host $CONTAINER_IP -u admin -p "$ADMIN_PASS" --eval "${@}"
 }
 
-function mongo_cmd_local() {
-    local name="$1" ; shift
-    docker exec $(get_cid $name) bash -c "mongo $@"
-}
-
 function test_connection() {
     local name=$1 ; shift
     CONTAINER_IP=$(get_container_ip $name)
@@ -208,7 +203,6 @@ function run_tests() {
     echo "  Testing scl usage"
     test_scl_usage $name 'mongo --version' '2.6'
     test_mongo $name
-    mongo_cmd_local $name <<< ""
 }
 
 function run_change_password_test() {

--- a/3.0-upg/test/run
+++ b/3.0-upg/test/run
@@ -45,11 +45,6 @@ function mongo_admin_cmd() {
     docker run --rm $IMAGE_NAME mongo admin --host $CONTAINER_IP -u admin -p "$ADMIN_PASS" --eval "${@}"
 }
 
-function mongo_cmd_local() {
-    local name="$1" ; shift
-    docker exec $(get_cid $name) bash -c "mongo $@"
-}
-
 function test_connection() {
     local name=$1 ; shift
     CONTAINER_IP=$(get_container_ip $name)
@@ -208,7 +203,6 @@ function run_tests() {
     echo "  Testing scl usage"
     test_scl_usage $name 'mongo --version' '3.0'
     test_mongo $name
-    mongo_cmd_local $name <<< ""
 }
 
 function run_change_password_test() {

--- a/3.2/test/run
+++ b/3.2/test/run
@@ -45,11 +45,6 @@ function mongo_admin_cmd() {
     docker run --rm $IMAGE_NAME mongo admin --host $CONTAINER_IP -u admin -p "$ADMIN_PASS" --eval "${@}"
 }
 
-function mongo_cmd_local() {
-    local name="$1" ; shift
-    docker exec $(get_cid $name) bash -c "mongo $@"
-}
-
 function test_connection() {
     local name=$1 ; shift
     CONTAINER_IP=$(get_container_ip $name)
@@ -208,7 +203,6 @@ function run_tests() {
     echo "  Testing scl usage"
     test_scl_usage $name 'mongo --version' '3.2'
     test_mongo $name
-    mongo_cmd_local $name <<< ""
 }
 
 function run_change_password_test() {


### PR DESCRIPTION
This hangs the tests forever if run with Docker 1.12 (tests work fine
with e.g., Docker 1.10).

The code is unnecessary now, as it seems to be a left-over of the
original way to check that SCL was enabled (introduced in #38). Now we
already have specific tests for SCL enablement, executed just two lines
above the line we're removing.
