### PR TITLE
3.2: remove smallfiles and noprealloc options

### DIFF
--- a/3.2/README.md
+++ b/3.2/README.md
@@ -22,7 +22,6 @@ The following environment variables influence the MongoDB configuration file. Th
 
 |    Variable name      |    Description                                                            |    Default
 | :-------------------- | ------------------------------------------------------------------------- | ----------------
-|  `MONGODB_NOPREALLOC` | Disable data file preallocation (only for mounted data directory from older MongoDB server).  |  true
 |  `MONGODB_SMALLFILES` | Set MongoDB to use a smaller default data file size (only for mounted data directory from older MongoDB server).  |  true
 |  `MONGODB_QUIET`      | Runs MongoDB in a quiet mode that attempts to limit the amount of output. |  true
 

--- a/3.2/README.md
+++ b/3.2/README.md
@@ -22,7 +22,6 @@ The following environment variables influence the MongoDB configuration file. Th
 
 |    Variable name      |    Description                                                            |    Default
 | :-------------------- | ------------------------------------------------------------------------- | ----------------
-|  `MONGODB_SMALLFILES` | Set MongoDB to use a smaller default data file size (only for mounted data directory from older MongoDB server).  |  true
 |  `MONGODB_QUIET`      | Runs MongoDB in a quiet mode that attempts to limit the amount of output. |  true
 
 

--- a/3.2/root/usr/bin/run-mongod
+++ b/3.2/root/usr/bin/run-mongod
@@ -13,7 +13,6 @@ function usage() {
   echo "  MONGODB_DATABASE"
   echo "  MONGODB_ADMIN_PASSWORD"
   echo "MongoDB settings:"
-  echo "  MONGODB_SMALLFILES (default: true)"
   echo "  MONGODB_QUIET (default: true)"
   exit 1
 }

