### PR TITLE
3.2: remove smallfiles and preallocation options from default configuration

### DIFF
--- a/3.2/root/usr/share/container-scripts/mongodb/mongodb.conf.template
+++ b/3.2/root/usr/share/container-scripts/mongodb/mongodb.conf.template
@@ -6,14 +6,6 @@ port = ${CONTAINER_PORT}
 # Default: /var/lib/mongodb/data
 dbpath = ${MONGODB_DATADIR}
 
-# Disable data file preallocation.
-# only for mounted data directory from older MongoDB server
-noprealloc = true
-
-# Set MongoDB to use a smaller default data file size.
-# only for mounted data directory from older MongoDB server
-smallfiles = true
-
 # Runs MongoDB in a quiet mode that attempts to limit the amount of output.
 # Default: true
 quiet = ${MONGODB_QUIET}


### PR DESCRIPTION
We all agreed that we can remove this options completely from the default configuration. If user has data in old format he should provide custom configuration file.

Follow-up to #200

PTAL @bparees 
CC @rhcarvalho @omron93 
