### PR TITLE
Make only admin password mandatory.

### DIFF
--- a/2.6/root/usr/bin/run-mongod
+++ b/2.6/root/usr/bin/run-mongod
@@ -8,10 +8,11 @@ source ${CONTAINER_SCRIPTS_PATH}/common.sh
 
 function usage() {
   echo "You must specify the following environment variables:"
+  echo "  MONGODB_ADMIN_PASSWORD"
+  echo "Optionally you can provide settings for user with 'readWrite' role:"
   echo "  MONGODB_USER"
   echo "  MONGODB_PASSWORD"
   echo "  MONGODB_DATABASE"
-  echo "  MONGODB_ADMIN_PASSWORD"
   echo "MongoDB settings:"
   echo "  MONGODB_PREALLOC (default: false)"
   echo "  MONGODB_SMALLFILES (default: true)"
@@ -28,14 +29,16 @@ function cleanup() {
 
 trap 'cleanup' SIGINT SIGTERM
 
+[[ -v MONGODB_ADMIN_PASSWORD ]] || usage
+if [[ -v MONGODB_USER || -v MONGODB_PASSWORD || -v MONGODB_DATABASE ]]; then
+  [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE ]] || usage
+  CREATE_USER=1
+fi
+
 # If user provides own config file use it and do not generate new one
 if [ ! -s $MONGODB_CONFIG_PATH ]; then
   # Generate config file for MongoDB
   envsubst < ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template > $MONGODB_CONFIG_PATH
-fi
-
-if ! [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE && -v MONGODB_ADMIN_PASSWORD ]]; then
-  usage
 fi
 
 mongo_common_args="-f $MONGODB_CONFIG_PATH"
@@ -52,12 +55,14 @@ if [ "$(mongo admin --quiet --eval "$js_command")" == "1" ]; then
 else
   mongo_create_admin
 fi
-js_command="db.system.users.count({'user':'${MONGODB_USER}', 'db':'${MONGODB_DATABASE}'})"
-if [ "$(mongo admin --quiet --eval "$js_command")" == "1" ]; then
-  echo "=> MONGODB_USER user is already created. Resetting password ..."
-  mongo_reset_user
-else
-  mongo_create_user
+if [[ -v CREATE_USER ]]; then
+  js_command="db.system.users.count({'user':'${MONGODB_USER}', 'db':'${MONGODB_DATABASE}'})"
+  if [ "$(mongo admin --quiet --eval "$js_command")" == "1" ]; then
+    echo "=> MONGODB_USER user is already created. Resetting password ..."
+    mongo_reset_user
+  else
+    mongo_create_user
+  fi
 fi
 # Restart the MongoDB daemon to bind on all interfaces
 mongod $mongo_common_args --shutdown

--- a/2.6/root/usr/bin/run-mongod-replication
+++ b/2.6/root/usr/bin/run-mongod-replication
@@ -19,12 +19,13 @@ source ${CONTAINER_SCRIPTS_PATH}/common.sh
 
 function usage() {
   echo "You must specify the following environment variables:"
-  echo "  MONGODB_USER"
-  echo "  MONGODB_PASSWORD"
-  echo "  MONGODB_DATABASE"
   echo "  MONGODB_ADMIN_PASSWORD"
   echo "  MONGODB_KEYFILE_VALUE"
   echo "  MONGODB_REPLICA_NAME"
+  echo "Optionally you can provide settings for user with 'readWrite' role:"
+  echo "  MONGODB_USER"
+  echo "  MONGODB_PASSWORD"
+  echo "  MONGODB_DATABASE"
   echo "Optional variables:"
   echo "  MONGODB_SERVICE_NAME (default: mongodb)"
   echo "MongoDB settings:"
@@ -43,14 +44,16 @@ function cleanup() {
 
 trap 'cleanup' SIGINT SIGTERM
 
+[[ -v MONGODB_ADMIN_PASSWORD ]] || usage
+if [[ -v MONGODB_USER || -v MONGODB_PASSWORD || -v MONGODB_DATABASE ]]; then
+  [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE ]] || usage
+  CREATE_USER=1
+fi
+
 # If user provides own config file use it and do not generate new one
 if [ ! -s "${MONGODB_CONFIG_PATH}" ]; then
   # Generate config file for MongoDB
   envsubst < "${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template" > "${MONGODB_CONFIG_PATH}"
-fi
-
-if ! [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE && -v MONGODB_ADMIN_PASSWORD && -v MONGODB_KEYFILE_VALUE && -v MONGODB_REPLICA_NAME ]]; then
-  usage
 fi
 
 mongo_common_args="-f ${MONGODB_CONFIG_PATH}"