--- a/3.2/root/usr/bin/run-mongod
+++ b/3.2/root/usr/bin/run-mongod
@@ -13,7 +13,6 @@ function usage() {
   echo "  MONGODB_DATABASE"
   echo "  MONGODB_ADMIN_PASSWORD"
   echo "MongoDB settings:"
-  echo "  MONGODB_NOPREALLOC (default: true)"
   echo "  MONGODB_SMALLFILES (default: true)"
   echo "  MONGODB_QUIET (default: true)"
   exit 1

--- a/3.2/root/usr/bin/run-mongod-replication
+++ b/3.2/root/usr/bin/run-mongod-replication
@@ -22,7 +22,6 @@ function usage() {
   echo "Optional variables:"
   echo "  MONGODB_INITIAL_REPLICA_COUNT"
   echo "MongoDB settings:"
-  echo "  MONGODB_NOPREALLOC (default: true)"
   echo "  MONGODB_SMALLFILES (default: true)"
   echo "  MONGODB_QUIET (default: true)"
   exit 1

--- a/3.2/root/usr/bin/run-mongod-replication
+++ b/3.2/root/usr/bin/run-mongod-replication
@@ -22,7 +22,6 @@ function usage() {
   echo "Optional variables:"
   echo "  MONGODB_INITIAL_REPLICA_COUNT"
   echo "MongoDB settings:"
-  echo "  MONGODB_SMALLFILES (default: true)"
   echo "  MONGODB_QUIET (default: true)"
   exit 1
 }

--- a/3.2/root/usr/share/container-scripts/mongodb/common.sh
+++ b/3.2/root/usr/share/container-scripts/mongodb/common.sh
@@ -10,7 +10,6 @@ set -o pipefail
 export MONGODB_DATADIR=/var/lib/mongodb/data
 export CONTAINER_PORT=27017
 # Configuration settings.
-export MONGODB_SMALLFILES=${MONGODB_SMALLFILES:-true}
 export MONGODB_QUIET=${MONGODB_QUIET:-true}
 
 MONGODB_CONFIG_PATH=/etc/mongod.conf

--- a/3.2/root/usr/share/container-scripts/mongodb/common.sh
+++ b/3.2/root/usr/share/container-scripts/mongodb/common.sh
@@ -10,7 +10,6 @@ set -o pipefail
 export MONGODB_DATADIR=/var/lib/mongodb/data
 export CONTAINER_PORT=27017
 # Configuration settings.
-export MONGODB_NOPREALLOC=${MONGODB_NOPREALLOC:-true}
 export MONGODB_SMALLFILES=${MONGODB_SMALLFILES:-true}
 export MONGODB_QUIET=${MONGODB_QUIET:-true}
 

--- a/3.2/root/usr/share/container-scripts/mongodb/mongodb.conf.template
+++ b/3.2/root/usr/share/container-scripts/mongodb/mongodb.conf.template
@@ -10,9 +10,9 @@ dbpath = ${MONGODB_DATADIR}
 # only for mounted data directory from older MongoDB server
 noprealloc = true
 
-# Set MongoDB to use a smaller default data file size. Default: true
+# Set MongoDB to use a smaller default data file size.
 # only for mounted data directory from older MongoDB server
-smallfiles = ${MONGODB_SMALLFILES}
+smallfiles = true
 
 # Runs MongoDB in a quiet mode that attempts to limit the amount of output.
 # Default: true

--- a/3.2/root/usr/share/container-scripts/mongodb/mongodb.conf.template
+++ b/3.2/root/usr/share/container-scripts/mongodb/mongodb.conf.template
@@ -6,9 +6,9 @@ port = ${CONTAINER_PORT}
 # Default: /var/lib/mongodb/data
 dbpath = ${MONGODB_DATADIR}
 
-# Disable data file preallocation. Default: true
+# Disable data file preallocation.
 # only for mounted data directory from older MongoDB server
-noprealloc = ${MONGODB_NOPREALLOC}
+noprealloc = true
 
 # Set MongoDB to use a smaller default data file size. Default: true
 # only for mounted data directory from older MongoDB server

--- a/3.2/test/run
+++ b/3.2/test/run
@@ -147,7 +147,6 @@ function test_config_option() {
 
 function run_configuration_tests() {
     echo "  Testing image configuration settings"
-    test_config_option MONGODB_SMALLFILES smallfiles true
     test_config_option MONGODB_QUIET quiet true
     echo "  Success!"
 }
@@ -292,8 +291,7 @@ function run_mount_config_test() {
     chmod a+rwx ${volume_dir}
     config_file=$volume_dir/mongod.conf
     echo "dbpath=/var/lib/mongodb/dbpath
-unixSocketPrefix = /var/lib/mongodb
-smallfiles = true" > $config_file
+unixSocketPrefix = /var/lib/mongodb" > $config_file
     chmod a+r ${config_file}
 
     DOCKER_ARGS="

--- a/3.2/test/run
+++ b/3.2/test/run
@@ -147,7 +147,6 @@ function test_config_option() {
 
 function run_configuration_tests() {
     echo "  Testing image configuration settings"
-    test_config_option MONGODB_NOPREALLOC noprealloc true
     test_config_option MONGODB_SMALLFILES smallfiles true
     test_config_option MONGODB_QUIET quiet true
     echo "  Success!"
@@ -294,8 +293,7 @@ function run_mount_config_test() {
     config_file=$volume_dir/mongod.conf
     echo "dbpath=/var/lib/mongodb/dbpath
 unixSocketPrefix = /var/lib/mongodb
-smallfiles = true
-noprealloc = true" > $config_file
+smallfiles = true" > $config_file
     chmod a+r ${config_file}
 
     DOCKER_ARGS="


### PR DESCRIPTION
Inspired by @omron93 comment in #184: [`Mongodb 3.2 uses wiredTiger storage engine - these options are for old mmapv1 engine`](https://github.com/sclorg/mongodb-container/pull/184#discussion_r82174964)

If this PR will be merged after #184 then it should be updated to also update `run-mongod-pet` script.

PTAL @bparees @rhcarvalho @omron93 
