### PR TITLE
check mongo status via host, not localhost to ensure remote accessibility

### DIFF
--- a/3.2/root/usr/share/container-scripts/mongodb/init-petset-replset.sh
+++ b/3.2/root/usr/share/container-scripts/mongodb/init-petset-replset.sh
@@ -140,8 +140,10 @@ function add_member() {
   info "Successfully joined replica set"
 }
 
-info "Waiting for local MongoDB to accept connections ..."
-wait_for_mongo_up &>/dev/null
+info "Waiting for local MongoDB to accept connections on ${MEMBER_HOST} ..."
+# connect using the host to ensure networking is working, otherwise
+# the add_member call will fail.
+wait_for_mongo_up ${MEMBER_HOST} &>/dev/null
 
 # PetSet pods are named with a predictable name, following the pattern:
 #   $(petset name)-$(zero-based index)


### PR DESCRIPTION
hopefully addresses mongodb petset replica flakes as seen here:
https://ci.openshift.redhat.com/jenkins/view/Origin%20Test%20Jobs/job/origin_extended_image_tests/794/

in which one of the slave instances isn't able to access itself(!!):
```
Dec 22 06:10:06.677: INFO: Running 'oc logs --config=/tmp/extended-test-mongodb-petset-replica-hpydx-s1sgr-user.kubeconfig --namespace=extended-test-mongodb-petset-replica-hpydx-s1sgr mongodb-replicaset-1 --timestamps'
pod logs for 2016-12-22T11:08:55.402173000Z => [Thu Dec 22 11:08:55] Waiting for local MongoDB to accept connections ...
2016-12-22T11:08:55.548729000Z 2016-12-22T11:08:55.547+0000 I CONTROL  [initandlisten] MongoDB starting : pid=16 port=27017 dbpath=/var/lib/mongodb/data 64-bit host=mongodb-replicaset-1
2016-12-22T11:08:55.549036000Z 2016-12-22T11:08:55.547+0000 I CONTROL  [initandlisten] db version v3.2.6
2016-12-22T11:08:55.549311000Z 2016-12-22T11:08:55.547+0000 I CONTROL  [initandlisten] git version: 05552b562c7a0b3143a729aaa0838e558dc49b25
2016-12-22T11:08:55.549569000Z 2016-12-22T11:08:55.547+0000 I CONTROL  [initandlisten] OpenSSL version: OpenSSL 1.0.1e-fips 11 Feb 2013
2016-12-22T11:08:55.549793000Z 2016-12-22T11:08:55.547+0000 I CONTROL  [initandlisten] allocator: tcmalloc
2016-12-22T11:08:55.550007000Z 2016-12-22T11:08:55.547+0000 I CONTROL  [initandlisten] modules: none
2016-12-22T11:08:55.550213000Z 2016-12-22T11:08:55.547+0000 I CONTROL  [initandlisten] build environment:
2016-12-22T11:08:55.550485000Z 2016-12-22T11:08:55.547+0000 I CONTROL  [initandlisten]     distarch: x86_64
2016-12-22T11:08:55.550733000Z 2016-12-22T11:08:55.547+0000 I CONTROL  [initandlisten]     target_arch: x86_64
2016-12-22T11:08:55.550985000Z 2016-12-22T11:08:55.547+0000 I CONTROL  [initandlisten] options: { config: "/etc/mongod.conf", net: { http: { enabled: false }, port: 27017 }, replication: { oplogSizeMB: 64, replSet: "rs0" }, security: { keyFile: "/var/lib/mongodb/keyfile" }, storage: { dbPath: "/var/lib/mongodb/data" }, systemLog: { quiet: true } }
2016-12-22T11:08:55.560117000Z 2016-12-22T11:08:55.555+0000 I STORAGE  [initandlisten] wiredtiger_open config: create,cache_size=3G,session_max=20000,eviction=(threads_max=4),config_base=false,statistics=(fast),log=(enabled=true,archive=true,path=journal,compressor=snappy),file_manager=(close_idle_time=100000),checkpoint=(wait=60,log_size=2GB),statistics_log=(wait=0),
2016-12-22T11:08:55.637315000Z 2016-12-22T11:08:55.604+0000 I CONTROL  [initandlisten] 
2016-12-22T11:08:55.637609000Z 2016-12-22T11:08:55.604+0000 I CONTROL  [initandlisten] ** WARNING: /sys/kernel/mm/transparent_hugepage/enabled is 'always'.
2016-12-22T11:08:55.637857000Z 2016-12-22T11:08:55.604+0000 I CONTROL  [initandlisten] **        We suggest setting it to 'never'
2016-12-22T11:08:55.638087000Z 2016-12-22T11:08:55.604+0000 I CONTROL  [initandlisten] 
2016-12-22T11:08:55.638341000Z 2016-12-22T11:08:55.604+0000 I CONTROL  [initandlisten] ** WARNING: /sys/kernel/mm/transparent_hugepage/defrag is 'always'.
2016-12-22T11:08:55.638590000Z 2016-12-22T11:08:55.606+0000 I CONTROL  [initandlisten] **        We suggest setting it to 'never'
2016-12-22T11:08:55.638836000Z 2016-12-22T11:08:55.606+0000 I CONTROL  [initandlisten] 
2016-12-22T11:08:55.639094000Z 2016-12-22T11:08:55.612+0000 I REPL     [initandlisten] Did not find local voted for document at startup;  NoMatchingDocument: Did not find replica set lastVote document in local.replset.election
2016-12-22T11:08:55.639390000Z 2016-12-22T11:08:55.612+0000 I REPL     [initandlisten] Did not find local replica set configuration document at startup;  NoMatchingDocument: Did not find replica set configuration document in local.system.replset
2016-12-22T11:08:55.639635000Z 2016-12-22T11:08:55.613+0000 I NETWORK  [HostnameCanonicalizationWorker] Starting hostname canonicalization worker
2016-12-22T11:08:55.639868000Z 2016-12-22T11:08:55.613+0000 I FTDC     [initandlisten] Initializing full-time diagnostic data capture with directory '/var/lib/mongodb/data/diagnostic.data'
2016-12-22T11:08:55.640112000Z 2016-12-22T11:08:55.630+0000 I NETWORK  [initandlisten] waiting for connections on port 27017
2016-12-22T11:08:55.689320000Z 2016-12-22T11:08:55.685+0000 I ACCESS   [conn1] note: no users configured in admin.system.users, allowing localhost access
2016-12-22T11:08:55.694596000Z => [Thu Dec 22 11:08:55] Adding mongodb-replicaset-1.mongodb-replicaset.extended-test-mongodb-petset-replica-hpydx-s1sgr.svc.cluster.local to replica set ...
2016-12-22T11:08:55.819897000Z 2016-12-22T11:08:55.814+0000 I NETWORK  [thread1] Starting new replica set monitor for rs0/mongodb-replicaset-0.mongodb-replicaset.extended-test-mongodb-petset-replica-hpydx-s1sgr.svc.cluster.local:27017
2016-12-22T11:08:55.820203000Z 2016-12-22T11:08:55.815+0000 I NETWORK  [ReplicaSetMonitorWatcher] starting
2016-12-22T11:08:56.283975000Z {
2016-12-22T11:08:56.284267000Z 	"ok" : 0,
2016-12-22T11:08:56.284532000Z 	"errmsg" : "Quorum check failed because not enough voting nodes responded; required 2 but only the following 1 voting nodes responded: mongodb-replicaset-0.mongodb-replicaset.extended-test-mongodb-petset-replica-hpydx-s1sgr.svc.cluster.local:27017; the following nodes did not respond affirmatively: mongodb-replicaset-1.mongodb-replicaset.extended-test-mongodb-petset-replica-hpydx-s1sgr.svc.cluster.local:27017 failed with HostUnreachable",
2016-12-22T11:08:56.284767000Z 	"code" : 74
2016-12-22T11:08:56.284997000Z }
2016-12-22T11:08:56.290041000Z => [Thu Dec 22 11:08:56] ERROR: couldn't add host to replica set!
```

