### PR TITLE
Update default config file to YAML format

### DIFF
--- a/2.6/root/usr/bin/run-mongod
+++ b/2.6/root/usr/bin/run-mongod
@@ -13,7 +13,7 @@ function usage() {
   echo "  MONGODB_DATABASE"
   echo "  MONGODB_ADMIN_PASSWORD"
   echo "MongoDB settings:"
-  echo "  MONGODB_NOPREALLOC (default: true)"
+  echo "  MONGODB_PREALLOC (default: false)"
   echo "  MONGODB_SMALLFILES (default: true)"
   echo "  MONGODB_QUIET (default: true)"
   exit 1

--- a/2.6/root/usr/bin/run-mongod-replication
+++ b/2.6/root/usr/bin/run-mongod-replication
@@ -28,7 +28,7 @@ function usage() {
   echo "Optional variables:"
   echo "  MONGODB_SERVICE_NAME (default: mongodb)"
   echo "MongoDB settings:"
-  echo "  MONGODB_NOPREALLOC (default: true)"
+  echo "  MONGODB_PREALLOC (default: false)"
   echo "  MONGODB_SMALLFILES (default: true)"
   echo "  MONGODB_QUIET (default: true)"
   exit 1

--- a/2.6/root/usr/share/container-scripts/mongodb/README.md
+++ b/2.6/root/usr/share/container-scripts/mongodb/README.md
@@ -22,7 +22,8 @@ The following environment variables influence the MongoDB configuration file. Th
 
 |    Variable name      |    Description                                                            |    Default
 | :-------------------- | ------------------------------------------------------------------------- | ----------------
-|  `MONGODB_NOPREALLOC` | Disable data file preallocation.                                          |  true
+|  `MONGODB_PREALLOC`   | Enable data file preallocation.                                           |  false
+|  `MONGODB_NOPREALLOC`   | DEPRECATED - use `MONGODB_PREALLOC` instead. Disable data file preallocation. |
 |  `MONGODB_SMALLFILES` | Set MongoDB to use a smaller default data file size.                      |  true
 |  `MONGODB_QUIET`      | Runs MongoDB in a quiet mode that attempts to limit the amount of output. |  true
 

--- a/2.6/root/usr/share/container-scripts/mongodb/common.sh
+++ b/2.6/root/usr/share/container-scripts/mongodb/common.sh
@@ -10,7 +10,11 @@ set -o pipefail
 export MONGODB_DATADIR=/var/lib/mongodb/data
 export CONTAINER_PORT=27017
 # Configuration settings.
-export MONGODB_NOPREALLOC=${MONGODB_NOPREALLOC:-true}
+if [[ "${MONGODB_NOPREALLOC:-}" == "false" ]]; then
+  export MONGODB_PREALLOC=${MONGODB_PREALLOC:-true}
+else
+  export MONGODB_PREALLOC=${MONGODB_PREALLOC:-false}
+fi
 export MONGODB_SMALLFILES=${MONGODB_SMALLFILES:-true}
 export MONGODB_QUIET=${MONGODB_QUIET:-true}
 

--- a/2.6/root/usr/share/container-scripts/mongodb/mongodb.conf.template
+++ b/2.6/root/usr/share/container-scripts/mongodb/mongodb.conf.template
@@ -1,23 +1,34 @@
-# mongodb.conf
+##
+## For list of options visit:
+## https://docs.mongodb.org/manual/reference/configuration-options/
+##
 
-port = ${CONTAINER_PORT}
+# systemLog Options - How to do logging
+systemLog:
+  # Runs the mongod in a quiet mode that attempts to limit the amount of output
+  quiet: ${MONGODB_QUIET}
 
-# Set this value to designate a directory for the mongod instance to store its data.
-# Default: /var/lib/mongodb/data
-dbpath = ${MONGODB_DATADIR}
 
-# Disable data file preallocation. Default: true
-noprealloc = ${MONGODB_NOPREALLOC}
+# net Options - Network interfaces settings
+net:
+  # Specify port number (27017 by default)
+  port: ${CONTAINER_PORT}
 
-# Set MongoDB to use a smaller default data file size. Default: true
-smallfiles = ${MONGODB_SMALLFILES}
 
-# Runs MongoDB in a quiet mode that attempts to limit the amount of output.
-# Default: true
-quiet = ${MONGODB_QUIET}
+# storage Options - How and Where to store data
+storage:
+  # Directory for datafiles (defaults to /data/db/)
+  dbPath: ${MONGODB_DATADIR}
 
-# Disable the HTTP interface (Defaults to localhost:28017).
-nohttpinterface = true
+  # Enable or disable the preallocation of data files (true by default)
+  preallocDataFiles: ${MONGODB_PREALLOC}
 
-# Size to use (in MB) for replication op log (default 5% of disk space)
-oplogSize = 64
+  # Use a smaller default file size (false by default)
+  smallFiles: ${MONGODB_SMALLFILES}
+
+
+# replication Options - Configures replication
+replication:
+  # Specifies a maximum size in megabytes for the replication operation log (i.e. the oplog,
+  # 5% of disk space by default)
+  oplogSizeMB: 64

--- a/2.6/test/run
+++ b/2.6/test/run
@@ -95,10 +95,10 @@ function test_mongo() {
     echo "  Testing MongoDB"
     if [ -v ADMIN_PASS ]; then
         echo "  Testing Admin user privileges"
-        mongo_admin_cmd "db=db.getSiblingDB('${DB}');db.removeUser('${USER}');"
-        mongo_admin_cmd "db=db.getSiblingDB('${DB}');db.addUser({user:'${USER}',pwd:'${PASS}',roles:['readWrite','userAdmin','dbAdmin']});"
+        mongo_admin_cmd "db=db.getSiblingDB('${DB}');db.dropUser('${USER}');"
+        mongo_admin_cmd "db=db.getSiblingDB('${DB}');db.createUser({user:'${USER}',pwd:'${PASS}',roles:['readWrite','userAdmin','dbAdmin']});"
         mongo_admin_cmd "db=db.getSiblingDB('${DB}');db.testData.insert({x:0});"
-        mongo_cmd "db.addUser({user:'test_user2',pwd:'test_password2',roles:['readWrite']});"
+        mongo_cmd "db.createUser({user:'test_user2',pwd:'test_password2',roles:['readWrite']});"
     fi
     echo "  Testing user privileges"
     mongo_cmd "db.testData.insert({ y : 1 });"
@@ -112,10 +112,10 @@ function test_mongo() {
 
 function test_config_option() {
     local env_var=$1 ; shift
-    local setting=$1 ; shift
-    local value=$1 ; shift
+    local env_val=$1 ; shift
+    local config_part=$1 ; shift
 
-    local name="configuration_${setting}"
+    local name="configuration_${env_var}"
 
     # If $value is a string, it needs to be in simple quotes ''.
     DOCKER_ARGS="
@@ -123,7 +123,7 @@ function test_config_option() {
 -e MONGODB_USER=user
 -e MONGODB_PASSWORD=password
 -e MONGODB_ADMIN_PASSWORD=adminPassword
--e $env_var=${value//\'/}
+-e $env_var=${env_val}
 "
     create_container ${name} ${DOCKER_ARGS}
 
@@ -135,16 +135,17 @@ function test_config_option() {
     test_connection ${name}
 
     # If nothing is found, grep returns 1 and test fails.
-    docker exec $(get_cid $name) bash -c "cat /etc/mongod.conf" | grep -q "$setting = $value"
+    docker exec $(get_cid $name) bash -c "cat /etc/mongod.conf" | grep -q "${config_part}"
 
     docker stop $(get_cid ${name})
 }
 
 function run_configuration_tests() {
     echo "  Testing image configuration settings"
-    test_config_option MONGODB_NOPREALLOC noprealloc true
-    test_config_option MONGODB_SMALLFILES smallfiles true
-    test_config_option MONGODB_QUIET quiet true
+    test_config_option MONGODB_PREALLOC false "preallocDataFiles: false"
+    test_config_option MONGODB_NOPREALLOC true "preallocDataFiles: false"
+    test_config_option MONGODB_SMALLFILES true "smallFiles: true"
+    test_config_option MONGODB_QUIET true "quiet: true"
     echo "  Success!"
 }
 

--- a/3.0-upg/root/usr/bin/run-mongod
+++ b/3.0-upg/root/usr/bin/run-mongod
@@ -13,7 +13,7 @@ function usage() {
   echo "  MONGODB_DATABASE"
   echo "  MONGODB_ADMIN_PASSWORD"
   echo "MongoDB settings:"
-  echo "  MONGODB_NOPREALLOC (default: true)"
+  echo "  MONGODB_PREALLOC (default: false)"
   echo "  MONGODB_SMALLFILES (default: true)"
   echo "  MONGODB_QUIET (default: true)"
   exit 1

--- a/3.0-upg/root/usr/bin/run-mongod-replication
+++ b/3.0-upg/root/usr/bin/run-mongod-replication
@@ -28,7 +28,7 @@ function usage() {
   echo "Optional variables:"
   echo "  MONGODB_SERVICE_NAME (default: mongodb)"
   echo "MongoDB settings:"
-  echo "  MONGODB_NOPREALLOC (default: true)"
+  echo "  MONGODB_PREALLOC (default: false)"
   echo "  MONGODB_SMALLFILES (default: true)"
   echo "  MONGODB_QUIET (default: true)"
   exit 1

--- a/3.0-upg/root/usr/share/container-scripts/mongodb/README.md
+++ b/3.0-upg/root/usr/share/container-scripts/mongodb/README.md
@@ -24,7 +24,8 @@ The following environment variables influence the MongoDB configuration file. Th
 
 |    Variable name      |    Description                                                            |    Default
 | :-------------------- | ------------------------------------------------------------------------- | ----------------
-|  `MONGODB_NOPREALLOC` | Disable data file preallocation.                                          |  true
+|  `MONGODB_PREALLOC`   | Enable data file preallocation.                                           |  false
+|  `MONGODB_NOPREALLOC`   | DEPRECATED - use `MONGODB_PREALLOC` instead. Disable data file preallocation. |
 |  `MONGODB_SMALLFILES` | Set MongoDB to use a smaller default data file size.                      |  true
 |  `MONGODB_QUIET`      | Runs MongoDB in a quiet mode that attempts to limit the amount of output. |  true
 

--- a/3.0-upg/root/usr/share/container-scripts/mongodb/common.sh
+++ b/3.0-upg/root/usr/share/container-scripts/mongodb/common.sh
@@ -10,7 +10,11 @@ set -o pipefail
 export MONGODB_DATADIR=/var/lib/mongodb/data
 export CONTAINER_PORT=27017
 # Configuration settings.
-export MONGODB_NOPREALLOC=${MONGODB_NOPREALLOC:-true}
+if [[ "${MONGODB_NOPREALLOC:-}" == "false" ]]; then
+  export MONGODB_PREALLOC=${MONGODB_PREALLOC:-true}
+else
+  export MONGODB_PREALLOC=${MONGODB_PREALLOC:-false}
+fi
 export MONGODB_SMALLFILES=${MONGODB_SMALLFILES:-true}
 export MONGODB_QUIET=${MONGODB_QUIET:-true}
 

--- a/3.0-upg/root/usr/share/container-scripts/mongodb/mongodb.conf.template
+++ b/3.0-upg/root/usr/share/container-scripts/mongodb/mongodb.conf.template
@@ -1,23 +1,35 @@
-# mongodb.conf
+##
+## For list of options visit:
+## https://docs.mongodb.org/manual/reference/configuration-options/
+##
 
-port = ${CONTAINER_PORT}
+# systemLog Options - How to do logging
+systemLog:
+  # Runs the mongod in a quiet mode that attempts to limit the amount of output
+  quiet: ${MONGODB_QUIET}
 
-# Set this value to designate a directory for the mongod instance to store its data.
-# Default: /var/lib/mongodb/data
-dbpath = ${MONGODB_DATADIR}
 
-# Disable data file preallocation. Default: true
-noprealloc = ${MONGODB_NOPREALLOC}
+# net Options - Network interfaces settings
+net:
+  # Specify port number (27017 by default)
+  port: ${CONTAINER_PORT}
 
-# Set MongoDB to use a smaller default data file size. Default: true
-smallfiles = ${MONGODB_SMALLFILES}
 
-# Runs MongoDB in a quiet mode that attempts to limit the amount of output.
-# Default: true
-quiet = ${MONGODB_QUIET}
+# storage Options - How and Where to store data
+storage:
+  # Directory for datafiles (defaults to /data/db/)
+  dbPath: ${MONGODB_DATADIR}
 
-# Disable the HTTP interface (Defaults to localhost:28017).
-nohttpinterface = true
+  mmapv1:
+    # Enable or disable the preallocation of data files (true by default)
+    preallocDataFiles: ${MONGODB_PREALLOC}
 
-# Size to use (in MB) for replication op log (default 5% of disk space)
-oplogSize = 64
+    # Use a smaller default file size (false by default)
+    smallFiles: ${MONGODB_SMALLFILES}
+
+
+# replication Options - Configures replication
+replication:
+  # Specifies a maximum size in megabytes for the replication operation log (i.e. the oplog,
+  # 5% of disk space by default)
+  oplogSizeMB: 64

--- a/3.0-upg/test/run
+++ b/3.0-upg/test/run
@@ -95,7 +95,7 @@ function test_mongo() {
     echo "  Testing MongoDB"
     if [ -v ADMIN_PASS ]; then
         echo "  Testing Admin user privileges"
-        mongo_admin_cmd "db=db.getSiblingDB('${DB}');db.removeUser('${USER}');"
+        mongo_admin_cmd "db=db.getSiblingDB('${DB}');db.dropUser('${USER}');"
         mongo_admin_cmd "db=db.getSiblingDB('${DB}');db.createUser({user:'${USER}',pwd:'${PASS}',roles:['readWrite','userAdmin','dbAdmin']});"
         mongo_admin_cmd "db=db.getSiblingDB('${DB}');db.testData.insert({x:0});"
         mongo_cmd "db.createUser({user:'test_user2',pwd:'test_password2',roles:['readWrite']});"
@@ -112,10 +112,10 @@ function test_mongo() {
 
 function test_config_option() {
     local env_var=$1 ; shift
-    local setting=$1 ; shift
-    local value=$1 ; shift
+    local env_val=$1 ; shift
+    local config_part=$1 ; shift
 
-    local name="configuration_${setting}"
+    local name="configuration_${env_var}"
 
     # If $value is a string, it needs to be in simple quotes ''.
     DOCKER_ARGS="
@@ -123,7 +123,7 @@ function test_config_option() {
 -e MONGODB_USER=user
 -e MONGODB_PASSWORD=password
 -e MONGODB_ADMIN_PASSWORD=adminPassword
--e $env_var=${value//\'/}
+-e $env_var=${env_val}
 "
     create_container ${name} ${DOCKER_ARGS}
 
@@ -135,16 +135,17 @@ function test_config_option() {
     test_connection ${name}
 
     # If nothing is found, grep returns 1 and test fails.
-    docker exec $(get_cid $name) bash -c "cat /etc/mongod.conf" | grep -q "$setting = $value"
+    docker exec $(get_cid $name) bash -c "cat /etc/mongod.conf" | grep -q "${config_part}"
 
     docker stop $(get_cid ${name})
 }
 
 function run_configuration_tests() {
     echo "  Testing image configuration settings"
-    test_config_option MONGODB_NOPREALLOC noprealloc true
-    test_config_option MONGODB_SMALLFILES smallfiles true
-    test_config_option MONGODB_QUIET quiet true
+    test_config_option MONGODB_PREALLOC false "preallocDataFiles: false"
+    test_config_option MONGODB_NOPREALLOC true "preallocDataFiles: false"
+    test_config_option MONGODB_SMALLFILES true "smallFiles: true"
+    test_config_option MONGODB_QUIET true "quiet: true"
     echo "  Success!"
 }
 

--- a/3.2/root/usr/share/container-scripts/mongodb/mongodb.conf.template
+++ b/3.2/root/usr/share/container-scripts/mongodb/mongodb.conf.template
@@ -1,17 +1,28 @@
-# mongodb.conf
+##
+## For list of options visit:
+## https://docs.mongodb.org/manual/reference/configuration-options/
+##
 
-port = ${CONTAINER_PORT}
+# systemLog Options - How to do logging
+systemLog:
+  # Runs the mongod in a quiet mode that attempts to limit the amount of output
+  quiet: ${MONGODB_QUIET}
 
-# Set this value to designate a directory for the mongod instance to store its data.
-# Default: /var/lib/mongodb/data
-dbpath = ${MONGODB_DATADIR}
 
-# Runs MongoDB in a quiet mode that attempts to limit the amount of output.
-# Default: true
-quiet = ${MONGODB_QUIET}
+# net Options - Network interfaces settings
+net:
+  # Specify port number (27017 by default)
+  port: ${CONTAINER_PORT}
 
-# Disable the HTTP interface (Defaults to localhost:28017).
-nohttpinterface = true
 
-# Size to use (in MB) for replication op log (default 5% of disk space)
-oplogSize = 64
+# storage Options - How and Where to store data
+storage:
+  # Directory for datafiles (defaults to /data/db/)
+  dbPath: ${MONGODB_DATADIR}
+
+
+# replication Options - Configures replication
+replication:
+  # Specifies a maximum size in megabytes for the replication operation log (i.e. the oplog,
+  # 5% of disk space by default)
+  oplogSizeMB: 64

--- a/3.2/test/run
+++ b/3.2/test/run
@@ -112,10 +112,10 @@ function test_mongo() {
 
 function test_config_option() {
     local env_var=$1 ; shift
-    local setting=$1 ; shift
-    local value=$1 ; shift
+    local env_val=$1 ; shift
+    local config_part=$1 ; shift
 
-    local name="configuration_${setting}"
+    local name="configuration_${env_var}"
 
     # If $value is a string, it needs to be in simple quotes ''.
     DOCKER_ARGS="
@@ -123,7 +123,7 @@ function test_config_option() {
 -e MONGODB_USER=user
 -e MONGODB_PASSWORD=password
 -e MONGODB_ADMIN_PASSWORD=adminPassword
--e $env_var=${value//\'/}
+-e $env_var=${env_val}
 "
     create_container ${name} ${DOCKER_ARGS}
 
@@ -135,14 +135,14 @@ function test_config_option() {
     test_connection ${name}
 
     # If nothing is found, grep returns 1 and test fails.
-    docker exec $(get_cid $name) bash -c "cat /etc/mongod.conf" | grep -q "$setting = $value"
+    docker exec $(get_cid $name) bash -c "cat /etc/mongod.conf" | grep -q "${config_part}"
 
     docker stop $(get_cid ${name})
 }
 
 function run_configuration_tests() {
     echo "  Testing image configuration settings"
-    test_config_option MONGODB_QUIET quiet true
+    test_config_option MONGODB_QUIET true "quiet: true"
     echo "  Success!"
 }
 


### PR DESCRIPTION
Update default config file to YAML format which was introduced in MongoDB 2.6.

Few changes:
 - HTTP interface is disable by default from 2.6 (https://docs.mongodb.com/manual/core/security-mongodb-configuration/), so no option about this is necessary 
 - In new format, there are no options "no" prefix (eg noprealloc) -> `MONGODB_NOPREALLOC` have to be negationed

@bparees Please take a look.

Resolves: #197