### PR TITLE
Test DATADIR permissions and fail cleanly.

### DIFF
--- a/2.6/Dockerfile
+++ b/2.6/Dockerfile
@@ -27,9 +27,8 @@ RUN yum install -y centos-release-scl && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \
-    mkdir -p /var/lib/mongodb/data && chown -R mongodb.0 /var/lib/mongodb/ /var/opt/rh/rh-mongodb26/lib/mongodb && \
+    mkdir -p /var/lib/mongodb/data && chown -R mongodb.0 /var/lib/mongodb/ && \
     # Loosen permission bits to avoid problems running container with arbitrary UID
-    chmod g+w -R /var/opt/rh/rh-mongodb26/lib/mongodb && \
     chmod -R g+rwx /var/lib/mongodb
 
 VOLUME ["/var/lib/mongodb/data"]

--- a/2.6/Dockerfile.rhel7
+++ b/2.6/Dockerfile.rhel7
@@ -34,9 +34,8 @@ RUN yum install -y yum-utils && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \
-    mkdir -p /var/lib/mongodb/data && chown -R mongodb.0 /var/lib/mongodb/ /var/opt/rh/rh-mongodb26/lib/mongodb && \
+    mkdir -p /var/lib/mongodb/data && chown -R mongodb.0 /var/lib/mongodb/ && \
     # Loosen permission bits to avoid problems running container with arbitrary UID
-    chmod g+w -R /var/opt/rh/rh-mongodb26/lib/mongodb && \
     chmod -R g+rwx /var/lib/mongodb
 
 VOLUME ["/var/lib/mongodb/data"]

--- a/2.6/root/usr/bin/run-mongod
+++ b/2.6/root/usr/bin/run-mongod
@@ -34,10 +34,13 @@ if [ ! -s $MONGODB_CONFIG_PATH ]; then
   envsubst < ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template > $MONGODB_CONFIG_PATH
 fi
 
-mongo_common_args="-f $MONGODB_CONFIG_PATH"
 if ! [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE && -v MONGODB_ADMIN_PASSWORD ]]; then
   usage
 fi
+
+mongo_common_args="-f $MONGODB_CONFIG_PATH"
+
+setup_default_datadir
 
 # Must bring up MongoDB on localhost only until it has an admin password set.
 mongod $mongo_common_args --bind_ip 127.0.0.1 &

--- a/2.6/root/usr/bin/run-mongod-replication
+++ b/2.6/root/usr/bin/run-mongod-replication
@@ -57,6 +57,7 @@ mongo_common_args="-f ${MONGODB_CONFIG_PATH}"
 
 # Attention: setup_keyfile may modify value of mongo_common_args!
 setup_keyfile
+setup_default_datadir
 
 ${CONTAINER_SCRIPTS_PATH}/init-replset.sh &
 

--- a/2.6/root/usr/share/container-scripts/mongodb/common.sh
+++ b/2.6/root/usr/share/container-scripts/mongodb/common.sh
@@ -171,6 +171,18 @@ function setup_keyfile() {
   mongo_common_args+=" --keyFile ${MONGODB_KEYFILE_PATH}"
 }
 
