### PR TITLE
Set cacheSizeGB for 3.2 image + add cgroup-limits script into images.

### DIFF
--- a/2.6/Dockerfile
+++ b/2.6/Dockerfile
@@ -18,7 +18,6 @@ ENV MONGODB_VERSION=2.6 \
 
 EXPOSE 27017
 
-
 ENTRYPOINT ["container-entrypoint"]
 CMD ["run-mongod"]
 
@@ -26,16 +25,19 @@ RUN yum install -y centos-release-scl && \
     INSTALL_PKGS="bind-utils gettext iproute rsync tar v8314 rh-mongodb26-mongodb rh-mongodb26" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
-    yum clean all && \
-    mkdir -p /var/lib/mongodb/data && chown -R mongodb.0 /var/lib/mongodb/ && \
-    # Loosen permission bits to avoid problems running container with arbitrary UID
-    chmod -R g+rwx /var/lib/mongodb
-
-VOLUME ["/var/lib/mongodb/data"]
+    yum clean all
 
 ADD root /
 
+
 # Container setup
-RUN touch /etc/mongod.conf && chown mongodb:0 /etc/mongod.conf && /usr/libexec/fix-permissions /etc/mongod.conf
+RUN touch /etc/mongod.conf && \
+    mkdir -p ${HOME}/data && \
+    chown -R mongodb:0 /etc/mongod.conf ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template ${HOME} && \
+    # Set g+rw(x) permission for group 0 - to avoid problems running container with arbitrary UID
+    /usr/libexec/fix-permissions "/etc/mongod.conf ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template \
+    ${HOME}"
+
+VOLUME ["/var/lib/mongodb/data"]
 
 USER 184

--- a/2.6/Dockerfile
+++ b/2.6/Dockerfile
@@ -33,10 +33,9 @@ ADD root /
 # Container setup
 RUN touch /etc/mongod.conf && \
     mkdir -p ${HOME}/data && \
-    chown -R mongodb:0 /etc/mongod.conf ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template ${HOME} && \
-    # Set g+rw(x) permission for group 0 - to avoid problems running container with arbitrary UID
-    /usr/libexec/fix-permissions "/etc/mongod.conf ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template \
-    ${HOME}"
+    # Set owner 'mongodb:0' and 'g+rw(x)' permission - to avoid problems running container with arbitrary UID
+    /usr/libexec/fix-permissions /etc/mongod.conf ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template \
+    ${HOME}
 
 VOLUME ["/var/lib/mongodb/data"]
 

--- a/2.6/Dockerfile.rhel7
+++ b/2.6/Dockerfile.rhel7
@@ -33,16 +33,18 @@ RUN yum install -y yum-utils && \
     INSTALL_PKGS="bind-utils gettext iproute rsync tar v8314 rh-mongodb26-mongodb rh-mongodb26" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
-    yum clean all && \
-    mkdir -p /var/lib/mongodb/data && chown -R mongodb.0 /var/lib/mongodb/ && \
-    # Loosen permission bits to avoid problems running container with arbitrary UID
-    chmod -R g+rwx /var/lib/mongodb
-
-VOLUME ["/var/lib/mongodb/data"]
+    yum clean all
 
 ADD root /
 
 # Container setup
-RUN touch /etc/mongod.conf && chown mongodb:0 /etc/mongod.conf && /usr/libexec/fix-permissions /etc/mongod.conf
+RUN touch /etc/mongod.conf && \
+    mkdir -p ${HOME}/data && \
+    chown -R mongodb:0 /etc/mongod.conf ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template ${HOME} && \
+    # Set g+rw(x) permission for group 0 - to avoid problems running container with arbitrary UID
+    /usr/libexec/fix-permissions "/etc/mongod.conf ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template \
+    ${HOME}"
+
+VOLUME ["/var/lib/mongodb/data"]
 
 USER 184

--- a/2.6/Dockerfile.rhel7
+++ b/2.6/Dockerfile.rhel7
@@ -40,10 +40,9 @@ ADD root /
 # Container setup
 RUN touch /etc/mongod.conf && \
     mkdir -p ${HOME}/data && \
-    chown -R mongodb:0 /etc/mongod.conf ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template ${HOME} && \
-    # Set g+rw(x) permission for group 0 - to avoid problems running container with arbitrary UID
-    /usr/libexec/fix-permissions "/etc/mongod.conf ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template \
-    ${HOME}"
+    # Set owner 'mongodb:0' and 'g+rw(x)' permission - to avoid problems running container with arbitrary UID
+    /usr/libexec/fix-permissions /etc/mongod.conf ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template \
+    ${HOME}
 
 VOLUME ["/var/lib/mongodb/data"]
 

