### PR TITLE
Add example for replication with Docker.

### DIFF
--- a/2.6/Dockerfile.rhel7
+++ b/2.6/Dockerfile.rhel7
@@ -30,7 +30,7 @@ CMD ["run-mongod"]
 RUN yum install -y yum-utils && \
     yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
-    INSTALL_PKGS="bind-utils gettext iproute rsync tar v8314 rh-mongodb26-mongodb rh-mongodb26" && \
+    INSTALL_PKGS="bind-utils gettext iproute rsync tar hostname v8314 rh-mongodb26-mongodb rh-mongodb26" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all

--- a/2.6/root/usr/share/container-scripts/mongodb/common.sh
+++ b/2.6/root/usr/share/container-scripts/mongodb/common.sh
@@ -73,7 +73,8 @@ function replset_addr() {
   local current_endpoints
   current_endpoints="$(endpoints)"
   if [ -z "${current_endpoints}" ]; then
-    echo >&2 "Cannot get address of replica set: no nodes are listed in service"
+    info "Cannot get address of replica set: no nodes are listed in service!"
+    info "CAUSE: DNS lookup for '${MONGODB_SERVICE_NAME:-mongodb}' returned no results."
     return 1
   fi
   echo "${MONGODB_REPLICA_NAME}/${current_endpoints//[[:space:]]/,}"

--- a/2.6/root/usr/share/container-scripts/mongodb/init-replset.sh
+++ b/2.6/root/usr/share/container-scripts/mongodb/init-replset.sh
@@ -10,18 +10,6 @@ source "${CONTAINER_SCRIPTS_PATH}/common.sh"
 # (for example, "replica-2.mongodb.myproject.svc.cluster.local")
 readonly MEMBER_HOST="$(hostname -f)"
 
-# Outputs available endpoints (hostnames) to stdout.
-# This also includes hostname of the current pod.
-#
-# Uses the following global variables:
-# - MONGODB_SERVICE_NAME (optional, defaults to 'mongodb')
-function find_endpoints() {
-  local service_name="${MONGODB_SERVICE_NAME:-mongodb}"
-
-  # Extract host names from lines like this: "10 33 0 mongodb-2.mongodb.myproject.svc.cluster.local."
-  dig "${service_name}" SRV +search +short | cut -d' ' -f4 | rev | cut -c2- | rev
-}
-
 # Initializes the replica set configuration.
 #
 # Arguments:
@@ -60,20 +48,7 @@ function add_member() {
   local host="$1"
   info "Adding ${host} to replica set ..."
 
-  # TODO: replace this with a call to `replset_addr` from common.sh, once it returns host names.
-  local endpoints
-  endpoints="$(find_endpoints | paste -s -d,)"
-
-  if [ -z "${endpoints}" ]; then
-    info "ERROR: couldn't add host to replica set!"
-    info "CAUSE: DNS lookup for '${MONGODB_SERVICE_NAME:-mongodb}' returned no results."
-    return 1
-  fi
-
-  local replset_addr
-  replset_addr="${MONGODB_REPLICA_NAME}/${endpoints}"
-
-  if ! mongo admin -u admin -p "${MONGODB_ADMIN_PASSWORD}" --host "${replset_addr}" --eval "while (!rs.add('${host}').ok) { sleep(100); }" --quiet; then
+  if ! mongo admin -u admin -p "${MONGODB_ADMIN_PASSWORD}" --host "$(replset_addr)" --eval "while (!rs.add('${host}').ok) { sleep(100); }" --quiet; then
     info "ERROR: couldn't add host to replica set!"
     return 1
   fi

--- a/2.6/test/run
+++ b/2.6/test/run
@@ -386,31 +386,40 @@ run_doc_test() {
 }
 
 function run_local_replication_test() {
+    function print_logs() {
+      for file in $CIDFILE_DIR/replset*; do
+        echo "INFO: printing logs for CID file ${file}"
+        docker logs $(cat ${file})
+      done
+    }
+    trap print_logs ERR
+
     echo "Testing replication on local docker"
     #Initializing replicaset
-    ADMIN_PASS=adminPassword
-    BASE_ARGS="
--e MONGODB_DATABASE=db
--e MONGODB_USER=user
--e MONGODB_PASSWORD=password
--e MONGODB_ADMIN_PASSWORD=${ADMIN_PASS}
--e MONGODB_REPLICA_NAME=rs0
--e MONGODB_KEYFILE_VALUE=xxxxxxxxxxxx
--e MONGODB_SMALLFILES=true
--e MONGODB_SERVICE_NAME=mongodb"
+
+    cat > variables <<EOF
+    MONGODB_DATABASE=db
+    MONGODB_USER=user
+    MONGODB_PASSWORD=password
+    MONGODB_ADMIN_PASSWORD=adminPassword
+    MONGODB_REPLICA_NAME=rs0
+    MONGODB_KEYFILE_VALUE=xxxxxxxxxxxx
+    MONGODB_SMALLFILES=true
+    MONGODB_SERVICE_NAME=mongodb
+EOF
+    source variables
 
     local network_name="mongodb-replset-$$"
     docker network create ${network_name}
 
-    docker run -d --cidfile $CIDFILE_DIR/replset0 --name=replset-0 --hostname=replset-0 --network ${network_name} --network-alias mongodb ${BASE_ARGS} $IMAGE_NAME run-mongod-replication
-    docker run -d --cidfile $CIDFILE_DIR/replset1 --name=replset-1 --hostname=replset-1 --network ${network_name} --network-alias mongodb ${BASE_ARGS} $IMAGE_NAME run-mongod-replication
-    docker run -d --cidfile $CIDFILE_DIR/replset2 --name=replset-2 --hostname=replset-2 --network ${network_name} --network-alias mongodb ${BASE_ARGS} $IMAGE_NAME run-mongod-replication
+    docker run -d --cidfile $CIDFILE_DIR/replset0 --name=replset-0 --hostname=replset-0 --network ${network_name} --network-alias mongodb --env-file=variables $IMAGE_NAME run-mongod-replication
+    docker run -d --cidfile $CIDFILE_DIR/replset1 --name=replset-1 --hostname=replset-1 --network ${network_name} --network-alias mongodb --env-file=variables $IMAGE_NAME run-mongod-replication
+    docker run -d --cidfile $CIDFILE_DIR/replset2 --name=replset-2 --hostname=replset-2 --network ${network_name} --network-alias mongodb --env-file=variables $IMAGE_NAME run-mongod-replication
 
-
-    local host="$(docker run --rm -e MONGODB_REPLICA_NAME=rs0 --network ${network_name} ${IMAGE_NAME} bash -c '. /usr/share/container-scripts/mongodb/common.sh && echo $(replset_addr)')"
+    local host="$(docker run --rm --env-file=variables --network ${network_name} ${IMAGE_NAME} bash -c '. /usr/share/container-scripts/mongodb/common.sh && echo $(replset_addr)')"
 
     # Storing document into replset and wait replication to finish ...
-    docker run --rm -e MONGODB_REPLICA_NAME=rs0 -e MONGODB_ADMIN_PASSWORD=${ADMIN_PASS} --network ${network_name} ${IMAGE_NAME} bash -c "set -e
+    docker run --rm --env-file=variables --network ${network_name} ${IMAGE_NAME} bash -c "set -e
       . /usr/share/container-scripts/mongodb/common.sh
       . /usr/share/container-scripts/mongodb/test-functions.sh
       wait_for_mongo_up '${host}'
@@ -418,15 +427,18 @@ function run_local_replication_test() {
       insert_and_wait_for_replication '${host}' '{a:5, b:10}'"
 
     # Adding new container
-    docker run -d --cidfile $CIDFILE_DIR/replset3 --name=replset-3 --hostname=replset-3 --network ${network_name} --network-alias mongodb ${BASE_ARGS} $IMAGE_NAME run-mongod-replication
+    docker run -d --cidfile $CIDFILE_DIR/replset3 --name=replset-3 --hostname=replset-3 --network ${network_name} --network-alias mongodb --env-file=variables $IMAGE_NAME run-mongod-replication
 
     # Storing document into replset and wait replication to finish ...
-    docker run --rm -e MONGODB_REPLICA_NAME=rs0 -e MONGODB_ADMIN_PASSWORD=${ADMIN_PASS} --network ${network_name} ${IMAGE_NAME} bash -c "set -e
+    docker run --rm --env-file=variables --network ${network_name} ${IMAGE_NAME} bash -c "set -e
       . /usr/share/container-scripts/mongodb/common.sh
       . /usr/share/container-scripts/mongodb/test-functions.sh
       wait_for_mongo_up '${host}'
       wait_replicaset_members '${host}' 4
       insert_and_wait_for_replication '${host}' '{a:5, b:10}'"
+
+    rm variables
+    trap ERR
 
     echo "  Success!"
 }

--- a/2.6/test/run
+++ b/2.6/test/run
@@ -452,12 +452,8 @@ run_container_creation_tests
 run_configuration_tests
 USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin
 # Test with random uid in container
-#CONTAINER_ARGS="-u 12345" USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin_altuid
-#run_change_password_test
-#run_mount_config_test
-#run_doc_test
-#CONTAINER_ARGS="-u 12345" USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin_altuid
-#run_change_password_test
-#run_mount_config_test
-
+CONTAINER_ARGS="-u 12345" USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin_altuid
+run_change_password_test
+run_mount_config_test
+run_doc_test
 run_local_replication_test

--- a/2.6/test/run
+++ b/2.6/test/run
@@ -413,8 +413,11 @@ EOF
     docker network create ${network_name}
 
     docker run -d --cidfile $CIDFILE_DIR/replset0 --name=replset-0 --hostname=replset-0 --network ${network_name} --network-alias mongodb --env-file=variables $IMAGE_NAME run-mongod-replication
+    docker exec replset-0 bash -c "while ! [ -f /tmp/initialized ]; do sleep 1; done"
     docker run -d --cidfile $CIDFILE_DIR/replset1 --name=replset-1 --hostname=replset-1 --network ${network_name} --network-alias mongodb --env-file=variables $IMAGE_NAME run-mongod-replication
+    docker exec replset-1 bash -c "while ! [ -f /tmp/initialized ]; do sleep 1; done"
     docker run -d --cidfile $CIDFILE_DIR/replset2 --name=replset-2 --hostname=replset-2 --network ${network_name} --network-alias mongodb --env-file=variables $IMAGE_NAME run-mongod-replication
+    docker exec replset-2 bash -c "while ! [ -f /tmp/initialized ]; do sleep 1; done"
 
     local host="$(docker run --rm --env-file=variables --network ${network_name} ${IMAGE_NAME} bash -c '. /usr/share/container-scripts/mongodb/common.sh && echo $(replset_addr)')"
 
@@ -428,6 +431,7 @@ EOF
 
     # Adding new container
     docker run -d --cidfile $CIDFILE_DIR/replset3 --name=replset-3 --hostname=replset-3 --network ${network_name} --network-alias mongodb --env-file=variables $IMAGE_NAME run-mongod-replication
+    docker exec replset-3 bash -c "while ! [ -f /tmp/initialized ]; do sleep 1; done"
 
     # Storing document into replset and wait replication to finish ...
     docker run --rm --env-file=variables --network ${network_name} ${IMAGE_NAME} bash -c "set -e

--- a/2.6/test/run
+++ b/2.6/test/run
@@ -24,6 +24,9 @@ function cleanup() {
         echo "Done."
     done
     rmdir $CIDFILE_DIR
+
+    local network_name="mongodb-replset-$$"
+    docker network ls | grep -q ${network_name} && docker network rm ${network_name}
 }
 trap cleanup EXIT SIGINT
 
@@ -382,13 +385,63 @@ run_doc_test() {
   echo
 }
 
+function run_local_replication_test() {
+    echo "Testing replication on local docker"
+    #Initializing replicaset
+    ADMIN_PASS=adminPassword
+    BASE_ARGS="
+-e MONGODB_DATABASE=db
+-e MONGODB_USER=user
+-e MONGODB_PASSWORD=password
+-e MONGODB_ADMIN_PASSWORD=${ADMIN_PASS}
+-e MONGODB_REPLICA_NAME=rs0
+-e MONGODB_KEYFILE_VALUE=xxxxxxxxxxxx
+-e MONGODB_SMALLFILES=true
+-e MONGODB_SERVICE_NAME=mongodb"
+
+    local network_name="mongodb-replset-$$"
+    docker network create ${network_name}
+
+    docker run -d --cidfile $CIDFILE_DIR/replset0 --name=replset-0 --hostname=replset-0 --network ${network_name} --network-alias mongodb ${BASE_ARGS} $IMAGE_NAME run-mongod-replication
+    docker run -d --cidfile $CIDFILE_DIR/replset1 --name=replset-1 --hostname=replset-1 --network ${network_name} --network-alias mongodb ${BASE_ARGS} $IMAGE_NAME run-mongod-replication
+    docker run -d --cidfile $CIDFILE_DIR/replset2 --name=replset-2 --hostname=replset-2 --network ${network_name} --network-alias mongodb ${BASE_ARGS} $IMAGE_NAME run-mongod-replication
+
+
+    local host="$(docker run --rm -e MONGODB_REPLICA_NAME=rs0 --network ${network_name} ${IMAGE_NAME} bash -c '. /usr/share/container-scripts/mongodb/common.sh && echo $(replset_addr)')"
+
+    # Storing document into replset and wait replication to finish ...
+    docker run --rm -e MONGODB_REPLICA_NAME=rs0 -e MONGODB_ADMIN_PASSWORD=${ADMIN_PASS} --network ${network_name} ${IMAGE_NAME} bash -c "set -e
+      . /usr/share/container-scripts/mongodb/common.sh
+      . /usr/share/container-scripts/mongodb/test-functions.sh
+      wait_for_mongo_up '${host}'
+      wait_replicaset_members '${host}' 3
+      insert_and_wait_for_replication '${host}' '{a:5, b:10}'"
+
+    # Adding new container
+    docker run -d --cidfile $CIDFILE_DIR/replset3 --name=replset-3 --hostname=replset-3 --network ${network_name} --network-alias mongodb ${BASE_ARGS} $IMAGE_NAME run-mongod-replication
+
+    # Storing document into replset and wait replication to finish ...
+    docker run --rm -e MONGODB_REPLICA_NAME=rs0 -e MONGODB_ADMIN_PASSWORD=${ADMIN_PASS} --network ${network_name} ${IMAGE_NAME} bash -c "set -e
+      . /usr/share/container-scripts/mongodb/common.sh
+      . /usr/share/container-scripts/mongodb/test-functions.sh
+      wait_for_mongo_up '${host}'
+      wait_replicaset_members '${host}' 4
+      insert_and_wait_for_replication '${host}' '{a:5, b:10}'"
+
+    echo "  Success!"
+}
 
 # Tests.
 run_container_creation_tests
 run_configuration_tests
 USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin
 # Test with random uid in container
-CONTAINER_ARGS="-u 12345" USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin_altuid
-run_change_password_test
-run_mount_config_test
-run_doc_test
+#CONTAINER_ARGS="-u 12345" USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin_altuid
+#run_change_password_test
+#run_mount_config_test
+#run_doc_test
+#CONTAINER_ARGS="-u 12345" USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin_altuid
+#run_change_password_test
+#run_mount_config_test
+
+run_local_replication_test

--- a/3.0-upg/Dockerfile.rhel7
+++ b/3.0-upg/Dockerfile.rhel7
@@ -30,7 +30,7 @@ CMD ["run-mongod"]
 RUN yum install -y yum-utils && \
     yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
-    INSTALL_PKGS="bind-utils gettext iproute rsync tar v8314 rh-mongodb30upg-mongodb rh-mongodb30upg" && \
+    INSTALL_PKGS="bind-utils gettext iproute rsync tar hostname v8314 rh-mongodb30upg-mongodb rh-mongodb30upg" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all

--- a/3.0-upg/root/usr/share/container-scripts/mongodb/common.sh
+++ b/3.0-upg/root/usr/share/container-scripts/mongodb/common.sh
@@ -73,7 +73,8 @@ function replset_addr() {
   local current_endpoints
   current_endpoints="$(endpoints)"
   if [ -z "${current_endpoints}" ]; then
-    echo >&2 "Cannot get address of replica set: no nodes are listed in service"
+    info "Cannot get address of replica set: no nodes are listed in service!"
+    info "CAUSE: DNS lookup for '${MONGODB_SERVICE_NAME:-mongodb}' returned no results."
     return 1
   fi
   echo "${MONGODB_REPLICA_NAME}/${current_endpoints//[[:space:]]/,}"

--- a/3.0-upg/root/usr/share/container-scripts/mongodb/init-replset.sh
+++ b/3.0-upg/root/usr/share/container-scripts/mongodb/init-replset.sh
@@ -10,18 +10,6 @@ source "${CONTAINER_SCRIPTS_PATH}/common.sh"
 # (for example, "replica-2.mongodb.myproject.svc.cluster.local")
 readonly MEMBER_HOST="$(hostname -f)"
 
-# Outputs available endpoints (hostnames) to stdout.
-# This also includes hostname of the current pod.
-#
-# Uses the following global variables:
-# - MONGODB_SERVICE_NAME (optional, defaults to 'mongodb')
-function find_endpoints() {
-  local service_name="${MONGODB_SERVICE_NAME:-mongodb}"
-
-  # Extract host names from lines like this: "10 33 0 mongodb-2.mongodb.myproject.svc.cluster.local."
-  dig "${service_name}" SRV +search +short | cut -d' ' -f4 | rev | cut -c2- | rev
-}
-
 # Initializes the replica set configuration.
 #
 # Arguments:
@@ -60,20 +48,7 @@ function add_member() {
   local host="$1"
   info "Adding ${host} to replica set ..."
 
-  # TODO: replace this with a call to `replset_addr` from common.sh, once it returns host names.
-  local endpoints
-  endpoints="$(find_endpoints | paste -s -d,)"
-
-  if [ -z "${endpoints}" ]; then
-    info "ERROR: couldn't add host to replica set!"
-    info "CAUSE: DNS lookup for '${MONGODB_SERVICE_NAME:-mongodb}' returned no results."
-    return 1
-  fi
-
-  local replset_addr
-  replset_addr="${MONGODB_REPLICA_NAME}/${endpoints}"
-
-  if ! mongo admin -u admin -p "${MONGODB_ADMIN_PASSWORD}" --host "${replset_addr}" --eval "while (!rs.add('${host}').ok) { sleep(100); }" --quiet; then
+  if ! mongo admin -u admin -p "${MONGODB_ADMIN_PASSWORD}" --host "$(replset_addr)" --eval "while (!rs.add('${host}').ok) { sleep(100); }" --quiet; then
     info "ERROR: couldn't add host to replica set!"
     return 1
   fi

--- a/3.0-upg/test/run
+++ b/3.0-upg/test/run
@@ -386,31 +386,40 @@ run_doc_test() {
 }
 
 function run_local_replication_test() {
+    function print_logs() {
+      for file in $CIDFILE_DIR/replset*; do
+        echo "INFO: printing logs for CID file ${file}"
+        docker logs $(cat ${file})
+      done
+    }
+    trap print_logs ERR
+
     echo "Testing replication on local docker"
     #Initializing replicaset
-    ADMIN_PASS=adminPassword
-    BASE_ARGS="
--e MONGODB_DATABASE=db
--e MONGODB_USER=user
--e MONGODB_PASSWORD=password
--e MONGODB_ADMIN_PASSWORD=${ADMIN_PASS}
--e MONGODB_REPLICA_NAME=rs0
--e MONGODB_KEYFILE_VALUE=xxxxxxxxxxxx
--e MONGODB_SMALLFILES=true
--e MONGODB_SERVICE_NAME=mongodb"
+
+    cat > variables <<EOF
+    MONGODB_DATABASE=db
+    MONGODB_USER=user
+    MONGODB_PASSWORD=password
+    MONGODB_ADMIN_PASSWORD=adminPassword
+    MONGODB_REPLICA_NAME=rs0
+    MONGODB_KEYFILE_VALUE=xxxxxxxxxxxx
+    MONGODB_SMALLFILES=true
+    MONGODB_SERVICE_NAME=mongodb
+EOF
+    source variables
 
     local network_name="mongodb-replset-$$"
     docker network create ${network_name}
 
-    docker run -d --cidfile $CIDFILE_DIR/replset0 --name=replset-0 --hostname=replset-0 --network ${network_name} --network-alias mongodb ${BASE_ARGS} $IMAGE_NAME run-mongod-replication
-    docker run -d --cidfile $CIDFILE_DIR/replset1 --name=replset-1 --hostname=replset-1 --network ${network_name} --network-alias mongodb ${BASE_ARGS} $IMAGE_NAME run-mongod-replication
-    docker run -d --cidfile $CIDFILE_DIR/replset2 --name=replset-2 --hostname=replset-2 --network ${network_name} --network-alias mongodb ${BASE_ARGS} $IMAGE_NAME run-mongod-replication
+    docker run -d --cidfile $CIDFILE_DIR/replset0 --name=replset-0 --hostname=replset-0 --network ${network_name} --network-alias mongodb --env-file=variables $IMAGE_NAME run-mongod-replication
+    docker run -d --cidfile $CIDFILE_DIR/replset1 --name=replset-1 --hostname=replset-1 --network ${network_name} --network-alias mongodb --env-file=variables $IMAGE_NAME run-mongod-replication
+    docker run -d --cidfile $CIDFILE_DIR/replset2 --name=replset-2 --hostname=replset-2 --network ${network_name} --network-alias mongodb --env-file=variables $IMAGE_NAME run-mongod-replication
 
-
-    local host="$(docker run --rm -e MONGODB_REPLICA_NAME=rs0 --network ${network_name} ${IMAGE_NAME} bash -c '. /usr/share/container-scripts/mongodb/common.sh && echo $(replset_addr)')"
+    local host="$(docker run --rm --env-file=variables --network ${network_name} ${IMAGE_NAME} bash -c '. /usr/share/container-scripts/mongodb/common.sh && echo $(replset_addr)')"
 
     # Storing document into replset and wait replication to finish ...
-    docker run --rm -e MONGODB_REPLICA_NAME=rs0 -e MONGODB_ADMIN_PASSWORD=${ADMIN_PASS} --network ${network_name} ${IMAGE_NAME} bash -c "set -e
+    docker run --rm --env-file=variables --network ${network_name} ${IMAGE_NAME} bash -c "set -e
       . /usr/share/container-scripts/mongodb/common.sh
       . /usr/share/container-scripts/mongodb/test-functions.sh
       wait_for_mongo_up '${host}'
@@ -418,15 +427,18 @@ function run_local_replication_test() {
       insert_and_wait_for_replication '${host}' '{a:5, b:10}'"
 
     # Adding new container
-    docker run -d --cidfile $CIDFILE_DIR/replset3 --name=replset-3 --hostname=replset-3 --network ${network_name} --network-alias mongodb ${BASE_ARGS} $IMAGE_NAME run-mongod-replication
+    docker run -d --cidfile $CIDFILE_DIR/replset3 --name=replset-3 --hostname=replset-3 --network ${network_name} --network-alias mongodb --env-file=variables $IMAGE_NAME run-mongod-replication
 
     # Storing document into replset and wait replication to finish ...
-    docker run --rm -e MONGODB_REPLICA_NAME=rs0 -e MONGODB_ADMIN_PASSWORD=${ADMIN_PASS} --network ${network_name} ${IMAGE_NAME} bash -c "set -e
+    docker run --rm --env-file=variables --network ${network_name} ${IMAGE_NAME} bash -c "set -e
       . /usr/share/container-scripts/mongodb/common.sh
       . /usr/share/container-scripts/mongodb/test-functions.sh
       wait_for_mongo_up '${host}'
       wait_replicaset_members '${host}' 4
       insert_and_wait_for_replication '${host}' '{a:5, b:10}'"
+
+    rm variables
+    trap ERR
 
     echo "  Success!"
 }

--- a/3.0-upg/test/run
+++ b/3.0-upg/test/run
@@ -452,12 +452,8 @@ run_container_creation_tests
 run_configuration_tests
 USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin
 # Test with random uid in container
-#CONTAINER_ARGS="-u 12345" USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin_altuid
-#run_change_password_test
-#run_mount_config_test
-#run_doc_test
-#CONTAINER_ARGS="-u 12345" USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin_altuid
-#run_change_password_test
-#run_mount_config_test
-
+CONTAINER_ARGS="-u 12345" USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin_altuid
+run_change_password_test
+run_mount_config_test
+run_doc_test
 run_local_replication_test

--- a/3.0-upg/test/run
+++ b/3.0-upg/test/run
@@ -413,8 +413,11 @@ EOF
     docker network create ${network_name}
 
     docker run -d --cidfile $CIDFILE_DIR/replset0 --name=replset-0 --hostname=replset-0 --network ${network_name} --network-alias mongodb --env-file=variables $IMAGE_NAME run-mongod-replication
+    docker exec replset-0 bash -c "while ! [ -f /tmp/initialized ]; do sleep 1; done"
     docker run -d --cidfile $CIDFILE_DIR/replset1 --name=replset-1 --hostname=replset-1 --network ${network_name} --network-alias mongodb --env-file=variables $IMAGE_NAME run-mongod-replication
+    docker exec replset-1 bash -c "while ! [ -f /tmp/initialized ]; do sleep 1; done"
     docker run -d --cidfile $CIDFILE_DIR/replset2 --name=replset-2 --hostname=replset-2 --network ${network_name} --network-alias mongodb --env-file=variables $IMAGE_NAME run-mongod-replication
+    docker exec replset-2 bash -c "while ! [ -f /tmp/initialized ]; do sleep 1; done"
 
     local host="$(docker run --rm --env-file=variables --network ${network_name} ${IMAGE_NAME} bash -c '. /usr/share/container-scripts/mongodb/common.sh && echo $(replset_addr)')"
 
@@ -428,6 +431,7 @@ EOF
 
     # Adding new container
     docker run -d --cidfile $CIDFILE_DIR/replset3 --name=replset-3 --hostname=replset-3 --network ${network_name} --network-alias mongodb --env-file=variables $IMAGE_NAME run-mongod-replication
+    docker exec replset-3 bash -c "while ! [ -f /tmp/initialized ]; do sleep 1; done"
 
     # Storing document into replset and wait replication to finish ...
     docker run --rm --env-file=variables --network ${network_name} ${IMAGE_NAME} bash -c "set -e

--- a/3.0-upg/test/run
+++ b/3.0-upg/test/run
@@ -24,6 +24,9 @@ function cleanup() {
         echo "Done."
     done
     rmdir $CIDFILE_DIR
+
+    local network_name="mongodb-replset-$$"
+    docker network ls | grep -q ${network_name} && docker network rm ${network_name}
 }
 trap cleanup EXIT SIGINT
 
@@ -382,13 +385,63 @@ run_doc_test() {
   echo
 }
 
+function run_local_replication_test() {
+    echo "Testing replication on local docker"
+    #Initializing replicaset
+    ADMIN_PASS=adminPassword
+    BASE_ARGS="
+-e MONGODB_DATABASE=db
+-e MONGODB_USER=user
+-e MONGODB_PASSWORD=password
+-e MONGODB_ADMIN_PASSWORD=${ADMIN_PASS}
+-e MONGODB_REPLICA_NAME=rs0
+-e MONGODB_KEYFILE_VALUE=xxxxxxxxxxxx
+-e MONGODB_SMALLFILES=true
+-e MONGODB_SERVICE_NAME=mongodb"
+
+    local network_name="mongodb-replset-$$"
+    docker network create ${network_name}
+
+    docker run -d --cidfile $CIDFILE_DIR/replset0 --name=replset-0 --hostname=replset-0 --network ${network_name} --network-alias mongodb ${BASE_ARGS} $IMAGE_NAME run-mongod-replication
+    docker run -d --cidfile $CIDFILE_DIR/replset1 --name=replset-1 --hostname=replset-1 --network ${network_name} --network-alias mongodb ${BASE_ARGS} $IMAGE_NAME run-mongod-replication
+    docker run -d --cidfile $CIDFILE_DIR/replset2 --name=replset-2 --hostname=replset-2 --network ${network_name} --network-alias mongodb ${BASE_ARGS} $IMAGE_NAME run-mongod-replication
+
+
+    local host="$(docker run --rm -e MONGODB_REPLICA_NAME=rs0 --network ${network_name} ${IMAGE_NAME} bash -c '. /usr/share/container-scripts/mongodb/common.sh && echo $(replset_addr)')"
+
+    # Storing document into replset and wait replication to finish ...
+    docker run --rm -e MONGODB_REPLICA_NAME=rs0 -e MONGODB_ADMIN_PASSWORD=${ADMIN_PASS} --network ${network_name} ${IMAGE_NAME} bash -c "set -e
+      . /usr/share/container-scripts/mongodb/common.sh
+      . /usr/share/container-scripts/mongodb/test-functions.sh
+      wait_for_mongo_up '${host}'
+      wait_replicaset_members '${host}' 3
+      insert_and_wait_for_replication '${host}' '{a:5, b:10}'"
+
+    # Adding new container
+    docker run -d --cidfile $CIDFILE_DIR/replset3 --name=replset-3 --hostname=replset-3 --network ${network_name} --network-alias mongodb ${BASE_ARGS} $IMAGE_NAME run-mongod-replication
+
+    # Storing document into replset and wait replication to finish ...
+    docker run --rm -e MONGODB_REPLICA_NAME=rs0 -e MONGODB_ADMIN_PASSWORD=${ADMIN_PASS} --network ${network_name} ${IMAGE_NAME} bash -c "set -e
+      . /usr/share/container-scripts/mongodb/common.sh
+      . /usr/share/container-scripts/mongodb/test-functions.sh
+      wait_for_mongo_up '${host}'
+      wait_replicaset_members '${host}' 4
+      insert_and_wait_for_replication '${host}' '{a:5, b:10}'"
+
+    echo "  Success!"
+}
 
 # Tests.
 run_container_creation_tests
 run_configuration_tests
 USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin
 # Test with random uid in container
-CONTAINER_ARGS="-u 12345" USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin_altuid
-run_change_password_test
-run_mount_config_test
-run_doc_test
+#CONTAINER_ARGS="-u 12345" USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin_altuid
+#run_change_password_test
+#run_mount_config_test
+#run_doc_test
+#CONTAINER_ARGS="-u 12345" USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin_altuid
+#run_change_password_test
+#run_mount_config_test
+
+run_local_replication_test

--- a/3.2/Dockerfile.rhel7
+++ b/3.2/Dockerfile.rhel7
@@ -30,7 +30,7 @@ CMD ["run-mongod"]
 RUN yum install -y yum-utils && \
     yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
-    INSTALL_PKGS="bind-utils gettext iproute rsync tar rh-mongodb32-mongodb rh-mongodb32 rh-mongodb32-mongo-tools" && \
+    INSTALL_PKGS="bind-utils gettext iproute rsync tar hostname rh-mongodb32-mongodb rh-mongodb32 rh-mongodb32-mongo-tools" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all

--- a/3.2/root/usr/share/container-scripts/mongodb/common.sh
+++ b/3.2/root/usr/share/container-scripts/mongodb/common.sh
@@ -67,7 +67,8 @@ function replset_addr() {
   local current_endpoints
   current_endpoints="$(endpoints)"
   if [ -z "${current_endpoints}" ]; then
-    echo >&2 "Cannot get address of replica set: no nodes are listed in service"
+    info "Cannot get address of replica set: no nodes are listed in service!"
+    info "CAUSE: DNS lookup for '${MONGODB_SERVICE_NAME:-mongodb}' returned no results."
     return 1
   fi
   echo "${MONGODB_REPLICA_NAME}/${current_endpoints//[[:space:]]/,}"

--- a/3.2/root/usr/share/container-scripts/mongodb/init-replset.sh
+++ b/3.2/root/usr/share/container-scripts/mongodb/init-replset.sh
@@ -10,18 +10,6 @@ source "${CONTAINER_SCRIPTS_PATH}/common.sh"
 # (for example, "replica-2.mongodb.myproject.svc.cluster.local")
 readonly MEMBER_HOST="$(hostname -f)"
 
-# Outputs available endpoints (hostnames) to stdout.
-# This also includes hostname of the current pod.
-#
-# Uses the following global variables:
-# - MONGODB_SERVICE_NAME (optional, defaults to 'mongodb')
-function find_endpoints() {
-  local service_name="${MONGODB_SERVICE_NAME:-mongodb}"
-
-  # Extract host names from lines like this: "10 33 0 mongodb-2.mongodb.myproject.svc.cluster.local."
-  dig "${service_name}" SRV +search +short | cut -d' ' -f4 | rev | cut -c2- | rev
-}
-
 # Initializes the replica set configuration.
 #
 # Arguments:
@@ -60,20 +48,7 @@ function add_member() {
   local host="$1"
   info "Adding ${host} to replica set ..."
 
-  # TODO: replace this with a call to `replset_addr` from common.sh, once it returns host names.
-  local endpoints
-  endpoints="$(find_endpoints | paste -s -d,)"
-
-  if [ -z "${endpoints}" ]; then
-    info "ERROR: couldn't add host to replica set!"
-    info "CAUSE: DNS lookup for '${MONGODB_SERVICE_NAME:-mongodb}' returned no results."
-    return 1
-  fi
-
-  local replset_addr
-  replset_addr="${MONGODB_REPLICA_NAME}/${endpoints}"
-
-  if ! mongo admin -u admin -p "${MONGODB_ADMIN_PASSWORD}" --host "${replset_addr}" --eval "while (!rs.add('${host}').ok) { sleep(100); }" --quiet; then
+  if ! mongo admin -u admin -p "${MONGODB_ADMIN_PASSWORD}" --host "$(replset_addr)" --eval "while (!rs.add('${host}').ok) { sleep(100); }" --quiet; then
     info "ERROR: couldn't add host to replica set!"
     return 1
   fi

--- a/3.2/test/run
+++ b/3.2/test/run
@@ -414,31 +414,40 @@ run_WT_cache_test() {
 }
 
 function run_local_replication_test() {
+    function print_logs() {
+      for file in $CIDFILE_DIR/replset*; do
+        echo "INFO: printing logs for CID file ${file}"
+        docker logs $(cat ${file})
+      done
+    }
+    trap print_logs ERR
+
     echo "Testing replication on local docker"
     #Initializing replicaset
-    ADMIN_PASS=adminPassword
-    BASE_ARGS="
--e MONGODB_DATABASE=db
--e MONGODB_USER=user
--e MONGODB_PASSWORD=password
--e MONGODB_ADMIN_PASSWORD=${ADMIN_PASS}
--e MONGODB_REPLICA_NAME=rs0
--e MONGODB_KEYFILE_VALUE=xxxxxxxxxxxx
--e MONGODB_SMALLFILES=true
--e MONGODB_SERVICE_NAME=mongodb"
+
+    cat > variables <<EOF
+    MONGODB_DATABASE=db
+    MONGODB_USER=user
+    MONGODB_PASSWORD=password
+    MONGODB_ADMIN_PASSWORD=adminPassword
+    MONGODB_REPLICA_NAME=rs0
+    MONGODB_KEYFILE_VALUE=xxxxxxxxxxxx
+    MONGODB_SMALLFILES=true
+    MONGODB_SERVICE_NAME=mongodb
+EOF
+    source variables
 
     local network_name="mongodb-replset-$$"
     docker network create ${network_name}
 
-    docker run -d --cidfile $CIDFILE_DIR/replset0 --name=replset-0 --hostname=replset-0 --network ${network_name} --network-alias mongodb ${BASE_ARGS} $IMAGE_NAME run-mongod-replication
-    docker run -d --cidfile $CIDFILE_DIR/replset1 --name=replset-1 --hostname=replset-1 --network ${network_name} --network-alias mongodb ${BASE_ARGS} $IMAGE_NAME run-mongod-replication
-    docker run -d --cidfile $CIDFILE_DIR/replset2 --name=replset-2 --hostname=replset-2 --network ${network_name} --network-alias mongodb ${BASE_ARGS} $IMAGE_NAME run-mongod-replication
+    docker run -d --cidfile $CIDFILE_DIR/replset0 --name=replset-0 --hostname=replset-0 --network ${network_name} --network-alias mongodb --env-file=variables $IMAGE_NAME run-mongod-replication
+    docker run -d --cidfile $CIDFILE_DIR/replset1 --name=replset-1 --hostname=replset-1 --network ${network_name} --network-alias mongodb --env-file=variables $IMAGE_NAME run-mongod-replication
+    docker run -d --cidfile $CIDFILE_DIR/replset2 --name=replset-2 --hostname=replset-2 --network ${network_name} --network-alias mongodb --env-file=variables $IMAGE_NAME run-mongod-replication
 
-
-    local host="$(docker run --rm -e MONGODB_REPLICA_NAME=rs0 --network ${network_name} ${IMAGE_NAME} bash -c '. /usr/share/container-scripts/mongodb/common.sh && echo $(replset_addr)')"
+    local host="$(docker run --rm --env-file=variables --network ${network_name} ${IMAGE_NAME} bash -c '. /usr/share/container-scripts/mongodb/common.sh && echo $(replset_addr)')"
 
     # Storing document into replset and wait replication to finish ...
-    docker run --rm -e MONGODB_REPLICA_NAME=rs0 -e MONGODB_ADMIN_PASSWORD=${ADMIN_PASS} --network ${network_name} ${IMAGE_NAME} bash -c "set -e
+    docker run --rm --env-file=variables --network ${network_name} ${IMAGE_NAME} bash -c "set -e
       . /usr/share/container-scripts/mongodb/common.sh
       . /usr/share/container-scripts/mongodb/test-functions.sh
       wait_for_mongo_up '${host}'
@@ -446,15 +455,18 @@ function run_local_replication_test() {
       insert_and_wait_for_replication '${host}' '{a:5, b:10}'"
 
     # Adding new container
-    docker run -d --cidfile $CIDFILE_DIR/replset3 --name=replset-3 --hostname=replset-3 --network ${network_name} --network-alias mongodb ${BASE_ARGS} $IMAGE_NAME run-mongod-replication
+    docker run -d --cidfile $CIDFILE_DIR/replset3 --name=replset-3 --hostname=replset-3 --network ${network_name} --network-alias mongodb --env-file=variables $IMAGE_NAME run-mongod-replication
 
     # Storing document into replset and wait replication to finish ...
-    docker run --rm -e MONGODB_REPLICA_NAME=rs0 -e MONGODB_ADMIN_PASSWORD=${ADMIN_PASS} --network ${network_name} ${IMAGE_NAME} bash -c "set -e
+    docker run --rm --env-file=variables --network ${network_name} ${IMAGE_NAME} bash -c "set -e
       . /usr/share/container-scripts/mongodb/common.sh
       . /usr/share/container-scripts/mongodb/test-functions.sh
       wait_for_mongo_up '${host}'
       wait_replicaset_members '${host}' 4
       insert_and_wait_for_replication '${host}' '{a:5, b:10}'"
+
+    rm variables
+    trap ERR
 
     echo "  Success!"
 }

--- a/3.2/test/run
+++ b/3.2/test/run
@@ -24,6 +24,9 @@ function cleanup() {
         echo "Done."
     done
     rmdir $CIDFILE_DIR
+
+    local network_name="mongodb-replset-$$"
+    docker network ls | grep -q ${network_name} && docker network rm ${network_name}
 }
 trap cleanup EXIT SIGINT
 
@@ -410,6 +413,52 @@ run_WT_cache_test() {
     echo
 }
 
+function run_local_replication_test() {
+    echo "Testing replication on local docker"
+    #Initializing replicaset
+    ADMIN_PASS=adminPassword
+    BASE_ARGS="
+-e MONGODB_DATABASE=db
+-e MONGODB_USER=user
+-e MONGODB_PASSWORD=password
+-e MONGODB_ADMIN_PASSWORD=${ADMIN_PASS}
+-e MONGODB_REPLICA_NAME=rs0
+-e MONGODB_KEYFILE_VALUE=xxxxxxxxxxxx
+-e MONGODB_SMALLFILES=true
+-e MONGODB_SERVICE_NAME=mongodb"
+
+    local network_name="mongodb-replset-$$"
+    docker network create ${network_name}
+
+    docker run -d --cidfile $CIDFILE_DIR/replset0 --name=replset-0 --hostname=replset-0 --network ${network_name} --network-alias mongodb ${BASE_ARGS} $IMAGE_NAME run-mongod-replication
+    docker run -d --cidfile $CIDFILE_DIR/replset1 --name=replset-1 --hostname=replset-1 --network ${network_name} --network-alias mongodb ${BASE_ARGS} $IMAGE_NAME run-mongod-replication
+    docker run -d --cidfile $CIDFILE_DIR/replset2 --name=replset-2 --hostname=replset-2 --network ${network_name} --network-alias mongodb ${BASE_ARGS} $IMAGE_NAME run-mongod-replication
+
+
+    local host="$(docker run --rm -e MONGODB_REPLICA_NAME=rs0 --network ${network_name} ${IMAGE_NAME} bash -c '. /usr/share/container-scripts/mongodb/common.sh && echo $(replset_addr)')"
+
+    # Storing document into replset and wait replication to finish ...
+    docker run --rm -e MONGODB_REPLICA_NAME=rs0 -e MONGODB_ADMIN_PASSWORD=${ADMIN_PASS} --network ${network_name} ${IMAGE_NAME} bash -c "set -e
+      . /usr/share/container-scripts/mongodb/common.sh
+      . /usr/share/container-scripts/mongodb/test-functions.sh
+      wait_for_mongo_up '${host}'
+      wait_replicaset_members '${host}' 3
+      insert_and_wait_for_replication '${host}' '{a:5, b:10}'"
+
+    # Adding new container
+    docker run -d --cidfile $CIDFILE_DIR/replset3 --name=replset-3 --hostname=replset-3 --network ${network_name} --network-alias mongodb ${BASE_ARGS} $IMAGE_NAME run-mongod-replication
+
+    # Storing document into replset and wait replication to finish ...
+    docker run --rm -e MONGODB_REPLICA_NAME=rs0 -e MONGODB_ADMIN_PASSWORD=${ADMIN_PASS} --network ${network_name} ${IMAGE_NAME} bash -c "set -e
+      . /usr/share/container-scripts/mongodb/common.sh
+      . /usr/share/container-scripts/mongodb/test-functions.sh
+      wait_for_mongo_up '${host}'
+      wait_replicaset_members '${host}' 4
+      insert_and_wait_for_replication '${host}' '{a:5, b:10}'"
+
+    echo "  Success!"
+}
+
 
 # Tests.
 run_container_creation_tests
@@ -421,3 +470,4 @@ run_change_password_test
 run_mount_config_test
 run_doc_test
 run_WT_cache_test
+run_local_replication_test

--- a/3.2/test/run
+++ b/3.2/test/run
@@ -441,8 +441,11 @@ EOF
     docker network create ${network_name}
 
     docker run -d --cidfile $CIDFILE_DIR/replset0 --name=replset-0 --hostname=replset-0 --network ${network_name} --network-alias mongodb --env-file=variables $IMAGE_NAME run-mongod-replication
+    docker exec replset-0 bash -c "while ! [ -f /tmp/initialized ]; do sleep 1; done"
     docker run -d --cidfile $CIDFILE_DIR/replset1 --name=replset-1 --hostname=replset-1 --network ${network_name} --network-alias mongodb --env-file=variables $IMAGE_NAME run-mongod-replication
+    docker exec replset-1 bash -c "while ! [ -f /tmp/initialized ]; do sleep 1; done"
     docker run -d --cidfile $CIDFILE_DIR/replset2 --name=replset-2 --hostname=replset-2 --network ${network_name} --network-alias mongodb --env-file=variables $IMAGE_NAME run-mongod-replication
+    docker exec replset-2 bash -c "while ! [ -f /tmp/initialized ]; do sleep 1; done"
 
     local host="$(docker run --rm --env-file=variables --network ${network_name} ${IMAGE_NAME} bash -c '. /usr/share/container-scripts/mongodb/common.sh && echo $(replset_addr)')"
 
@@ -456,6 +459,7 @@ EOF
 
     # Adding new container
     docker run -d --cidfile $CIDFILE_DIR/replset3 --name=replset-3 --hostname=replset-3 --network ${network_name} --network-alias mongodb --env-file=variables $IMAGE_NAME run-mongod-replication
+    docker exec replset-3 bash -c "while ! [ -f /tmp/initialized ]; do sleep 1; done"
 
     # Storing document into replset and wait replication to finish ...
     docker run --rm --env-file=variables --network ${network_name} ${IMAGE_NAME} bash -c "set -e

--- a/examples/replset-docker/README.md
+++ b/examples/replset-docker/README.md
@@ -1,0 +1,92 @@
+# MongoDB Replication Example Using a Docker
+
+This [MongoDB replication](https://docs.mongodb.com/manual/replication/) example
+uses a [Docker engine](http://docker.com) to run replica set members.
+
+**This platform is mainly for developing and testing.**
+
+## Getting Started
+
+You will need an Docker engine where you can run containers. If you want to avoid running all replset members on one host, you can also use [Docker Swarm](https://docs.docker.com/swarm/).
+
+## Example Working Scenarios
+
+This section describes how this example is designed to work.
+
+**All practices for [MongoDB replication](https://docs.mongodb.com/manual/replication/) applies alto to this example**
+
+### Initial Deployment: 3-member Replica Set
+
+To create replica set with three members you can use this script:
+
+```bash
+cat > variables <<EOF
+MONGODB_DATABASE=db
+MONGODB_USER=user
+MONGODB_PASSWORD=password
+MONGODB_ADMIN_PASSWORD=adminPassword
+MONGODB_REPLICA_NAME=rs0
+MONGODB_KEYFILE_VALUE=xxxxxxxxxxxx
+MONGODB_SMALLFILES=true
+MONGODB_SERVICE_NAME=mongodb"
+EOF
+source variables
+
+IMAGE_NAME=centos/mongodb-32-centos7
+
+network_name="mongodb-replset"
+docker network create ${network_name}
+
+docker run -d --name replset-0 --hostname replset-0 --env-file=variables --network ${network_name} --network-alias ${MONGODB_SERVICE_NAME} ${IMAGE_NAME} run-mongod-pet
+docker run -d --name replset-1 --hostname replset-1 --env-file=variables --network ${network_name} --network-alias ${MONGODB_SERVICE_NAME} ${IMAGE_NAME} run-mongod-pet
+docker run -d --name replset-2 --hostname replset-2 --env-file=variables --network ${network_name} --network-alias ${MONGODB_SERVICE_NAME} ${IMAGE_NAME} run-mongod-pet
+```
+
+`run-mongod-pet` command have to be run in container (same scripts as for [OpenShift StatefulSet replication example](https://github.com/sclorg/mongodb-container/tree/master/examples/petset).
+
+Parameters for `docker run` command:
+- `--name` and `--hostname` have to be set to the same value for each container to proper inter-container addressing
+- same `--network-alias` has to be added to all containers to be able to automatically connect containers together (alias has to be equal to `$MONGODB_SERVICE_NAME`). This allows dynamic adding of members to replicaset.
+- all environmental variables required for replication have to be set - see help of the image (**TODO** write it somewhere - [deprecated](https://github.com/sclorg/mongodb-container/tree/master/2.4/examples/replica))
+
+To be able to select a container, which initialize the ReplicaSet, `HOSTNAME` of one container has to match this regular expression: `.*-0`.
+
+And later from one of the containers you can easilly connect to MongoDB:
+
+```console
+sh-4.2$ mongo $MONGODB_DATABASE -u $MONGODB_USER -p $MONGODB_PASSWORD --host $MONGODB_REPLICA_NAME/localhost
+MongoDB shell version: 3.2.6
+connecting to: sampledb
+rs0:PRIMARY>
+```
+
+Note: You can also use host version of mongo shell, but you have to substitute values of environmental variables and IP address instead of `localhost` by yourself.
+
+During the lifetime of your deployment, one or more of those members might crash or fail.  In this case, replica set member is removed. It some special cases, replica set configuration might not be updated -- see Known Limitations.
+
+**Note**: for production usage, you should maintain as much separation between
+members as possible. It is recommended to run containers on different hosts.
+
+### Adding member
+
+To add a new member into replicaset run:
+
+```bash
+docker run -d --name replset-3 --hostname replset-3 --env-file=variables --network ${network_name} --network-alias ${MONGODB_SERVICE_NAME} ${IMAGE_NAME} run-mongod-pet
+```
+
+New container is created and it automatically connects to the replica set.
+
+### Removing member
+
+To prevent possible data lost, automatic removing of members from replicaset is not supported.
+
+To do it:
+
+1. stop the container (for example `docker stop replset-2`)
+2. connect to replica set and [remove the member](https://docs.mongodb.com/manual/tutorial/remove-replica-set-member/)
+
+### Known Limitations
+
+* Adding or removing new member to replica set takes some time (elections, syncing,...), so after your command finished it may take some time until replica set is ready
+**TODO**  => suggest to use mongo from container and use functions from common.sh

--- a/examples/replset-docker/README.md
+++ b/examples/replset-docker/README.md
@@ -38,8 +38,11 @@ network_name="mongodb-replset"
 docker network create ${network_name}
 
 docker run -d --cidfile $CIDFILE_DIR/replset0 --name=replset-0 --hostname=replset-0 --network ${network_name} --network-alias mongodb --env-file=variables $IMAGE_NAME run-mongod-replication
+docker exec replset-0 bash -c "while ! [ -f /tmp/initialized ]; do sleep 1; done"
 docker run -d --cidfile $CIDFILE_DIR/replset1 --name=replset-1 --hostname=replset-1 --network ${network_name} --network-alias mongodb --env-file=variables $IMAGE_NAME run-mongod-replication
+docker exec replset-1 bash -c "while ! [ -f /tmp/initialized ]; do sleep 1; done"
 docker run -d --cidfile $CIDFILE_DIR/replset2 --name=replset-2 --hostname=replset-2 --network ${network_name} --network-alias mongodb --env-file=variables $IMAGE_NAME run-mongod-replication
+docker exec replset-2 bash -c "while ! [ -f /tmp/initialized ]; do sleep 1; done"
 ```
 
 `run-mongod-replication` command have to be run in container (same script as for [OpenShift StatefulSet replication example](https://github.com/sclorg/mongodb-container/tree/master/examples/petset).
@@ -73,6 +76,7 @@ To add a new member into replicaset run:
 
 ```bash
 docker run -d --cidfile $CIDFILE_DIR/replset3 --name=replset-3 --hostname=replset-3 --network ${network_name} --network-alias mongodb --env-file=variables $IMAGE_NAME run-mongod-replication
+docker exec replset-3 bash -c "while ! [ -f /tmp/initialized ]; do sleep 1; done"
 ```
 
 New container is created and it automatically connects to the replica set.


### PR DESCRIPTION
This PR allows user to create replset using only local docker. Also test for testing local replset is added.

This is replacement of #178.

Creating of replset would be (taken from README):
```
cat > variables <<EOF
MONGODB_DATABASE=db
MONGODB_USER=user
MONGODB_PASSWORD=password
MONGODB_ADMIN_PASSWORD=adminPassword
MONGODB_REPLICA_NAME=rs0
MONGODB_KEYFILE_VALUE=xxxxxxxxxxxx
MONGODB_SMALLFILES=true
MONGODB_SERVICE_NAME=mongodb"
EOF
source variables

IMAGE_NAME=centos/mongodb-32-centos7

network_name="mongodb-replset"
docker network create ${network_name}

docker run -d --cidfile $CIDFILE_DIR/replset0 --name=replset-0 --hostname=replset-0 --network ${network_name} --network-alias mongodb --env-file=variables $IMAGE_NAME run-mongod-replication
docker exec replset-0 bash -c "while ! [ -f /tmp/initialized ]; do sleep 1; done"
docker run -d --cidfile $CIDFILE_DIR/replset1 --name=replset-1 --hostname=replset-1 --network ${network_name} --network-alias mongodb --env-file=variables $IMAGE_NAME run-mongod-replication
docker exec replset-1 bash -c "while ! [ -f /tmp/initialized ]; do sleep 1; done"
docker run -d --cidfile $CIDFILE_DIR/replset2 --name=replset-2 --hostname=replset-2 --network ${network_name} --network-alias mongodb --env-file=variables $IMAGE_NAME run-mongod-replication
docker exec replset-2 bash -c "while ! [ -f /tmp/initialized ]; do sleep 1; done"
```

I am not sure about these two things:
1) remove members from replset config after container exits?
2) have one initializing pod which exits after replset is initialized?

(it is similar to difference petset vs. replset scripts in this repo)  

@bparees @hhorak What are you opinions?

IMPOV:
1) We are adding containers dynamically. So it seems to me logical also to remove them automatically. Absence of dynamic removing removes a lot of advantages of containers (quick reacting to changing situation), because it is required to manually update replset internal configuration. Also somehow specify unique IP for every starting container.
2) I am not sure about this. Docker allows setting restart policy for containers, so user could specify to automatically restart failed container. In case "container making initialization" equals "one member of replset" - it would not be possible to use automatic restarting (starting this container for second time will fail). So maybe I vote for exiting container which do initialization.

**UPDATE:**

Answer to both questions is "do it same as `PetSet` is Kubernetes`. So container only for initialization and no removing from mongodb replicaset configuration.
It is possible to use same code for docker replication as used in OpenShift template using `PetSet`. To do this, two things have to be changed:

- DNS of "pure" docker does not support  `SRV` records (was used in `init-replset.sh`). It was used during connecting to replicaset. Using A records is the same, because  SRV records are used immediately after they are obtained (so they are immediately resolved to IP addresses too)

- Container is using `hostname -f` to get its identification which is added to replicaset configuration. But this command is not in RHEL base image, so I added it. @bparees Are RHEL based images also tested and used in OpenShift? I thought yes... 