+# setup_default_datadir checks permissions of mounded directory into default
+# data directory MONGODB_DATADIR
+function setup_default_datadir() {
+  if [ ! -w "$MONGODB_DATADIR" ]; then
+    echo >&2 "ERROR: Couldn't write into ${MONGODB_DATADIR}"
+    echo >&2 "CAUSE: current user doesn't have permissions for writing to ${MONGODB_DATADIR} directory"
+    echo >&2 "DETAILS: current user id = $(id -u), user groups: $(id -G)"
+    echo >&2 "DETAILS: directory permissions: $(stat -c '%A owned by %u:%g, SELinux: %C' "${MONGODB_DATADIR}")"
+    exit 1
+  fi
+}
+
 # info prints a message prefixed by date and time.
 function info() {
   printf "=> [%s] %s\n" "$(date +'%a %b %d %T')" "$*"

--- a/3.0-upg/Dockerfile
+++ b/3.0-upg/Dockerfile
@@ -27,9 +27,8 @@ RUN yum install -y centos-release-scl && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \
-    mkdir -p /var/lib/mongodb/data && chown -R mongodb.0 /var/lib/mongodb/ /var/opt/rh/rh-mongodb30upg/lib/mongodb && \
+    mkdir -p /var/lib/mongodb/data && chown -R mongodb.0 /var/lib/mongodb/ && \
     # Loosen permission bits to avoid problems running container with arbitrary UID
-    chmod g+w -R /var/opt/rh/rh-mongodb30upg/lib/mongodb && \
     chmod -R g+rwx /var/lib/mongodb
 
 VOLUME ["/var/lib/mongodb/data"]

--- a/3.0-upg/Dockerfile.rhel7
+++ b/3.0-upg/Dockerfile.rhel7
@@ -34,9 +34,8 @@ RUN yum install -y yum-utils && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \
-    mkdir -p /var/lib/mongodb/data && chown -R mongodb.0 /var/lib/mongodb/ /var/opt/rh/rh-mongodb30upg/lib/mongodb && \
+    mkdir -p /var/lib/mongodb/data && chown -R mongodb.0 /var/lib/mongodb/ && \
     # Loosen permission bits to avoid problems running container with arbitrary UID
-    chmod g+w -R /var/opt/rh/rh-mongodb30upg/lib/mongodb && \
     chmod -R g+rwx /var/lib/mongodb
 
 VOLUME ["/var/lib/mongodb/data"]

--- a/3.0-upg/root/usr/bin/run-mongod
+++ b/3.0-upg/root/usr/bin/run-mongod
@@ -42,10 +42,13 @@ if [ ! -s $MONGODB_CONFIG_PATH ]; then
   envsubst < ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template > $MONGODB_CONFIG_PATH
 fi
 
-mongo_common_args="-f $MONGODB_CONFIG_PATH"
 if ! [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE && -v MONGODB_ADMIN_PASSWORD ]]; then
   usage
 fi
+
+mongo_common_args="-f $MONGODB_CONFIG_PATH"
+
+setup_default_datadir
 
 # Must bring up MongoDB on localhost only until it has an admin password set.
 mongod $mongo_common_args --bind_ip 127.0.0.1 &

--- a/3.0-upg/root/usr/bin/run-mongod-replication
+++ b/3.0-upg/root/usr/bin/run-mongod-replication
@@ -57,6 +57,7 @@ mongo_common_args="-f ${MONGODB_CONFIG_PATH}"
 
 # Attention: setup_keyfile may modify value of mongo_common_args!
 setup_keyfile
+setup_default_datadir
 
 ${CONTAINER_SCRIPTS_PATH}/init-replset.sh &
 

--- a/3.0-upg/root/usr/share/container-scripts/mongodb/common.sh
+++ b/3.0-upg/root/usr/share/container-scripts/mongodb/common.sh
@@ -171,6 +171,18 @@ function setup_keyfile() {
   mongo_common_args+=" --keyFile ${MONGODB_KEYFILE_PATH}"
 }
 