--- a/2.6/root/usr/bin/cgroup-limits
+++ b/2.6/root/usr/bin/cgroup-limits
@@ -1,0 +1,92 @@
+#!/usr/bin/python
+
+"""
+Script for parsing cgroup information
+
+This script will read some limits from the cgroup system and parse
+them, printing out "VARIABLE=VALUE" on each line for every limit that is
+successfully read. Output of this script can be directly fed into
+bash's export command. Recommended usage from a bash script:
+
+    set -o errexit
+    export_vars=$(cgroup-limits) ; export $export_vars
+
+Variables currently supported:
+    MAX_MEMORY_LIMIT_IN_BYTES
+        Maximum possible limit MEMORY_LIMIT_IN_BYTES can have. This is
+        currently constant value of 9223372036854775807.
+    MEMORY_LIMIT_IN_BYTES
+        Maximum amount of user memory in bytes. If this value is set
+        to the same value as MAX_MEMORY_LIMIT_IN_BYTES, it means that
+        there is no limit set. The value is taken from
+        /sys/fs/cgroup/memory/memory.limit_in_bytes
+    NUMBER_OF_CORES
+        Number of detected CPU cores that can be used. This value is
+        calculated from /sys/fs/cgroup/cpuset/cpuset.cpus
+    NO_MEMORY_LIMIT
+        Set to "true" if MEMORY_LIMIT_IN_BYTES is so high that the caller
+        can act as if no memory limit was set. Undefined otherwise.
+"""
+
+from __future__ import print_function
+import sys
+
+
+def _read_file(path):
+    try:
+        with open(path, 'r') as f:
+            return f.read().strip()
+    except IOError:
+        return None
+
+
+def get_memory_limit():
+    """
+    Read memory limit, in bytes.
+    """
+
+    limit = _read_file('/sys/fs/cgroup/memory/memory.limit_in_bytes')
+    if limit is None or not limit.isdigit():
+        print("Warning: Can't detect memory limit from cgroups",
+              file=sys.stderr)
+        return None
+    return int(limit)
+
+
+def get_number_of_cores():
+    """
+    Read number of CPU cores.
+    """
+
+    core_count = 0
+
+    line = _read_file('/sys/fs/cgroup/cpuset/cpuset.cpus')
+    if line is None:
+        print("Warning: Can't detect number of CPU cores from cgroups",
+              file=sys.stderr)
+        return None
+
+    for group in line.split(','):
+        core_ids = list(map(int, group.split('-')))
+        if len(core_ids) == 2:
+            core_count += core_ids[1] - core_ids[0] + 1
+        else:
+            core_count += 1
+
+    return core_count
+
+
+if __name__ == "__main__":
+    env_vars = {
+        "MAX_MEMORY_LIMIT_IN_BYTES": 9223372036854775807,
+        "MEMORY_LIMIT_IN_BYTES": get_memory_limit(),
+        "NUMBER_OF_CORES": get_number_of_cores()
+    }
+
+    env_vars = {k: v for k, v in env_vars.items() if v is not None}
+
+    if env_vars.get("MEMORY_LIMIT_IN_BYTES", 0) >= 92233720368547:
+        env_vars["NO_MEMORY_LIMIT"] = "true"
+
+    for key, value in env_vars.items():
+        print("{0}={1}".format(key, value))

--- a/2.6/root/usr/libexec/fix-permissions
+++ b/2.6/root/usr/libexec/fix-permissions
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Fix permissions on the given directory to allow group read/write of 
 # regular files and execute of directories.
-find $1 -exec chgrp 0 {} \;
-find $1 -exec chmod g+rw {} \;
-find $1 -type d -exec chmod g+x {} +
+find $@ -exec chown mongodb:0 {} \;
+find $@ -exec chmod g+rw {} \;
+find $@ -type d -exec chmod g+x {} +

--- a/3.0-upg/Dockerfile
+++ b/3.0-upg/Dockerfile
@@ -18,7 +18,6 @@ ENV MONGODB_VERSION=3.0-upg \
 
 EXPOSE 27017
 
-
 ENTRYPOINT ["container-entrypoint"]
 CMD ["run-mongod"]
 
