### PR TITLE
Add simple openshift tests to this repository

### DIFF
--- a/3.2/root/usr/share/container-scripts/mongodb/test-functions.sh
+++ b/3.2/root/usr/share/container-scripts/mongodb/test-functions.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# insert_and_wait_for_replication insert data in host and wait all replset members
+# applied recent oplog entry
+function insert_and_wait_for_replication() {
+  local host
+  host=$1
+  local data
+  data=$2
+
+  # Storing document into replset and wait replication to finish
+  local script
+  script="db.getSiblingDB('test_db').data.insert(${data});
+    for (var i = 0; i < 60; i++) {
+      var status=rs.status();
+      var optime=status.members[0].optime;
+      var ok=true;
+      for(var j=1; j < status.members.length; j++) {
+        if(tojson(optime) != tojson(status.members[j].optime)) {
+          ok=false;
+        }
+      };
+      if(ok == true) {
+        print('INFO: All members of replicaset are synchronized');
+        quit(0);
+      }
+      sleep(1000);
+    }
+    print('ERROR: Members of replicaset are not synchronized');
+    printjson(rs.status());
+    quit(1);"
+
+  mongo admin --host "${host}" -u admin -p "${MONGODB_ADMIN_PASSWORD}" --eval "${script}"
+}
+
+# wait_replicaset_members waits till replset has specified number of members
+function wait_replicaset_members() {
+  local host
+  host=$1
+  local count
+  count=$2
+
+  local script
+  script="for (var i = 0; i < 60; i++) {
+    var ret = rs.status().members.length;
+    if (ret == ${count}) {
+      print('INFO: Replicaset has expected number of members');
+      quit(0);
+    }
+    sleep(1000);
+  }
+  print('ERROR: Wrong count of members in replicaset');
+  printjson(rs.status());
+  quit(1);"
+
+  mongo admin --host "${host}" -u admin -p "${MONGODB_ADMIN_PASSWORD}" --eval "${script}"
+}

--- a/3.2/test/run-openshift
+++ b/3.2/test/run-openshift
@@ -1,0 +1,87 @@
+#!/bin/bash
+#
+# Test the MongoDB image in OpenShift.
+#
+# IMAGE_NAME specifies a name of the candidate image used for testing.
+# The image has to be available before this script is executed.
+#
+
+set -exo nounset
+
+function prepare_oc_client() {
+  # Prepare oc command
+  if [[ ! -d ../openshift-client/ ]]; then
+    OC_RELEASE=$(curl -s https://api.github.com/repos/openshift/origin/releases | grep "browser_download_url" | grep "openshift-origin-client" | grep "linux-64bit" | sort | tail -n 1 | sed -e 's|"browser_download_url": ||' | tr -d ' "')
+
+    curl -L ${OC_RELEASE} | tar xz
+    mv ./openshift-origin-client-tools-* ../openshift-client
+  fi
+  export PATH=${PATH}:`pwd`/../openshift-client/
+}
+prepare_oc_client
+
+function cleanup() {
+  echo "Stopping and removing OpenShift cluster..."
+  oc delete project --all
+  oc cluster down
+}
+trap cleanup EXIT SIGINT
+
+function print_logs() {
+  oc get all
+  while read pod_info; do
+    pod=$(echo ${pod_info} | tr -s ' ' | cut -f1 -d' ')
+    echo "INFO: printing logs for pod ${pod}"
+    oc logs ${pod}
+  done < <(oc get pods --no-headers=true)
+}
+trap print_logs ERR
+
+# Start OpenShift cluster
+oc cluster up
+
+# Prepare image - add tag different than :latest
+# With :latest default imagePullPolicy is Always
+# https://docs.openshift.com/enterprise/3.2/dev_guide/managing_images.html#image-pull-policy
+docker tag ${IMAGE_NAME} ${IMAGE_NAME}:test-openshift
+IMAGE_NAME=${IMAGE_NAME}:test-openshift
+
+#
+# General functions
+#
+
+# wait_for_ready_pods wait till number of pods with label get ready
+function wait_for_ready_pods() {
+  local label="$1"
+  local count="$2"
+  for i in $(seq 30); do
+    if [[ "$(oc get pods --no-headers=true -l${label} | grep "1/1" | wc -l)" -eq ${count} ]]; then
+      return 0
+    fi
+    echo "Waiting for ${count} ready pods labeled with '${label}'..."
+    sleep 20
+  done
+  return 1
+}
+
+# Deploy MongoDB clustered application
+USER=user
+PASS=pass
+ADMIN_PASS=adminPass
+DB=db
+
+oc new-project petset-example
+oc new-app --file=../examples/petset/mongodb-petset-persistent.yaml -p MONGODB_USER=${USER} -p MONGODB_PASSWORD=${PASS} -p MONGODB_DATABASE=${DB} -p MONGODB_ADMIN_PASSWORD=${ADMIN_PASS} -p MONGODB_IMAGE=${IMAGE_NAME} -p VOLUME_CAPACITY=500M
+
+wait_for_ready_pods "app=mongodb-petset-replication" 3
+wait_for_ready_pods "openshift.io/deployer-pod-for.name" 0
+
+host="rs0/$(oc get endpoints mongodb --no-headers | tr -s ' ' | cut -f2 -d' ')"
+
+docker exec origin kubectl run --attach --restart=Never mongodb-test --image ${IMAGE_NAME} --env="MONGODB_ADMIN_PASSWORD=${ADMIN_PASS}" --command -- bash -c "set -x
+. /usr/share/container-scripts/mongodb/common.sh
+. /usr/share/container-scripts/mongodb/test-functions.sh
+wait_for_mongo_up '${host}'
+wait_replicaset_members '${host}' 3
+insert_and_wait_for_replication '${host}' '{a:5, b:10}'"
+


### PR DESCRIPTION
Tests for images are now packed together with source in `test/run` script. I would like add some simple scripts to test images in OpenShift environment.

It is quite easy to deploy OpenShift with `oc cluster up` and having these simple tests would allow developers/users to easily test changes or to add this testing to CI.

This PR adds new make target `test-openshift` - by it images are built and `test/run-openshift` is run (if exists), it is similar how `make test` is handled.

Also new template for replicaset is added to `examples` (it is a "copy" of template from `2.4/examples/` with parametrized image name).

Now `run-openshift` deploys OpenShift and created application from `examples/replset/mongodb-clustered.json` template. And it tests replicating data to all members and scaling up and down. The script should contains basically only instructions which user would use to create and administer application in OpenShift from command line.
Extending this scripts to test also petset is very welcomed (or providing hints to do it). Also maybe some things can be done simpler, so I would like to know it.

@hhorak @bparees Please review.

When I tested this it showed me some bugs what should be fixed in replication scripts. So in current implementation do not pass this every time. Also I hope adding this test to CI would make time needed to merge changes in replication scripts shorter.