--- a/2.6/root/usr/share/container-scripts/mongodb/README.md
+++ b/2.6/root/usr/share/container-scripts/mongodb/README.md
@@ -12,10 +12,15 @@ initialization by passing `-e VAR=VALUE` to the Docker run command.
 
 |    Variable name          |    Description                              |
 | :------------------------ | -----------------------------------------   |
-|  `MONGODB_USER`       | User name for MONGODB account to be created |
+|  `MONGODB_ADMIN_PASSWORD` | Password for the admin user                 |
+
+Optionally you can provide settings for user with 'readWrite' role.
+
+|    Variable name          |    Description                              |
+| :------------------------ | -----------------------------------------   |
+|  `MONGODB_USER`           | User name for MONGODB account to be created |
 |  `MONGODB_PASSWORD`       | Password for the user account               |
 |  `MONGODB_DATABASE`       | Database name                               |
-|  `MONGODB_ADMIN_PASSWORD` | Password for the admin user                 |
 
 
 The following environment variables influence the MongoDB configuration file. They are all optional.

--- a/2.6/root/usr/share/container-scripts/mongodb/init-replset.sh
+++ b/2.6/root/usr/share/container-scripts/mongodb/init-replset.sh
@@ -43,7 +43,7 @@ function initiate() {
 
   info "Creating MongoDB users ..."
   mongo_create_admin
-  mongo_create_user "-u admin -p ${MONGODB_ADMIN_PASSWORD}"
+  [[ -v CREATE_USER ]] && mongo_create_user "-u admin -p ${MONGODB_ADMIN_PASSWORD}"
 
   info "Successfully initialized replica set"
 }

--- a/2.6/test/run
+++ b/2.6/test/run
@@ -45,6 +45,42 @@ function mongo_admin_cmd() {
     docker run --rm $IMAGE_NAME mongo admin --host $CONTAINER_IP -u admin -p "$ADMIN_PASS" --eval "${@}"
 }
 