@@ -26,16 +25,19 @@ RUN yum install -y centos-release-scl && \
     INSTALL_PKGS="bind-utils gettext iproute rsync tar v8314 rh-mongodb30upg-mongodb rh-mongodb30upg" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
-    yum clean all && \
-    mkdir -p /var/lib/mongodb/data && chown -R mongodb.0 /var/lib/mongodb/ && \
-    # Loosen permission bits to avoid problems running container with arbitrary UID
-    chmod -R g+rwx /var/lib/mongodb
-
-VOLUME ["/var/lib/mongodb/data"]
+    yum clean all
 
 ADD root /
 
+
 # Container setup
-RUN touch /etc/mongod.conf && chown mongodb:0 /etc/mongod.conf && /usr/libexec/fix-permissions /etc/mongod.conf
+RUN touch /etc/mongod.conf && \
+    mkdir -p ${HOME}/data && \
+    chown -R mongodb:0 /etc/mongod.conf ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template ${HOME} && \
+    # Set g+rw(x) permission for group 0 - to avoid problems running container with arbitrary UID
+    /usr/libexec/fix-permissions "/etc/mongod.conf ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template \
+    ${HOME}"
+
+VOLUME ["/var/lib/mongodb/data"]
 
 USER 184

--- a/3.0-upg/Dockerfile
+++ b/3.0-upg/Dockerfile
@@ -33,10 +33,9 @@ ADD root /
 # Container setup
 RUN touch /etc/mongod.conf && \
     mkdir -p ${HOME}/data && \
-    chown -R mongodb:0 /etc/mongod.conf ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template ${HOME} && \
-    # Set g+rw(x) permission for group 0 - to avoid problems running container with arbitrary UID
-    /usr/libexec/fix-permissions "/etc/mongod.conf ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template \
-    ${HOME}"
+    # Set owner 'mongodb:0' and 'g+rw(x)' permission - to avoid problems running container with arbitrary UID
+    /usr/libexec/fix-permissions /etc/mongod.conf ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template \
+    ${HOME}
 
 VOLUME ["/var/lib/mongodb/data"]
 

--- a/3.0-upg/Dockerfile.rhel7
+++ b/3.0-upg/Dockerfile.rhel7
@@ -33,16 +33,18 @@ RUN yum install -y yum-utils && \
     INSTALL_PKGS="bind-utils gettext iproute rsync tar v8314 rh-mongodb30upg-mongodb rh-mongodb30upg" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
-    yum clean all && \
-    mkdir -p /var/lib/mongodb/data && chown -R mongodb.0 /var/lib/mongodb/ && \
-    # Loosen permission bits to avoid problems running container with arbitrary UID
-    chmod -R g+rwx /var/lib/mongodb
-
-VOLUME ["/var/lib/mongodb/data"]
+    yum clean all
 
 ADD root /
 
 # Container setup
-RUN touch /etc/mongod.conf && chown mongodb:0 /etc/mongod.conf && /usr/libexec/fix-permissions /etc/mongod.conf
+RUN touch /etc/mongod.conf && \
+    mkdir -p ${HOME}/data && \
+    chown -R mongodb:0 /etc/mongod.conf ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template ${HOME} && \
+    # Set g+rw(x) permission for group 0 - to avoid problems running container with arbitrary UID
+    /usr/libexec/fix-permissions "/etc/mongod.conf ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template \
+    ${HOME}"
+
+VOLUME ["/var/lib/mongodb/data"]
 
 USER 184

--- a/3.0-upg/Dockerfile.rhel7
+++ b/3.0-upg/Dockerfile.rhel7
@@ -40,10 +40,9 @@ ADD root /
 # Container setup
 RUN touch /etc/mongod.conf && \
     mkdir -p ${HOME}/data && \
-    chown -R mongodb:0 /etc/mongod.conf ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template ${HOME} && \
-    # Set g+rw(x) permission for group 0 - to avoid problems running container with arbitrary UID
-    /usr/libexec/fix-permissions "/etc/mongod.conf ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template \
-    ${HOME}"
+    # Set owner 'mongodb:0' and 'g+rw(x)' permission - to avoid problems running container with arbitrary UID
+    /usr/libexec/fix-permissions /etc/mongod.conf ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template \
+    ${HOME}
 
 VOLUME ["/var/lib/mongodb/data"]
 

