### PR TITLE
Timezone for container - petset

### DIFF
--- a/examples/petset/mongodb-petset-persistent.yaml
+++ b/examples/petset/mongodb-petset-persistent.yaml
@@ -130,6 +130,8 @@ objects:
                   value: "${MONGODB_KEYFILE_VALUE}"
                 - name: MONGODB_SERVICE_NAME
                   value: "${MONGODB_SERVICE_NAME}"
+                - name: TZ
+                  value: "${TZ}"
               resources:
                 limits:
                   memory: "${MEMORY_LIMIT}"

--- a/examples/petset/mongodb-petset-persistent.yaml
+++ b/examples/petset/mongodb-petset-persistent.yaml
@@ -69,6 +69,10 @@ parameters:
     displayName: "Memory Limit"
     description: "Maximum amount of memory the container can use."
     value: "512Mi"
+  - name: TIMEZONE
+    displayName: "Time zone"
+    description: "The time zone for the mongodb cluster"
+    value: "UTC"    
 
 objects:
   # A headless service to create DNS records


### PR DESCRIPTION
The default timezone is utc. Some customers need to have there local timezone. It would be nice to be able to set the timezone at the creation time