+# setup_default_datadir checks permissions of mounded directory into default
+# data directory MONGODB_DATADIR
+function setup_default_datadir() {
+  if [ ! -w "$MONGODB_DATADIR" ]; then
+    echo >&2 "ERROR: Couldn't write into ${MONGODB_DATADIR}"
+    echo >&2 "CAUSE: current user doesn't have permissions for writing to ${MONGODB_DATADIR} directory"
+    echo >&2 "DETAILS: current user id = $(id -u), user groups: $(id -G)"
+    echo >&2 "DETAILS: directory permissions: $(stat -c '%A owned by %u:%g, SELinux: %C' "${MONGODB_DATADIR}")"
+    exit 1
+  fi
+}
+
 # info prints a message prefixed by date and time.
 function info() {
   printf "=> [%s] %s\n" "$(date +'%a %b %d %T')" "$*"

--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -27,9 +27,8 @@ RUN yum install -y centos-release-scl && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \
-    mkdir -p /var/lib/mongodb/data && chown -R mongodb.0 /var/lib/mongodb/ /var/opt/rh/rh-mongodb32/lib/mongodb && \
+    mkdir -p /var/lib/mongodb/data && chown -R mongodb.0 /var/lib/mongodb/ && \
     # Loosen permission bits to avoid problems running container with arbitrary UID
-    chmod g+w -R /var/opt/rh/rh-mongodb32/lib/mongodb && \
     chmod -R g+rwx /var/lib/mongodb
 
 VOLUME ["/var/lib/mongodb/data"]

--- a/3.2/Dockerfile.rhel7
+++ b/3.2/Dockerfile.rhel7
@@ -34,9 +34,8 @@ RUN yum install -y yum-utils && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \
-    mkdir -p /var/lib/mongodb/data && chown -R mongodb.0 /var/lib/mongodb/ /var/opt/rh/rh-mongodb32/lib/mongodb && \
+    mkdir -p /var/lib/mongodb/data && chown -R mongodb.0 /var/lib/mongodb/ && \
     # Loosen permission bits to avoid problems running container with arbitrary UID
-    chmod g+w -R /var/opt/rh/rh-mongodb32/lib/mongodb && \
     chmod -R g+rwx /var/lib/mongodb
 
 VOLUME ["/var/lib/mongodb/data"]

--- a/3.2/root/usr/bin/run-mongod
+++ b/3.2/root/usr/bin/run-mongod
@@ -32,10 +32,13 @@ if [ ! -s $MONGODB_CONFIG_PATH ]; then
   envsubst < ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template > $MONGODB_CONFIG_PATH
 fi
 
-mongo_common_args="-f $MONGODB_CONFIG_PATH"
 if ! [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE && -v MONGODB_ADMIN_PASSWORD ]]; then
   usage
 fi
+
+mongo_common_args="-f $MONGODB_CONFIG_PATH"
+
+setup_default_datadir
 
 # Must bring up MongoDB on localhost only until it has an admin password set.
 mongod $mongo_common_args --bind_ip 127.0.0.1 &

--- a/3.2/root/usr/bin/run-mongod-replication
+++ b/3.2/root/usr/bin/run-mongod-replication
@@ -55,6 +55,7 @@ mongo_common_args="-f ${MONGODB_CONFIG_PATH}"
 
 # Attention: setup_keyfile may modify value of mongo_common_args!
 setup_keyfile
+setup_default_datadir
 
 ${CONTAINER_SCRIPTS_PATH}/init-replset.sh &
 

--- a/3.2/root/usr/share/container-scripts/mongodb/common.sh
+++ b/3.2/root/usr/share/container-scripts/mongodb/common.sh
@@ -165,6 +165,18 @@ function setup_keyfile() {
   mongo_common_args+=" --keyFile ${MONGODB_KEYFILE_PATH}"
 }
 
+# setup_default_datadir checks permissions of mounded directory into default
+# data directory MONGODB_DATADIR
+function setup_default_datadir() {
+  if [ ! -w "$MONGODB_DATADIR" ]; then
+    echo >&2 "ERROR: Couldn't write into ${MONGODB_DATADIR}"
+    echo >&2 "CAUSE: current user doesn't have permissions for writing to ${MONGODB_DATADIR} directory"
+    echo >&2 "DETAILS: current user id = $(id -u), user groups: $(id -G)"
+    echo >&2 "DETAILS: directory permissions: $(stat -c '%A owned by %u:%g, SELinux: %C' "${MONGODB_DATADIR}")"
+    exit 1
+  fi
+}
+
 # info prints a message prefixed by date and time.
 function info() {
   printf "=> [%s] %s\n" "$(date +'%a %b %d %T')" "$*"


### PR DESCRIPTION
Test permissions of `MONGODB_DATADIR` and if it is not writable (or SELinux deny it), print error message and exit cleanly.

Also removes creating of SCL rpm package default directory (`/var/opt/rh/rh-mongodb26/lib/mongodb`,...) and changing of permissions. These directories are created by rpm, so it is not necessary to create them. Also they are not used anywhere, so working with them in Dockerfiles is redundant.

Resolves: #99