--- a/3.0-upg/root/usr/bin/cgroup-limits
+++ b/3.0-upg/root/usr/bin/cgroup-limits
@@ -1,0 +1,92 @@
+#!/usr/bin/python
+
+"""
+Script for parsing cgroup information
+
+This script will read some limits from the cgroup system and parse
+them, printing out "VARIABLE=VALUE" on each line for every limit that is
+successfully read. Output of this script can be directly fed into
+bash's export command. Recommended usage from a bash script:
+
+    set -o errexit
+    export_vars=$(cgroup-limits) ; export $export_vars
+
+Variables currently supported:
+    MAX_MEMORY_LIMIT_IN_BYTES
+        Maximum possible limit MEMORY_LIMIT_IN_BYTES can have. This is
+        currently constant value of 9223372036854775807.
+    MEMORY_LIMIT_IN_BYTES
+        Maximum amount of user memory in bytes. If this value is set
+        to the same value as MAX_MEMORY_LIMIT_IN_BYTES, it means that
+        there is no limit set. The value is taken from
+        /sys/fs/cgroup/memory/memory.limit_in_bytes
+    NUMBER_OF_CORES
+        Number of detected CPU cores that can be used. This value is
+        calculated from /sys/fs/cgroup/cpuset/cpuset.cpus
+    NO_MEMORY_LIMIT
+        Set to "true" if MEMORY_LIMIT_IN_BYTES is so high that the caller
+        can act as if no memory limit was set. Undefined otherwise.
+"""
+
+from __future__ import print_function
+import sys
+
+
+def _read_file(path):
+    try:
+        with open(path, 'r') as f:
+            return f.read().strip()
+    except IOError:
+        return None
+
+
+def get_memory_limit():
+    """
+    Read memory limit, in bytes.
+    """
+
+    limit = _read_file('/sys/fs/cgroup/memory/memory.limit_in_bytes')
+    if limit is None or not limit.isdigit():
+        print("Warning: Can't detect memory limit from cgroups",
+              file=sys.stderr)
+        return None
+    return int(limit)
+
+
+def get_number_of_cores():
+    """
+    Read number of CPU cores.
+    """
+
+    core_count = 0
+
+    line = _read_file('/sys/fs/cgroup/cpuset/cpuset.cpus')
+    if line is None:
+        print("Warning: Can't detect number of CPU cores from cgroups",
+              file=sys.stderr)
+        return None
+
+    for group in line.split(','):
+        core_ids = list(map(int, group.split('-')))
+        if len(core_ids) == 2:
+            core_count += core_ids[1] - core_ids[0] + 1
+        else:
+            core_count += 1
+
+    return core_count
+
+
+if __name__ == "__main__":
+    env_vars = {
+        "MAX_MEMORY_LIMIT_IN_BYTES": 9223372036854775807,
+        "MEMORY_LIMIT_IN_BYTES": get_memory_limit(),
+        "NUMBER_OF_CORES": get_number_of_cores()
+    }
+
+    env_vars = {k: v for k, v in env_vars.items() if v is not None}
+
+    if env_vars.get("MEMORY_LIMIT_IN_BYTES", 0) >= 92233720368547:
+        env_vars["NO_MEMORY_LIMIT"] = "true"
+
+    for key, value in env_vars.items():
+        print("{0}={1}".format(key, value))

--- a/3.0-upg/root/usr/libexec/fix-permissions
+++ b/3.0-upg/root/usr/libexec/fix-permissions
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Fix permissions on the given directory to allow group read/write of 
 # regular files and execute of directories.
-find $1 -exec chgrp 0 {} \;
-find $1 -exec chmod g+rw {} \;
-find $1 -type d -exec chmod g+x {} +
+find $@ -exec chown mongodb:0 {} \;
+find $@ -exec chmod g+rw {} \;
+find $@ -type d -exec chmod g+x {} +

