### PR TITLE
Remove differences between init-petset-replset.sh and init-replset.sh

### DIFF
--- a/2.6/root/usr/share/container-scripts/mongodb/common.sh
+++ b/2.6/root/usr/share/container-scripts/mongodb/common.sh
@@ -66,7 +66,7 @@ function _wait_for_mongo() {
     message="down"
   fi
 
-  local mongo_cmd="mongo admin --host ${2:-localhost} --port ${CONTAINER_PORT} "
+  local mongo_cmd="mongo admin --host ${2:-localhost} "
 
   local i
   for i in $(seq $MAX_ATTEMPTS); do
@@ -89,10 +89,10 @@ function endpoints() {
   dig ${service_name} A +search +short 2>/dev/null
 }
 
-# build_mongo_config builds the MongoDB replicaSet config used for the cluster
-# initialization.
+# replset_config_members builds part of the MongoDB replicaSet config: "members: [...]"
+# used for the cluster initialization.
 # Takes a list of space-separated member IPs as the first argument.
-function build_mongo_config() {
+function replset_config_members() {
   local current_endpoints
   current_endpoints="$1"
   local members
@@ -108,17 +108,7 @@ function build_mongo_config() {
       let member_id++
     fi
   done
-  echo -n "var config={ _id: \"${MONGODB_REPLICA_NAME}\", members: [ ${members%,} ] }"
-}
-
-# mongo_initiate initiates the replica set.
-# Takes a list of space-separated member IPs as the first argument.
-function mongo_initiate() {
-  local mongo_wait
-  mongo_wait="while (rs.status().startupStatus || (rs.status().hasOwnProperty(\"myState\") && rs.status().myState != 1)) { printjson( rs.status() ); sleep(1000); }; printjson( rs.status() );"
-  config=$(build_mongo_config "$1")
-  echo "=> Initiating MongoDB replica using: ${config}"
-  mongo admin --eval "${config};rs.initiate(config);${mongo_wait}"
+  echo -n "members: [ ${members%,} ]"
 }
 
 # replset_addr return the address of the current replSet
@@ -148,7 +138,7 @@ function replset_wait_sync() {
       var status=rs.status();
       var primary_optime=status.members.filter(function(el) {return el.state ==1})[0].optime;
       // Check that at least one member has same optime as PRIMARY (PRIMARY and one SECONDARY ~ >= 2)
-      if(status.members.filter(function(el) {return el.optime.ts.tojson() == primary_optime.ts.tojson()}).length >= 2)
+      if(status.members.filter(function(el) {return tojson(el.optime) == tojson(primary_optime)}).length >= 2)
         quit(0);
       else
         sleep(${SLEEP_TIME}*1000);
@@ -173,24 +163,6 @@ function mongo_remove() {
   echo "=> Removing ${mongo_addr} from replica set ..."
   mongo admin -u admin -p "${MONGODB_ADMIN_PASSWORD}" \
     --host "${host}" --eval "rs.remove('${mongo_addr}');" || true
-}
-
-# mongo_add advertise the current container to other mongo replicas
-function mongo_add() {
-  local host
-  # if we cannot determine the IP address of the primary, exit without an error
-  # to allow callers to proceed with their logic
-  host="$(replset_addr || true)"
-  if [ -z "$host" ]; then
-    return
-  fi
-
-  local mongo_addr
-  mongo_addr="$(mongo_addr)"
-
-  echo "=> Adding ${mongo_addr} to replica set ..."
-  mongo admin -u admin -p "${MONGODB_ADMIN_PASSWORD}" \
-    --host "${host}" --eval "rs.add('${mongo_addr}');"
 }
 
 # mongo_create_admin creates the MongoDB admin user with password: MONGODB_ADMIN_PASSWORD
@@ -283,4 +255,9 @@ function setup_keyfile() {
   echo ${MONGODB_KEYFILE_VALUE} > ${MONGODB_KEYFILE_PATH}
   chmod 0600 ${MONGODB_KEYFILE_PATH}
   mongo_common_args+=" --keyFile ${MONGODB_KEYFILE_PATH}"
+}
+
+# info prints a message prefixed by date and time.
+function info() {
+  printf "=> [%s] %s\n" "$(date +'%a %b %d %T')" "$*"
 }

--- a/3.0-upg/root/usr/share/container-scripts/mongodb/common.sh
+++ b/3.0-upg/root/usr/share/container-scripts/mongodb/common.sh
@@ -66,7 +66,7 @@ function _wait_for_mongo() {
     message="down"
   fi
 
-  local mongo_cmd="mongo admin --host ${2:-localhost} --port ${CONTAINER_PORT} "
+  local mongo_cmd="mongo admin --host ${2:-localhost} "
 
   local i
   for i in $(seq $MAX_ATTEMPTS); do
@@ -89,10 +89,10 @@ function endpoints() {
   dig ${service_name} A +search +short 2>/dev/null
 }
 
-# build_mongo_config builds the MongoDB replicaSet config used for the cluster
-# initialization.
+# replset_config_members builds part of the MongoDB replicaSet config: "members: [...]"
+# used for the cluster initialization.
 # Takes a list of space-separated member IPs as the first argument.
-function build_mongo_config() {
+function replset_config_members() {
   local current_endpoints
   current_endpoints="$1"
   local members
@@ -108,17 +108,7 @@ function build_mongo_config() {
       let member_id++
     fi
   done
-  echo -n "var config={ _id: \"${MONGODB_REPLICA_NAME}\", members: [ ${members%,} ] }"
-}
-
-# mongo_initiate initiates the replica set.
-# Takes a list of space-separated member IPs as the first argument.
-function mongo_initiate() {
-  local mongo_wait
-  mongo_wait="while (rs.status().startupStatus || (rs.status().hasOwnProperty(\"myState\") && rs.status().myState != 1)) { printjson( rs.status() ); sleep(1000); }; printjson( rs.status() );"
-  config=$(build_mongo_config "$1")
-  echo "=> Initiating MongoDB replica using: ${config}"
-  mongo admin --eval "${config};rs.initiate(config);${mongo_wait}"
+  echo -n "members: [ ${members%,} ]"
 }
 
 # replset_addr return the address of the current replSet
@@ -148,7 +138,7 @@ function replset_wait_sync() {
       var status=rs.status();
       var primary_optime=status.members.filter(function(el) {return el.state ==1})[0].optime;
       // Check that at least one member has same optime as PRIMARY (PRIMARY and one SECONDARY ~ >= 2)
-      if(status.members.filter(function(el) {return el.optime.ts.tojson() == primary_optime.ts.tojson()}).length >= 2)
+      if(status.members.filter(function(el) {return tojson(el.optime) == tojson(primary_optime)}).length >= 2)
         quit(0);
       else
         sleep(${SLEEP_TIME}*1000);
@@ -173,24 +163,6 @@ function mongo_remove() {
   echo "=> Removing ${mongo_addr} from replica set ..."
   mongo admin -u admin -p "${MONGODB_ADMIN_PASSWORD}" \
     --host "${host}" --eval "rs.remove('${mongo_addr}');" || true
-}
-
-# mongo_add advertise the current container to other mongo replicas
-function mongo_add() {
-  local host
-  # if we cannot determine the IP address of the primary, exit without an error
-  # to allow callers to proceed with their logic
-  host="$(replset_addr || true)"
-  if [ -z "$host" ]; then
-    return
-  fi
-
-  local mongo_addr
-  mongo_addr="$(mongo_addr)"
-
-  echo "=> Adding ${mongo_addr} to replica set ..."
-  mongo admin -u admin -p "${MONGODB_ADMIN_PASSWORD}" \
-    --host "${host}" --eval "rs.add('${mongo_addr}');"
 }
 
 # mongo_create_admin creates the MongoDB admin user with password: MONGODB_ADMIN_PASSWORD
@@ -283,4 +255,9 @@ function setup_keyfile() {
   echo ${MONGODB_KEYFILE_VALUE} > ${MONGODB_KEYFILE_PATH}
   chmod 0600 ${MONGODB_KEYFILE_PATH}
   mongo_common_args+=" --keyFile ${MONGODB_KEYFILE_PATH}"
+}
+
+# info prints a message prefixed by date and time.
+function info() {
+  printf "=> [%s] %s\n" "$(date +'%a %b %d %T')" "$*"
 }

--- a/3.2/root/usr/share/container-scripts/mongodb/common.sh
+++ b/3.2/root/usr/share/container-scripts/mongodb/common.sh
@@ -64,7 +64,7 @@ function _wait_for_mongo() {
     message="down"
   fi
 
-  local mongo_cmd="mongo admin --host ${2:-localhost} --port ${CONTAINER_PORT} "
+  local mongo_cmd="mongo admin --host ${2:-localhost} "
 
   local i
   for i in $(seq $MAX_ATTEMPTS); do
@@ -87,10 +87,10 @@ function endpoints() {
   dig ${service_name} A +search +short 2>/dev/null
 }
 
-# build_mongo_config builds the MongoDB replicaSet config used for the cluster
-# initialization.
+# replset_config_members builds part of the MongoDB replicaSet config: "members: [...]"
+# used for the cluster initialization.
 # Takes a list of space-separated member IPs as the first argument.
-function build_mongo_config() {
+function replset_config_members() {
   local current_endpoints
   current_endpoints="$1"
   local members
@@ -106,17 +106,7 @@ function build_mongo_config() {
       let member_id++
     fi
   done
-  echo -n "var config={ _id: \"${MONGODB_REPLICA_NAME}\", members: [ ${members%,} ] }"
-}
-
-# mongo_initiate initiates the replica set.
-# Takes a list of space-separated member IPs as the first argument.
-function mongo_initiate() {
-  local mongo_wait
-  mongo_wait="while (rs.status().startupStatus || (rs.status().hasOwnProperty(\"myState\") && rs.status().myState != 1)) { printjson( rs.status() ); sleep(1000); }; printjson( rs.status() );"
-  config=$(build_mongo_config "$1")
-  echo "=> Initiating MongoDB replica using: ${config}"
-  mongo admin --eval "${config};rs.initiate(config);${mongo_wait}"
+  echo -n "members: [ ${members%,} ]"
 }
 
 # replset_addr return the address of the current replSet
@@ -146,7 +136,7 @@ function replset_wait_sync() {
       var status=rs.status();
       var primary_optime=status.members.filter(function(el) {return el.state ==1})[0].optime;
       // Check that at least one member has same optime as PRIMARY (PRIMARY and one SECONDARY ~ >= 2)
-      if(status.members.filter(function(el) {return el.optime.ts.tojson() == primary_optime.ts.tojson()}).length >= 2)
+      if(status.members.filter(function(el) {return tojson(el.optime) == tojson(primary_optime)}).length >= 2)
         quit(0);
       else
         sleep(${SLEEP_TIME}*1000);
@@ -171,24 +161,6 @@ function mongo_remove() {
   echo "=> Removing ${mongo_addr} from replica set ..."
   mongo admin -u admin -p "${MONGODB_ADMIN_PASSWORD}" \
     --host "${host}" --eval "rs.remove('${mongo_addr}');" || true
-}
-
-# mongo_add advertise the current container to other mongo replicas
-function mongo_add() {
-  local host
-  # if we cannot determine the IP address of the primary, exit without an error
-  # to allow callers to proceed with their logic
-  host="$(replset_addr || true)"
-  if [ -z "$host" ]; then
-    return
-  fi
-
-  local mongo_addr
-  mongo_addr="$(mongo_addr)"
-
-  echo "=> Adding ${mongo_addr} to replica set ..."
-  mongo admin -u admin -p "${MONGODB_ADMIN_PASSWORD}" \
-    --host "${host}" --eval "rs.add('${mongo_addr}');"
 }
 
 # mongo_create_admin creates the MongoDB admin user with password: MONGODB_ADMIN_PASSWORD

--- a/3.2/root/usr/share/container-scripts/mongodb/init-petset-replset.sh
+++ b/3.2/root/usr/share/container-scripts/mongodb/init-petset-replset.sh
@@ -42,7 +42,6 @@ function find_endpoints() {
   dig "${service_name}" SRV +search +short | cut -d' ' -f4 | rev | cut -c2- | rev
 }
 
-# TODO: unify this and `mongo_initiate` from common.sh
 # Initializes the replica set configuration. It is safe to call this function if
 # a replica set is already configured.
 #


### PR DESCRIPTION
Remove differences between init-petset-replset.sh and init-replset.sh as small as possible:
 - remove mongo_add() and mongo_initiate() from common.sh -> above mentioned scripts contains these functions
 - added newly introduced code in init-petset-replset.sh to init-replset.sh

In `initiate()` function only one big part of code is added:
- waiting for all endpoints are present and accept connections

Other differences are only to make `init-replset.sh` to use functions from `common.sh` and not to use petset addressing.

@rhcarvalho @php-coder @bparees  Please take a look.


New diff in background init scripts:
```patch
--- 3.2/root/usr/share/container-scripts/mongodb/init-petset-replset.sh	2017-02-01 14:51:52.261033466 +0100
+++ 3.2/root/usr/share/container-scripts/mongodb/init-replset.sh	2017-02-01 15:07:52.993116071 +0100
@@ -8,7 +8,7 @@
 
 # This is a full hostname that will be added to replica set
 # (for example, "replica-2.mongodb.myproject.svc.cluster.local")
-readonly MEMBER_HOST="$(hostname -f)"
+readonly MEMBER_HOST="$(container_addr)"
 
 # Description of possible statuses: https://docs.mongodb.com/manual/reference/replica-states/
 readonly WAIT_PRIMARY_STATUS='
@@ -30,18 +30,6 @@
   print(mbrs[0].stateStr);
 "
 
-# Outputs available endpoints (hostnames) to stdout.
-# This also includes hostname of the current pod.
-#
-# Uses the following global variables:
-# - MONGODB_SERVICE_NAME (optional, defaults to 'mongodb')
-function find_endpoints() {
-  local service_name="${MONGODB_SERVICE_NAME:-mongodb}"
-
-  # Extract host names from lines like this: "10 33 0 mongodb-2.mongodb.myproject.svc.cluster.local."
-  dig "${service_name}" SRV +search +short | cut -d' ' -f4 | rev | cut -c2- | rev
-}
-
 # Initializes the replica set configuration. It is safe to call this function if
 # a replica set is already configured.
 #
@@ -52,15 +40,42 @@
 # - MONGODB_REPLICA_NAME
 # - MONGODB_ADMIN_PASSWORD
 # - WAIT_PRIMARY_STATUS
+# - MONGODB_INITIAL_REPLICA_COUNT
 function initiate() {
   local host="$1"
 
+  # Wait for all nodes to be listed in endpoints() and accept connections
+  current_endpoints=$(endpoints)
+  if [ -n "${MONGODB_INITIAL_REPLICA_COUNT:-}" ]; then
+    echo -n "=> Waiting for $MONGODB_INITIAL_REPLICA_COUNT MongoDB endpoints ..."
+    while [[ "$(echo "${current_endpoints}" | wc -l)" -lt ${MONGODB_INITIAL_REPLICA_COUNT} ]]; do
+      sleep 2
+      current_endpoints=$(endpoints)
+    done
+  else
+    echo "Attention: MONGODB_INITIAL_REPLICA_COUNT is not set and it could lead to a improperly configured replica set."
+    echo "To fix this, set MONGODB_INITIAL_REPLICA_COUNT variable to the number of members in the replica set in"
+    echo "the configuration of post deployment hook."
+
+    echo -n "=> Waiting for MongoDB endpoints ..."
+    while [ -z "${current_endpoints}" ]; do
+      sleep 2
+      current_endpoints=$(endpoints)
+    done
+  fi
+  echo "${current_endpoints}"
+  echo "=> Waiting for all endpoints to accept connections..."
+  for node in ${current_endpoints}; do
+    wait_for_mongo_up ${node} &>/dev/null
+  done
+
+
   if mongo --eval "quit(db.isMaster().setName == '${MONGODB_REPLICA_NAME}' ? 0 : 1)" --quiet; then
     info "Replica set '${MONGODB_REPLICA_NAME}' already exists, skipping initialization"
     return
   fi
 
-  local config="{_id: '${MONGODB_REPLICA_NAME}', members: [{_id: 0, host: '${host}'}]}"
+  local config="{_id: '${MONGODB_REPLICA_NAME}', $(replset_config_members "${current_endpoints}")}"
 
   info "Initiating MongoDB replica using: ${config}"
   mongo admin --eval "rs.initiate(${config});${WAIT_PRIMARY_STATUS}" --quiet
@@ -81,7 +96,6 @@
 # Global variables:
 # - MAX_ATTEMPTS
 # - SLEEP_TIME
-# - MONGODB_REPLICA_NAME
 # - MONGODB_ADMIN_PASSWORD
 # - WAIT_PRIMARY_OR_SECONDARY_STATUS
 function add_member() {
@@ -105,18 +119,14 @@
     quit(1);
   "
 
-  # TODO: replace this with a call to `replset_addr` from common.sh, once it returns host names.
-  local endpoints
-  endpoints="$(find_endpoints | paste -s -d,)"
-
-  if [ -z "${endpoints}" ]; then
+  if [ -z "$(endpoints)" ]; then
     info "ERROR: couldn't add host to replica set!"
     info "CAUSE: DNS lookup for '${MONGODB_SERVICE_NAME:-mongodb}' returned no results."
     return 1
   fi
 
   local replset_addr
-  replset_addr="${MONGODB_REPLICA_NAME}/${endpoints}"
+  replset_addr="$(replset_addr)"
 
   if ! mongo admin -u admin -p "${MONGODB_ADMIN_PASSWORD}" --host "${replset_addr}" --eval "${script}" --quiet; then
     info "ERROR: couldn't add host to replica set!"
@@ -144,17 +154,14 @@
 # the add_member call will fail.
 wait_for_mongo_up ${MEMBER_HOST} &>/dev/null
 
-# StatefulSet pods are named with a predictable name, following the pattern:
-#   $(statefulset name)-$(zero-based index)
-# MEMBER_ID is computed by removing the prefix matching "*-", i.e.:
-#  "mongodb-0" -> "0"
-#  "mongodb-1" -> "1"
-#  "mongodb-2" -> "2"
-readonly MEMBER_ID="${HOSTNAME##*-}"
-
 # Initialize replica set only if we're the first member
-if [ "${MEMBER_ID}" = '0' ]; then
+if [ "$1" == "initiate" ]; then
+  main_process_id=$2
+  # Initiate replica set
   initiate "${MEMBER_HOST}"
+
+  # Exit this pod
+  kill ${main_process_id}
 else
   add_member "${MEMBER_HOST}"
 fi
```

P.S: I will apply changes also to 2.4, 2.6 and 3.0-upg after this patch is OK.