+# Make sure the invocation of docker run fails.
+function assert_container_creation_fails() {
+
+  # Time the docker run command. It should fail. If it doesn't fail,
+  # container will keep running so we kill it with SIGKILL to make sure
+  # timeout returns a non-zero value.
+  set +e
+  timeout -s 9 --preserve-status 10s docker run --rm "$@" $IMAGE_NAME
+  ret=$?
+  set -e
+
+  # Timeout will exit with a high number.
+  if [ $ret -gt 30 ]; then
+    return 1
+  fi
+}
+
+function run_container_creation_tests() {
+  echo "  Testing wrong user variables usage"
+
+  assert_container_creation_fails -e MONGODB_USER=user -e MONGODB_PASSWORD=pass
+  assert_container_creation_fails -e MONGODB_DATABASE=db -e MONGODB_PASSWORD=pass
+  assert_container_creation_fails -e MONGODB_DATABASE=db -e MONGODB_USER=user
+  assert_container_creation_fails -e MONGODB_USER=user -e MONGODB_DATABASE=db -e MONGODB_PASSWORD=pass
+
+  assert_container_creation_fails -e MONGODB_ADMIN_PASSWORD=Pass -e MONGODB_USER=user
+  assert_container_creation_fails -e MONGODB_ADMIN_PASSWORD=Pass -e MONGODB_PASSWORD=pass
+  assert_container_creation_fails -e MONGODB_ADMIN_PASSWORD=Pass -e MONGODB_DATABASE=db
+
+  echo "  Success!"
+  echo "  Testing good user variables usage"
+  assert_container_creation_fails -e MONGODB_ADMIN_PASSWORD=Pass || [ $? -eq 1 ]
+  assert_container_creation_fails -e MONGODB_ADMIN_PASSWORD=Pass -e MONGODB_USER=user -e MONGODB_DATABASE=db -e MONGODB_PASSWORD=pass || [ $? -eq 1 ]
+  echo "  Success!"
+}
+
 function test_connection() {
     local name=$1 ; shift
     CONTAINER_IP=$(get_container_ip $name)
@@ -348,6 +384,7 @@ run_doc_test() {
 
 
 # Tests.
+run_container_creation_tests
 run_configuration_tests
 USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin
 # Test with random uid in container

--- a/3.0-upg/root/usr/bin/run-mongod
+++ b/3.0-upg/root/usr/bin/run-mongod
@@ -8,10 +8,11 @@ source ${CONTAINER_SCRIPTS_PATH}/common.sh
 
 function usage() {
   echo "You must specify the following environment variables:"
+  echo "  MONGODB_ADMIN_PASSWORD"
+  echo "Optionally you can provide settings for user with 'readWrite' role:"
   echo "  MONGODB_USER"
   echo "  MONGODB_PASSWORD"
   echo "  MONGODB_DATABASE"
-  echo "  MONGODB_ADMIN_PASSWORD"
   echo "MongoDB settings:"
   echo "  MONGODB_PREALLOC (default: false)"
   echo "  MONGODB_SMALLFILES (default: true)"
@@ -36,14 +37,16 @@ Notice: This image is supported only for upgrade from MongoDB 2.6 to 3.2.
 
 trap 'cleanup' SIGINT SIGTERM
 
+[[ -v MONGODB_ADMIN_PASSWORD ]] || usage
+if [[ -v MONGODB_USER || -v MONGODB_PASSWORD || -v MONGODB_DATABASE ]]; then
+  [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE ]] || usage
+  CREATE_USER=1
+fi
+
 # If user provides own config file use it and do not generate new one
 if [ ! -s $MONGODB_CONFIG_PATH ]; then
   # Generate config file for MongoDB
   envsubst < ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template > $MONGODB_CONFIG_PATH
-fi
-
-if ! [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE && -v MONGODB_ADMIN_PASSWORD ]]; then
-  usage
 fi
 
 mongo_common_args="-f $MONGODB_CONFIG_PATH"
@@ -60,12 +63,14 @@ if [ "$(mongo admin --quiet --eval "$js_command")" == "1" ]; then
 else
   mongo_create_admin
 fi
-js_command="db.system.users.count({'user':'${MONGODB_USER}', 'db':'${MONGODB_DATABASE}'})"
-if [ "$(mongo admin --quiet --eval "$js_command")" == "1" ]; then
-  echo "=> MONGODB_USER user is already created. Resetting password ..."
-  mongo_reset_user
-else
-  mongo_create_user
+if [[ -v CREATE_USER ]]; then
+  js_command="db.system.users.count({'user':'${MONGODB_USER}', 'db':'${MONGODB_DATABASE}'})"
+  if [ "$(mongo admin --quiet --eval "$js_command")" == "1" ]; then
+    echo "=> MONGODB_USER user is already created. Resetting password ..."
+    mongo_reset_user
+  else
+    mongo_create_user
+  fi
 fi
 # Restart the MongoDB daemon to bind on all interfaces
 mongod $mongo_common_args --shutdown

--- a/3.0-upg/root/usr/bin/run-mongod-replication
+++ b/3.0-upg/root/usr/bin/run-mongod-replication
@@ -19,12 +19,13 @@ source ${CONTAINER_SCRIPTS_PATH}/common.sh
 
 function usage() {
   echo "You must specify the following environment variables:"
-  echo "  MONGODB_USER"
-  echo "  MONGODB_PASSWORD"
-  echo "  MONGODB_DATABASE"
   echo "  MONGODB_ADMIN_PASSWORD"
   echo "  MONGODB_KEYFILE_VALUE"
   echo "  MONGODB_REPLICA_NAME"
+  echo "Optionally you can provide settings for user with 'readWrite' role:"
+  echo "  MONGODB_USER"
+  echo "  MONGODB_PASSWORD"
+  echo "  MONGODB_DATABASE"
   echo "Optional variables:"
   echo "  MONGODB_SERVICE_NAME (default: mongodb)"
   echo "MongoDB settings:"
@@ -43,14 +44,16 @@ function cleanup() {
 
 trap 'cleanup' SIGINT SIGTERM
 
+[[ -v MONGODB_ADMIN_PASSWORD ]] || usage
+if [[ -v MONGODB_USER || -v MONGODB_PASSWORD || -v MONGODB_DATABASE ]]; then
+  [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE ]] || usage
+  CREATE_USER=1
+fi
+
 # If user provides own config file use it and do not generate new one
 if [ ! -s "${MONGODB_CONFIG_PATH}" ]; then
   # Generate config file for MongoDB
   envsubst < "${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template" > "${MONGODB_CONFIG_PATH}"
-fi
-
-if ! [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE && -v MONGODB_ADMIN_PASSWORD && -v MONGODB_KEYFILE_VALUE && -v MONGODB_REPLICA_NAME ]]; then
-  usage
 fi
 
 mongo_common_args="-f ${MONGODB_CONFIG_PATH}"

--- a/3.0-upg/root/usr/share/container-scripts/mongodb/README.md
+++ b/3.0-upg/root/usr/share/container-scripts/mongodb/README.md
@@ -14,10 +14,15 @@ initialization by passing `-e VAR=VALUE` to the Docker run command.
 
 |    Variable name          |    Description                              |
 | :------------------------ | -----------------------------------------   |
-|  `MONGODB_USER`       | User name for MONGODB account to be created |
+|  `MONGODB_ADMIN_PASSWORD` | Password for the admin user                 |
+
+Optionally you can provide settings for user with 'readWrite' role.
+
+|    Variable name          |    Description                              |
+| :------------------------ | -----------------------------------------   |
+|  `MONGODB_USER`           | User name for MONGODB account to be created |
 |  `MONGODB_PASSWORD`       | Password for the user account               |
 |  `MONGODB_DATABASE`       | Database name                               |
-|  `MONGODB_ADMIN_PASSWORD` | Password for the admin user                 |
 
 
 The following environment variables influence the MongoDB configuration file. They are all optional.

--- a/3.0-upg/root/usr/share/container-scripts/mongodb/init-replset.sh
+++ b/3.0-upg/root/usr/share/container-scripts/mongodb/init-replset.sh
@@ -43,7 +43,7 @@ function initiate() {
 
   info "Creating MongoDB users ..."
   mongo_create_admin
-  mongo_create_user "-u admin -p ${MONGODB_ADMIN_PASSWORD}"
+  [[ -v CREATE_USER ]] && mongo_create_user "-u admin -p ${MONGODB_ADMIN_PASSWORD}"
 
   info "Successfully initialized replica set"
 }

--- a/3.0-upg/test/run
+++ b/3.0-upg/test/run
@@ -45,6 +45,42 @@ function mongo_admin_cmd() {
     docker run --rm $IMAGE_NAME mongo admin --host $CONTAINER_IP -u admin -p "$ADMIN_PASS" --eval "${@}"
 }
 
+# Make sure the invocation of docker run fails.
+function assert_container_creation_fails() {
+
+  # Time the docker run command. It should fail. If it doesn't fail,
+  # container will keep running so we kill it with SIGKILL to make sure
+  # timeout returns a non-zero value.
+  set +e
+  timeout -s 9 --preserve-status 10s docker run --rm "$@" $IMAGE_NAME
+  ret=$?
+  set -e
+
+  # Timeout will exit with a high number.
+  if [ $ret -gt 30 ]; then
+    return 1
+  fi
+}
+
+function run_container_creation_tests() {
+  echo "  Testing wrong user variables usage"
+
+  assert_container_creation_fails -e MONGODB_USER=user -e MONGODB_PASSWORD=pass
+  assert_container_creation_fails -e MONGODB_DATABASE=db -e MONGODB_PASSWORD=pass
+  assert_container_creation_fails -e MONGODB_DATABASE=db -e MONGODB_USER=user
+  assert_container_creation_fails -e MONGODB_USER=user -e MONGODB_DATABASE=db -e MONGODB_PASSWORD=pass
+
+  assert_container_creation_fails -e MONGODB_ADMIN_PASSWORD=Pass -e MONGODB_USER=user
+  assert_container_creation_fails -e MONGODB_ADMIN_PASSWORD=Pass -e MONGODB_PASSWORD=pass
+  assert_container_creation_fails -e MONGODB_ADMIN_PASSWORD=Pass -e MONGODB_DATABASE=db
+
+  echo "  Success!"
+  echo "  Testing good user variables usage"
+  assert_container_creation_fails -e MONGODB_ADMIN_PASSWORD=Pass || [ $? -eq 1 ]
+  assert_container_creation_fails -e MONGODB_ADMIN_PASSWORD=Pass -e MONGODB_USER=user -e MONGODB_DATABASE=db -e MONGODB_PASSWORD=pass || [ $? -eq 1 ]
+  echo "  Success!"
+}
+
 function test_connection() {
     local name=$1 ; shift
     CONTAINER_IP=$(get_container_ip $name)
@@ -348,6 +384,7 @@ run_doc_test() {
 
 
 # Tests.
+run_container_creation_tests
 run_configuration_tests
 USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin
 # Test with random uid in container

--- a/3.2/root/usr/bin/run-mongod
+++ b/3.2/root/usr/bin/run-mongod
@@ -8,10 +8,11 @@ source ${CONTAINER_SCRIPTS_PATH}/common.sh
 
 function usage() {
   echo "You must specify the following environment variables:"
+  echo "  MONGODB_ADMIN_PASSWORD"
+  echo "Optionally you can provide settings for user with 'readWrite' role:"
   echo "  MONGODB_USER"
   echo "  MONGODB_PASSWORD"
   echo "  MONGODB_DATABASE"
-  echo "  MONGODB_ADMIN_PASSWORD"
   echo "MongoDB settings:"
   echo "  MONGODB_QUIET (default: true)"
   exit 1
@@ -26,14 +27,16 @@ function cleanup() {
 
 trap 'cleanup' SIGINT SIGTERM
 
+[[ -v MONGODB_ADMIN_PASSWORD ]] || usage
+if [[ -v MONGODB_USER || -v MONGODB_PASSWORD || -v MONGODB_DATABASE ]]; then
+  [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE ]] || usage
+  CREATE_USER=1
+fi
+
 # If user provides own config file use it and do not generate new one
 if [ ! -s $MONGODB_CONFIG_PATH ]; then
   # Generate config file for MongoDB
   envsubst < ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template > $MONGODB_CONFIG_PATH
-fi
-
-if ! [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE && -v MONGODB_ADMIN_PASSWORD ]]; then
-  usage
 fi
 
 mongo_common_args="-f $MONGODB_CONFIG_PATH"
@@ -50,12 +53,14 @@ if [ "$(mongo admin --quiet --eval "$js_command")" == "1" ]; then
 else
   mongo_create_admin
 fi
-js_command="db.system.users.count({'user':'${MONGODB_USER}', 'db':'${MONGODB_DATABASE}'})"
-if [ "$(mongo admin --quiet --eval "$js_command")" == "1" ]; then
-  echo "=> MONGODB_USER user is already created. Resetting password ..."
-  mongo_reset_user
-else
-  mongo_create_user
+if [[ -v CREATE_USER ]]; then
+  js_command="db.system.users.count({'user':'${MONGODB_USER}', 'db':'${MONGODB_DATABASE}'})"
+  if [ "$(mongo admin --quiet --eval "$js_command")" == "1" ]; then
+    echo "=> MONGODB_USER user is already created. Resetting password ..."
+    mongo_reset_user
+  else
+    mongo_create_user
+  fi
 fi
 # Restart the MongoDB daemon to bind on all interfaces
 mongod $mongo_common_args --shutdown

--- a/3.2/root/usr/bin/run-mongod-replication
+++ b/3.2/root/usr/bin/run-mongod-replication
@@ -19,12 +19,13 @@ source ${CONTAINER_SCRIPTS_PATH}/common.sh
 
 function usage() {
   echo "You must specify the following environment variables:"
-  echo "  MONGODB_USER"
-  echo "  MONGODB_PASSWORD"
-  echo "  MONGODB_DATABASE"
   echo "  MONGODB_ADMIN_PASSWORD"
   echo "  MONGODB_KEYFILE_VALUE"
   echo "  MONGODB_REPLICA_NAME"
+  echo "Optionally you can provide settings for user with 'readWrite' role:"
+  echo "  MONGODB_USER"
+  echo "  MONGODB_PASSWORD"
+  echo "  MONGODB_DATABASE"
   echo "Optional variables:"
   echo "  MONGODB_SERVICE_NAME (default: mongodb)"
   echo "MongoDB settings:"
@@ -41,14 +42,16 @@ function cleanup() {
 
 trap 'cleanup' SIGINT SIGTERM
 
+[[ -v MONGODB_ADMIN_PASSWORD ]] || usage
+if [[ -v MONGODB_USER || -v MONGODB_PASSWORD || -v MONGODB_DATABASE ]]; then
+  [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE ]] || usage
+  CREATE_USER=1
+fi
+
 # If user provides own config file use it and do not generate new one
 if [ ! -s "${MONGODB_CONFIG_PATH}" ]; then
   # Generate config file for MongoDB
   envsubst < "${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template" > "${MONGODB_CONFIG_PATH}"
-fi
-
-if ! [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE && -v MONGODB_ADMIN_PASSWORD && -v MONGODB_KEYFILE_VALUE && -v MONGODB_REPLICA_NAME ]]; then
-  usage
 fi
 
 mongo_common_args="-f ${MONGODB_CONFIG_PATH}"

--- a/3.2/root/usr/share/container-scripts/mongodb/README.md
+++ b/3.2/root/usr/share/container-scripts/mongodb/README.md
@@ -12,10 +12,15 @@ initialization by passing `-e VAR=VALUE` to the Docker run command.
 
 |    Variable name          |    Description                              |
 | :------------------------ | -----------------------------------------   |
-|  `MONGODB_USER`       | User name for MONGODB account to be created |
+|  `MONGODB_ADMIN_PASSWORD` | Password for the admin user                 |
+
+Optionally you can provide settings for user with 'readWrite' role.
+
+|    Variable name          |    Description                              |
+| :------------------------ | -----------------------------------------   |
+|  `MONGODB_USER`           | User name for MONGODB account to be created |
 |  `MONGODB_PASSWORD`       | Password for the user account               |
 |  `MONGODB_DATABASE`       | Database name                               |
-|  `MONGODB_ADMIN_PASSWORD` | Password for the admin user                 |
 
 
 The following environment variables influence the MongoDB configuration file. They are all optional.

--- a/3.2/root/usr/share/container-scripts/mongodb/init-replset.sh
+++ b/3.2/root/usr/share/container-scripts/mongodb/init-replset.sh
@@ -43,7 +43,7 @@ function initiate() {
 
   info "Creating MongoDB users ..."
   mongo_create_admin
-  mongo_create_user "-u admin -p ${MONGODB_ADMIN_PASSWORD}"
+  [[ -v CREATE_USER ]] && mongo_create_user "-u admin -p ${MONGODB_ADMIN_PASSWORD}"
 
   info "Successfully initialized replica set"
 }

--- a/3.2/test/run
+++ b/3.2/test/run
@@ -45,6 +45,42 @@ function mongo_admin_cmd() {
     docker run --rm $IMAGE_NAME mongo admin --host $CONTAINER_IP -u admin -p "$ADMIN_PASS" --eval "${@}"
 }
 
+# Make sure the invocation of docker run fails.
+function assert_container_creation_fails() {
+
+  # Time the docker run command. It should fail. If it doesn't fail,
+  # container will keep running so we kill it with SIGKILL to make sure
+  # timeout returns a non-zero value.
+  set +e
+  timeout -s 9 --preserve-status 10s docker run --rm "$@" $IMAGE_NAME
+  ret=$?
+  set -e
+
+  # Timeout will exit with a high number.
+  if [ $ret -gt 30 ]; then
+    return 1
+  fi
+}
+
+function run_container_creation_tests() {
+  echo "  Testing wrong user variables usage"
+
+  assert_container_creation_fails -e MONGODB_USER=user -e MONGODB_PASSWORD=pass
+  assert_container_creation_fails -e MONGODB_DATABASE=db -e MONGODB_PASSWORD=pass
+  assert_container_creation_fails -e MONGODB_DATABASE=db -e MONGODB_USER=user
+  assert_container_creation_fails -e MONGODB_USER=user -e MONGODB_DATABASE=db -e MONGODB_PASSWORD=pass
+
+  assert_container_creation_fails -e MONGODB_ADMIN_PASSWORD=Pass -e MONGODB_USER=user
+  assert_container_creation_fails -e MONGODB_ADMIN_PASSWORD=Pass -e MONGODB_PASSWORD=pass
+  assert_container_creation_fails -e MONGODB_ADMIN_PASSWORD=Pass -e MONGODB_DATABASE=db
+
+  echo "  Success!"
+  echo "  Testing good user variables usage"
+  assert_container_creation_fails -e MONGODB_ADMIN_PASSWORD=Pass || [ $? -eq 1 ]
+  assert_container_creation_fails -e MONGODB_ADMIN_PASSWORD=Pass -e MONGODB_USER=user -e MONGODB_DATABASE=db -e MONGODB_PASSWORD=pass || [ $? -eq 1 ]
+  echo "  Success!"
+}
+
 function test_connection() {
     local name=$1 ; shift
     CONTAINER_IP=$(get_container_ip $name)
@@ -343,6 +379,7 @@ run_doc_test() {
 
 
 # Tests.
+run_container_creation_tests
 run_configuration_tests
 USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00t" run_tests admin
 # Test with random uid in container


### PR DESCRIPTION
User have to only specify `MONGODB_ADMIN_PASSWORD` and optionally provide settings for user with 'readWrite' role.

Resolves: #32