--- a/3.0-upg/root/usr/share/container-scripts/mongodb/common.sh
+++ b/3.0-upg/root/usr/share/container-scripts/mongodb/common.sh
@@ -186,15 +186,18 @@ function setup_default_datadir() {
 # setup_wiredtiger_cache checks amount of available RAM (it has to use cgroups in container)
 # and if there are any memory restrictions set storage.wiredTiger.engineConfig.cacheSizeGB
 # in MONGODB_CONFIG_PATH to upstream default size
-# it is inteded to update mongodb.conf.template, with custom config file it might create conflict
+# it is intended to update mongodb.conf.template, with custom config file it might create conflict
 function setup_wiredtiger_cache() {
+  local config_file
+  config_file=${1:-$MONGODB_CONFIG_PATH}
+
   declare $(cgroup-limits)
   if [[ ! -v MEMORY_LIMIT_IN_BYTES || "${NO_MEMORY_LIMIT:-}" == "true" ]]; then
     return 0;
   fi
 
   cache_size=$(python -c "min=1; limit=int($MEMORY_LIMIT_IN_BYTES / pow(2,30) * 0.5); print( min if limit < min else limit)")
-  echo "storage.wiredTiger.engineConfig.cacheSizeGB: ${cache_size}" >> ${MONGODB_CONFIG_PATH}
+  echo "storage.wiredTiger.engineConfig.cacheSizeGB: ${cache_size}" >> ${config_file}
 
   info "wiredTiger cacheSizeGB set to ${cache_size}"
 }

--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -18,7 +18,6 @@ ENV MONGODB_VERSION=3.2 \
 
 EXPOSE 27017
 
-
 ENTRYPOINT ["container-entrypoint"]
 CMD ["run-mongod"]
 
@@ -26,16 +25,19 @@ RUN yum install -y centos-release-scl && \
     INSTALL_PKGS="bind-utils gettext iproute rsync tar rh-mongodb32-mongodb rh-mongodb32 rh-mongodb32-mongo-tools" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
-    yum clean all && \
-    mkdir -p /var/lib/mongodb/data && chown -R mongodb.0 /var/lib/mongodb/ && \
-    # Loosen permission bits to avoid problems running container with arbitrary UID
-    chmod -R g+rwx /var/lib/mongodb
-
-VOLUME ["/var/lib/mongodb/data"]
+    yum clean all
 
 ADD root /
 
+
 # Container setup
-RUN touch /etc/mongod.conf && chown mongodb:0 /etc/mongod.conf && /usr/libexec/fix-permissions /etc/mongod.conf
+RUN touch /etc/mongod.conf && \
+    mkdir -p ${HOME}/data && \
+    chown -R mongodb:0 /etc/mongod.conf ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template ${HOME} && \
+    # Set g+rw(x) permission for group 0 - to avoid problems running container with arbitrary UID
+    /usr/libexec/fix-permissions "/etc/mongod.conf ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template \
+    ${HOME}"
+
+VOLUME ["/var/lib/mongodb/data"]
 
 USER 184

--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -33,10 +33,9 @@ ADD root /
 # Container setup
 RUN touch /etc/mongod.conf && \
     mkdir -p ${HOME}/data && \
-    chown -R mongodb:0 /etc/mongod.conf ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template ${HOME} && \
-    # Set g+rw(x) permission for group 0 - to avoid problems running container with arbitrary UID
-    /usr/libexec/fix-permissions "/etc/mongod.conf ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template \
-    ${HOME}"
+    # Set owner 'mongodb:0' and 'g+rw(x)' permission - to avoid problems running container with arbitrary UID
+    /usr/libexec/fix-permissions /etc/mongod.conf ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template \
+    ${HOME}
 
 VOLUME ["/var/lib/mongodb/data"]
 

--- a/3.2/Dockerfile.rhel7
+++ b/3.2/Dockerfile.rhel7
@@ -33,16 +33,18 @@ RUN yum install -y yum-utils && \
     INSTALL_PKGS="bind-utils gettext iproute rsync tar rh-mongodb32-mongodb rh-mongodb32 rh-mongodb32-mongo-tools" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
-    yum clean all && \
-    mkdir -p /var/lib/mongodb/data && chown -R mongodb.0 /var/lib/mongodb/ && \
-    # Loosen permission bits to avoid problems running container with arbitrary UID
-    chmod -R g+rwx /var/lib/mongodb
-
-VOLUME ["/var/lib/mongodb/data"]
+    yum clean all
 
 ADD root /
 
 # Container setup
-RUN touch /etc/mongod.conf && chown mongodb:0 /etc/mongod.conf && /usr/libexec/fix-permissions /etc/mongod.conf
+RUN touch /etc/mongod.conf && \
+    mkdir -p ${HOME}/data && \
+    chown -R mongodb:0 /etc/mongod.conf ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template ${HOME} && \
+    # Set g+rw(x) permission for group 0 - to avoid problems running container with arbitrary UID
+    /usr/libexec/fix-permissions "/etc/mongod.conf ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template \
+    ${HOME}"
+
+VOLUME ["/var/lib/mongodb/data"]
 
 USER 184

--- a/3.2/Dockerfile.rhel7
+++ b/3.2/Dockerfile.rhel7
@@ -40,10 +40,9 @@ ADD root /
 # Container setup
 RUN touch /etc/mongod.conf && \
     mkdir -p ${HOME}/data && \
-    chown -R mongodb:0 /etc/mongod.conf ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template ${HOME} && \
-    # Set g+rw(x) permission for group 0 - to avoid problems running container with arbitrary UID
-    /usr/libexec/fix-permissions "/etc/mongod.conf ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template \
-    ${HOME}"
+    # Set owner 'mongodb:0' and 'g+rw(x)' permission - to avoid problems running container with arbitrary UID
+    /usr/libexec/fix-permissions /etc/mongod.conf ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template \
+    ${HOME}
 
 VOLUME ["/var/lib/mongodb/data"]
 

--- a/3.2/root/usr/bin/cgroup-limits
+++ b/3.2/root/usr/bin/cgroup-limits
@@ -1,0 +1,92 @@
+#!/usr/bin/python
+
+"""
+Script for parsing cgroup information
+
+This script will read some limits from the cgroup system and parse
+them, printing out "VARIABLE=VALUE" on each line for every limit that is
+successfully read. Output of this script can be directly fed into
+bash's export command. Recommended usage from a bash script:
+
+    set -o errexit
+    export_vars=$(cgroup-limits) ; export $export_vars
+
+Variables currently supported:
+    MAX_MEMORY_LIMIT_IN_BYTES
+        Maximum possible limit MEMORY_LIMIT_IN_BYTES can have. This is
+        currently constant value of 9223372036854775807.
+    MEMORY_LIMIT_IN_BYTES
+        Maximum amount of user memory in bytes. If this value is set
+        to the same value as MAX_MEMORY_LIMIT_IN_BYTES, it means that
+        there is no limit set. The value is taken from
+        /sys/fs/cgroup/memory/memory.limit_in_bytes
+    NUMBER_OF_CORES
+        Number of detected CPU cores that can be used. This value is
+        calculated from /sys/fs/cgroup/cpuset/cpuset.cpus
+    NO_MEMORY_LIMIT
+        Set to "true" if MEMORY_LIMIT_IN_BYTES is so high that the caller
+        can act as if no memory limit was set. Undefined otherwise.
+"""
+
+from __future__ import print_function
+import sys
+
+
+def _read_file(path):
+    try:
+        with open(path, 'r') as f:
+            return f.read().strip()
+    except IOError:
+        return None
+
+
+def get_memory_limit():
+    """
+    Read memory limit, in bytes.
+    """
+
+    limit = _read_file('/sys/fs/cgroup/memory/memory.limit_in_bytes')
+    if limit is None or not limit.isdigit():
+        print("Warning: Can't detect memory limit from cgroups",
+              file=sys.stderr)
+        return None
+    return int(limit)
+
+
+def get_number_of_cores():
+    """
+    Read number of CPU cores.
+    """
+
+    core_count = 0
+
+    line = _read_file('/sys/fs/cgroup/cpuset/cpuset.cpus')
+    if line is None:
+        print("Warning: Can't detect number of CPU cores from cgroups",
+              file=sys.stderr)
+        return None
+
+    for group in line.split(','):
+        core_ids = list(map(int, group.split('-')))
+        if len(core_ids) == 2:
+            core_count += core_ids[1] - core_ids[0] + 1
+        else:
+            core_count += 1
+
+    return core_count
+
+
+if __name__ == "__main__":
+    env_vars = {
+        "MAX_MEMORY_LIMIT_IN_BYTES": 9223372036854775807,
+        "MEMORY_LIMIT_IN_BYTES": get_memory_limit(),
+        "NUMBER_OF_CORES": get_number_of_cores()
+    }
+
+    env_vars = {k: v for k, v in env_vars.items() if v is not None}
+
+    if env_vars.get("MEMORY_LIMIT_IN_BYTES", 0) >= 92233720368547:
+        env_vars["NO_MEMORY_LIMIT"] = "true"
+
+    for key, value in env_vars.items():
+        print("{0}={1}".format(key, value))

--- a/3.2/root/usr/bin/run-mongod
+++ b/3.2/root/usr/bin/run-mongod
@@ -33,11 +33,12 @@ if [[ -v MONGODB_USER || -v MONGODB_PASSWORD || -v MONGODB_DATABASE ]]; then
   CREATE_USER=1
 fi
 
+setup_wiredtiger_cache ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template
+
 # If user provides own config file use it and do not generate new one
 if [ ! -s $MONGODB_CONFIG_PATH ]; then
   # Generate config file for MongoDB
   envsubst < ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template > $MONGODB_CONFIG_PATH
-  setup_wiredtiger_cache
 fi
 
 mongo_common_args="-f $MONGODB_CONFIG_PATH"

--- a/3.2/root/usr/bin/run-mongod
+++ b/3.2/root/usr/bin/run-mongod
@@ -37,6 +37,7 @@ fi
 if [ ! -s $MONGODB_CONFIG_PATH ]; then
   # Generate config file for MongoDB
   envsubst < ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template > $MONGODB_CONFIG_PATH
+  setup_wiredtiger_cache
 fi
 
 mongo_common_args="-f $MONGODB_CONFIG_PATH"

--- a/3.2/root/usr/bin/run-mongod-replication
+++ b/3.2/root/usr/bin/run-mongod-replication
@@ -48,11 +48,12 @@ if [[ -v MONGODB_USER || -v MONGODB_PASSWORD || -v MONGODB_DATABASE ]]; then
   CREATE_USER=1
 fi
 
+setup_wiredtiger_cache ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template
+
 # If user provides own config file use it and do not generate new one
 if [ ! -s "${MONGODB_CONFIG_PATH}" ]; then
   # Generate config file for MongoDB
   envsubst < "${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template" > "${MONGODB_CONFIG_PATH}"
-  setup_wiredtiger_cache
 fi
 
 mongo_common_args="-f ${MONGODB_CONFIG_PATH}"

--- a/3.2/root/usr/bin/run-mongod-replication
+++ b/3.2/root/usr/bin/run-mongod-replication
@@ -52,6 +52,7 @@ fi
 if [ ! -s "${MONGODB_CONFIG_PATH}" ]; then
   # Generate config file for MongoDB
   envsubst < "${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template" > "${MONGODB_CONFIG_PATH}"
+  setup_wiredtiger_cache
 fi
 
 mongo_common_args="-f ${MONGODB_CONFIG_PATH}"

--- a/3.2/root/usr/libexec/fix-permissions
+++ b/3.2/root/usr/libexec/fix-permissions
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Fix permissions on the given directory to allow group read/write of 
 # regular files and execute of directories.
-find $1 -exec chgrp 0 {} \;
-find $1 -exec chmod g+rw {} \;
-find $1 -type d -exec chmod g+x {} +
+find $@ -exec chown mongodb:0 {} \;
+find $@ -exec chmod g+rw {} \;
+find $@ -type d -exec chmod g+x {} +

--- a/3.2/root/usr/share/container-scripts/mongodb/common.sh
+++ b/3.2/root/usr/share/container-scripts/mongodb/common.sh
@@ -177,6 +177,22 @@ function setup_default_datadir() {
   fi
 }
 
+# setup_wiredtiger_cache checks amount of available RAM (it has to use cgroups in container)
+# and if there are any memory restrictions set storage.wiredTiger.engineConfig.cacheSizeGB
+# in MONGODB_CONFIG_PATH to upstream default size
+# it is inteded to update mongodb.conf.template, with custom config file it might create conflict
+function setup_wiredtiger_cache() {
+  declare $(cgroup-limits)
+  if [[ ! -v MEMORY_LIMIT_IN_BYTES || "${NO_MEMORY_LIMIT:-}" == "true" ]]; then
+    return 0;
+  fi
+
+  cache_size=$(python -c "min=1; limit=int(($MEMORY_LIMIT_IN_BYTES / pow(2,30) - 1) * 0.6); print( min if limit < min else limit)")
+  echo "storage.wiredTiger.engineConfig.cacheSizeGB: ${cache_size}" >> ${MONGODB_CONFIG_PATH}
+
+  info "wiredTiger cacheSizeGB set to ${cache_size}"
+}
+
 # info prints a message prefixed by date and time.
 function info() {
   printf "=> [%s] %s\n" "$(date +'%a %b %d %T')" "$*"

--- a/3.2/root/usr/share/container-scripts/mongodb/common.sh
+++ b/3.2/root/usr/share/container-scripts/mongodb/common.sh
@@ -180,15 +180,18 @@ function setup_default_datadir() {
 # setup_wiredtiger_cache checks amount of available RAM (it has to use cgroups in container)
 # and if there are any memory restrictions set storage.wiredTiger.engineConfig.cacheSizeGB
 # in MONGODB_CONFIG_PATH to upstream default size
-# it is inteded to update mongodb.conf.template, with custom config file it might create conflict
+# it is intended to update mongodb.conf.template, with custom config file it might create conflict
 function setup_wiredtiger_cache() {
+  local config_file
+  config_file=${1:-$MONGODB_CONFIG_PATH}
+
   declare $(cgroup-limits)
   if [[ ! -v MEMORY_LIMIT_IN_BYTES || "${NO_MEMORY_LIMIT:-}" == "true" ]]; then
     return 0;
   fi
 
   cache_size=$(python -c "min=1; limit=int(($MEMORY_LIMIT_IN_BYTES / pow(2,30) - 1) * 0.6); print( min if limit < min else limit)")
-  echo "storage.wiredTiger.engineConfig.cacheSizeGB: ${cache_size}" >> ${MONGODB_CONFIG_PATH}
+  echo "storage.wiredTiger.engineConfig.cacheSizeGB: ${cache_size}" >> ${config_file}
 
   info "wiredTiger cacheSizeGB set to ${cache_size}"
 }

--- a/3.2/test/run
+++ b/3.2/test/run
@@ -377,6 +377,39 @@ run_doc_test() {
   echo
 }
 
+run_WT_cache_test() {
+    local name="WT_cache_size"
+    echo "  Testing setting of WT cache size"
+    local database='db'
+    local user='user'
+    local password='password'
+    local admin_password='adminPassword'
+
+    DOCKER_ARGS="
+-e MONGODB_DATABASE=${database}
+-e MONGODB_USER=${user}
+-e MONGODB_PASSWORD=${password}
+-e MONGODB_ADMIN_PASSWORD=${admin_password}
+"
+    # need to set these because `mongo_cmd` relies on global variables
+    USER=${user}
+    PASS=${password}
+    DB=${database}
+    ADMIN_PASS=${admin_password}
+
+    # minimum is 1G
+    create_container "${name}_200M" ${DOCKER_ARGS} -m 200M
+    test_connection ${name}_200M
+    mongo_admin_cmd "if (db.serverStatus()['wiredTiger']['cache']['maximum bytes configured'] == Math.pow(2,30)){quit(0)}; quit(1)"
+    # if greater that 1G, use 60% of (RAM - 1G)
+    create_container "${name}_5G" ${DOCKER_ARGS} -m 5G
+    test_connection ${name}_5G
+    mongo_admin_cmd "if (db.serverStatus()['wiredTiger']['cache']['maximum bytes configured'] == 2*Math.pow(2,30)){quit(0)}; quit(1)"
+
+    echo "  Success!"
+    echo
+}
+
 
 # Tests.
 run_container_creation_tests
@@ -387,3 +420,4 @@ CONTAINER_ARGS="-u 12345" USER="user1" PASS="pass1" DB="test_db" ADMIN_PASS="r00
 run_change_password_test
 run_mount_config_test
 run_doc_test
+run_WT_cache_test

--- a/3.2/test/run
+++ b/3.2/test/run
@@ -402,9 +402,9 @@ run_WT_cache_test() {
     test_connection ${name}_200M
     mongo_admin_cmd "if (db.serverStatus()['wiredTiger']['cache']['maximum bytes configured'] == Math.pow(2,30)){quit(0)}; quit(1)"
     # if greater that 1G, use 60% of (RAM - 1G)
-    create_container "${name}_5G" ${DOCKER_ARGS} -m 5G
-    test_connection ${name}_5G
-    mongo_admin_cmd "if (db.serverStatus()['wiredTiger']['cache']['maximum bytes configured'] == 2*Math.pow(2,30)){quit(0)}; quit(1)"
+    create_container "${name}_6G" ${DOCKER_ARGS} -m 6G
+    test_connection ${name}_6G
+    mongo_admin_cmd "if (db.serverStatus()['wiredTiger']['cache']['maximum bytes configured'] == 3*Math.pow(2,30)){quit(0)}; quit(1)"
 
     echo "  Success!"
     echo


### PR DESCRIPTION
- add `cgroup-limits` scripts to check amount of available memory to all supported images.
- add function to set WT cache size to default in configuration file for images which supports wiredTiger
- set WT cache size for MongoDB 3.2, where wiredTiger is a default storage engine.

@bparees Please take a look.

Fixes #204 
