### PR TITLE
Move checkinkg of variables and usage into common.sh

### DIFF
--- a/2.6/root/usr/bin/run-mongod
+++ b/2.6/root/usr/bin/run-mongod
@@ -6,20 +6,6 @@ set -o pipefail
 
 source ${CONTAINER_SCRIPTS_PATH}/common.sh
 
-function usage() {
-  echo "You must specify the following environment variables:"
-  echo "  MONGODB_ADMIN_PASSWORD"
-  echo "Optionally you can provide settings for user with 'readWrite' role:"
-  echo "  MONGODB_USER"
-  echo "  MONGODB_PASSWORD"
-  echo "  MONGODB_DATABASE"
-  echo "MongoDB settings:"
-  echo "  MONGODB_PREALLOC (default: false)"
-  echo "  MONGODB_SMALLFILES (default: true)"
-  echo "  MONGODB_QUIET (default: true)"
-  exit 1
-}
-
 function cleanup() {
   echo "=> Shutting down MongoDB server ..."
   pkill -INT mongod || :
@@ -29,11 +15,7 @@ function cleanup() {
 
 trap 'cleanup' SIGINT SIGTERM
 
-[[ -v MONGODB_ADMIN_PASSWORD ]] || usage
-if [[ -v MONGODB_USER || -v MONGODB_PASSWORD || -v MONGODB_DATABASE ]]; then
-  [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE ]] || usage
-  export CREATE_USER=1
-fi
+check_env_vars
 
 # If user provides own config file use it and do not generate new one
 if [ ! -s $MONGODB_CONFIG_PATH ]; then

--- a/2.6/root/usr/bin/run-mongod-replication
+++ b/2.6/root/usr/bin/run-mongod-replication
@@ -17,24 +17,6 @@ set -o pipefail
 
 source ${CONTAINER_SCRIPTS_PATH}/common.sh
 
-function usage() {
-  echo "You must specify the following environment variables:"
-  echo "  MONGODB_ADMIN_PASSWORD"
-  echo "  MONGODB_KEYFILE_VALUE"
-  echo "  MONGODB_REPLICA_NAME"
-  echo "Optionally you can provide settings for user with 'readWrite' role:"
-  echo "  MONGODB_USER"
-  echo "  MONGODB_PASSWORD"
-  echo "  MONGODB_DATABASE"
-  echo "Optional variables:"
-  echo "  MONGODB_SERVICE_NAME (default: mongodb)"
-  echo "MongoDB settings:"
-  echo "  MONGODB_PREALLOC (default: false)"
-  echo "  MONGODB_SMALLFILES (default: true)"
-  echo "  MONGODB_QUIET (default: true)"
-  exit 1
-}
-
 function cleanup() {
   echo "=> Shutting down MongoDB server ..."
   pkill -INT mongod || :
@@ -44,11 +26,7 @@ function cleanup() {
 
 trap 'cleanup' SIGINT SIGTERM
 
-[[ -v MONGODB_ADMIN_PASSWORD ]] || usage
-if [[ -v MONGODB_USER || -v MONGODB_PASSWORD || -v MONGODB_DATABASE ]]; then
-  [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE ]] || usage
-  export CREATE_USER=1
-fi
+REPLICATION=1 check_env_vars
 
 # If user provides own config file use it and do not generate new one
 if [ ! -s "${MONGODB_CONFIG_PATH}" ]; then

--- a/2.6/root/usr/share/container-scripts/mongodb/common.sh
+++ b/2.6/root/usr/share/container-scripts/mongodb/common.sh
@@ -183,6 +183,65 @@ function setup_default_datadir() {
   fi
 }
 
+# check_env_vars checks environmental variables
+# if variables to create non-admin user are provided, sets CREATE_USER=1
+# if REPLICATION variable is set, checks also replication variables
+function check_env_vars() {
+  local readonly database_regex='^[^/\. "$]*$'
+
+  [[ -v MONGODB_ADMIN_PASSWORD ]] || usage "MONGODB_ADMIN_PASSWORD has to be set."
+
+  if [[ -v MONGODB_USER || -v MONGODB_PASSWORD || -v MONGODB_DATABASE ]]; then
+    [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE ]] || usage "You have to set all or none of variables: MONGODB_USER, MONGODB_PASSWORD, MONGODB_DATABASE"
+
+    [[ "${MONGODB_DATABASE}" =~ $database_regex ]] || usage "Database name must match regex: $database_regex"
+    [ ${#MONGODB_DATABASE} -le 63 ] || usage "Database name too long (maximum 63 characters)"
+
+    export CREATE_USER=1
+  fi
+
+  if [[ -v REPLICATION ]]; then
+    [[ -v MONGODB_KEYFILE_VALUE ]] || usage "MONGODB_KEYFILE_VALUE has to be set"
+    [[ -v MONGODB_REPLICA_NAME ]] ||  usage "MONGODB_REPLICA_NAME has to be set"
+  fi
+}
+
+# usage prints info about required enviromental variables
+# if $1 is passed, prints error message containing $1
+# if REPLICATION variable is set, prints also info about replication variables
+function usage() {
+  if [ $# == 1 ]; then
+    echo >&2 "error: $1"
+  fi
+
+  echo "
+You must specify the following environment variables:
+  MONGODB_ADMIN_PASSWORD
+Optionally you can provide settings for user with 'readWrite' role:
+  MONGODB_USER
+  MONGODB_PASSWORD
+  MONGODB_DATABASE
+Optional settings:
+  MONGODB_PREALLOC (default: false)
+  MONGODB_SMALLFILES (default: true)
+  MONGODB_QUIET (default: true)"
+
+  if [[ -v REPLICATION ]]; then
+    echo "
+For replication you must also specify the following environment variables:
+  MONGODB_KEYFILE_VALUE
+  MONGODB_REPLICA_NAME
+Optional settings:
+  MONGODB_SERVICE_NAME (default: mongodb)
+"
+  fi
+  echo "
+For more information see /usr/share/container-scripts/mongodb/README.md
+within the container or visit https://github.com/sclorgk/mongodb-container/."
+
+  exit 1
+}
+
 # info prints a message prefixed by date and time.
 function info() {
   printf "=> [%s] %s\n" "$(date +'%a %b %d %T')" "$*"

--- a/2.6/root/usr/share/container-scripts/mongodb/common.sh
+++ b/2.6/root/usr/share/container-scripts/mongodb/common.sh
@@ -217,6 +217,7 @@ function usage() {
 You must specify the following environment variables:
   MONGODB_ADMIN_PASSWORD
 Optionally you can provide settings for a user with 'readWrite' role:
+(Note you MUST specify all three of these settings)
   MONGODB_USER
   MONGODB_PASSWORD
   MONGODB_DATABASE

--- a/2.6/root/usr/share/container-scripts/mongodb/common.sh
+++ b/2.6/root/usr/share/container-scripts/mongodb/common.sh
@@ -201,8 +201,7 @@ function check_env_vars() {
   fi
 
   if [[ -v REPLICATION ]]; then
-    [[ -v MONGODB_KEYFILE_VALUE ]] || usage "MONGODB_KEYFILE_VALUE has to be set"
-    [[ -v MONGODB_REPLICA_NAME ]] ||  usage "MONGODB_REPLICA_NAME has to be set"
+    [[ -v MONGODB_KEYFILE_VALUE && -v MONGODB_REPLICA_NAME ]] || usage "MONGODB_KEYFILE_VALUE and MONGODB_REPLICA_NAME have to be set"
   fi
 }
 
@@ -217,7 +216,7 @@ function usage() {
   echo "
 You must specify the following environment variables:
   MONGODB_ADMIN_PASSWORD
-Optionally you can provide settings for user with 'readWrite' role:
+Optionally you can provide settings for a user with 'readWrite' role:
   MONGODB_USER
   MONGODB_PASSWORD
   MONGODB_DATABASE

--- a/3.0-upg/root/usr/bin/run-mongod
+++ b/3.0-upg/root/usr/bin/run-mongod
@@ -6,20 +6,6 @@ set -o pipefail
 
 source ${CONTAINER_SCRIPTS_PATH}/common.sh
 
-function usage() {
-  echo "You must specify the following environment variables:"
-  echo "  MONGODB_ADMIN_PASSWORD"
-  echo "Optionally you can provide settings for user with 'readWrite' role:"
-  echo "  MONGODB_USER"
-  echo "  MONGODB_PASSWORD"
-  echo "  MONGODB_DATABASE"
-  echo "MongoDB settings:"
-  echo "  MONGODB_PREALLOC (default: false)"
-  echo "  MONGODB_SMALLFILES (default: true)"
-  echo "  MONGODB_QUIET (default: true)"
-  exit 1
-}
-
 function cleanup() {
   echo "=> Shutting down MongoDB server ..."
   pkill -INT mongod || :
@@ -36,6 +22,8 @@ Notice: This image is supported only for upgrade from MongoDB 2.6 to 3.2.
 "
 
 trap 'cleanup' SIGINT SIGTERM
+
+check_env_vars
 
 [[ -v MONGODB_ADMIN_PASSWORD ]] || usage
 if [[ -v MONGODB_USER || -v MONGODB_PASSWORD || -v MONGODB_DATABASE ]]; then

--- a/3.0-upg/root/usr/bin/run-mongod
+++ b/3.0-upg/root/usr/bin/run-mongod
@@ -25,12 +25,6 @@ trap 'cleanup' SIGINT SIGTERM
 
 check_env_vars
 
-[[ -v MONGODB_ADMIN_PASSWORD ]] || usage
-if [[ -v MONGODB_USER || -v MONGODB_PASSWORD || -v MONGODB_DATABASE ]]; then
-  [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE ]] || usage
-  export CREATE_USER=1
-fi
-
 # If user provides own config file use it and do not generate new one
 if [ ! -s $MONGODB_CONFIG_PATH ]; then
   # Generate config file for MongoDB

--- a/3.0-upg/root/usr/bin/run-mongod-replication
+++ b/3.0-upg/root/usr/bin/run-mongod-replication
@@ -17,24 +17,6 @@ set -o pipefail
 
 source ${CONTAINER_SCRIPTS_PATH}/common.sh
 
-function usage() {
-  echo "You must specify the following environment variables:"
-  echo "  MONGODB_ADMIN_PASSWORD"
-  echo "  MONGODB_KEYFILE_VALUE"
-  echo "  MONGODB_REPLICA_NAME"
-  echo "Optionally you can provide settings for user with 'readWrite' role:"
-  echo "  MONGODB_USER"
-  echo "  MONGODB_PASSWORD"
-  echo "  MONGODB_DATABASE"
-  echo "Optional variables:"
-  echo "  MONGODB_SERVICE_NAME (default: mongodb)"
-  echo "MongoDB settings:"
-  echo "  MONGODB_PREALLOC (default: false)"
-  echo "  MONGODB_SMALLFILES (default: true)"
-  echo "  MONGODB_QUIET (default: true)"
-  exit 1
-}
-
 function cleanup() {
   echo "=> Shutting down MongoDB server ..."
   pkill -INT mongod || :
@@ -44,11 +26,7 @@ function cleanup() {
 
 trap 'cleanup' SIGINT SIGTERM
 
-[[ -v MONGODB_ADMIN_PASSWORD ]] || usage
-if [[ -v MONGODB_USER || -v MONGODB_PASSWORD || -v MONGODB_DATABASE ]]; then
-  [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE ]] || usage
-  export CREATE_USER=1
-fi
+REPLICATION=1 check_env_vars
 
 # If user provides own config file use it and do not generate new one
 if [ ! -s "${MONGODB_CONFIG_PATH}" ]; then

--- a/3.0-upg/root/usr/share/container-scripts/mongodb/common.sh
+++ b/3.0-upg/root/usr/share/container-scripts/mongodb/common.sh
@@ -220,8 +220,7 @@ function check_env_vars() {
   fi
 
   if [[ -v REPLICATION ]]; then
-    [[ -v MONGODB_KEYFILE_VALUE ]] || usage "MONGODB_KEYFILE_VALUE has to be set"
-    [[ -v MONGODB_REPLICA_NAME ]] ||  usage "MONGODB_REPLICA_NAME has to be set"
+    [[ -v MONGODB_KEYFILE_VALUE && -v MONGODB_REPLICA_NAME ]] || usage "MONGODB_KEYFILE_VALUE and MONGODB_REPLICA_NAME have to be set"
   fi
 }
 
@@ -236,7 +235,7 @@ function usage() {
   echo "
 You must specify the following environment variables:
   MONGODB_ADMIN_PASSWORD
-Optionally you can provide settings for user with 'readWrite' role:
+Optionally you can provide settings for a user with 'readWrite' role:
   MONGODB_USER
   MONGODB_PASSWORD
   MONGODB_DATABASE

--- a/3.0-upg/root/usr/share/container-scripts/mongodb/common.sh
+++ b/3.0-upg/root/usr/share/container-scripts/mongodb/common.sh
@@ -236,6 +236,7 @@ function usage() {
 You must specify the following environment variables:
   MONGODB_ADMIN_PASSWORD
 Optionally you can provide settings for a user with 'readWrite' role:
+(Note you MUST specify all three of these settings)
   MONGODB_USER
   MONGODB_PASSWORD
   MONGODB_DATABASE

--- a/3.0-upg/root/usr/share/container-scripts/mongodb/common.sh
+++ b/3.0-upg/root/usr/share/container-scripts/mongodb/common.sh
@@ -202,6 +202,65 @@ function setup_wiredtiger_cache() {
   info "wiredTiger cacheSizeGB set to ${cache_size}"
 }
 
+# check_env_vars checks environmental variables
+# if variables to create non-admin user are provided, sets CREATE_USER=1
+# if REPLICATION variable is set, checks also replication variables
+function check_env_vars() {
+  local readonly database_regex='^[^/\. "$]*$'
+
+  [[ -v MONGODB_ADMIN_PASSWORD ]] || usage "MONGODB_ADMIN_PASSWORD has to be set."
+
+  if [[ -v MONGODB_USER || -v MONGODB_PASSWORD || -v MONGODB_DATABASE ]]; then
+    [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE ]] || usage "You have to set all or none of variables: MONGODB_USER, MONGODB_PASSWORD, MONGODB_DATABASE"
+
+    [[ "${MONGODB_DATABASE}" =~ $database_regex ]] || usage "Database name must match regex: $database_regex"
+    [ ${#MONGODB_DATABASE} -le 63 ] || usage "Database name too long (maximum 63 characters)"
+
+    export CREATE_USER=1
+  fi
+
+  if [[ -v REPLICATION ]]; then
+    [[ -v MONGODB_KEYFILE_VALUE ]] || usage "MONGODB_KEYFILE_VALUE has to be set"
+    [[ -v MONGODB_REPLICA_NAME ]] ||  usage "MONGODB_REPLICA_NAME has to be set"
+  fi
+}
+
+# usage prints info about required enviromental variables
+# if $1 is passed, prints error message containing $1
+# if REPLICATION variable is set, prints also info about replication variables
+function usage() {
+  if [ $# == 1 ]; then
+    echo >&2 "error: $1"
+  fi
+
+  echo "
+You must specify the following environment variables:
+  MONGODB_ADMIN_PASSWORD
+Optionally you can provide settings for user with 'readWrite' role:
+  MONGODB_USER
+  MONGODB_PASSWORD
+  MONGODB_DATABASE
+Optional settings:
+  MONGODB_PREALLOC (default: false)
+  MONGODB_SMALLFILES (default: true)
+  MONGODB_QUIET (default: true)"
+
+  if [[ -v REPLICATION ]]; then
+    echo "
+For replication you must also specify the following environment variables:
+  MONGODB_KEYFILE_VALUE
+  MONGODB_REPLICA_NAME
+Optional settings:
+  MONGODB_SERVICE_NAME (default: mongodb)
+"
+  fi
+  echo "
+For more information see /usr/share/container-scripts/mongodb/README.md
+within the container or visit https://github.com/sclorgk/mongodb-container/."
+
+  exit 1
+}
+
 # info prints a message prefixed by date and time.
 function info() {
   printf "=> [%s] %s\n" "$(date +'%a %b %d %T')" "$*"

--- a/3.2/root/usr/bin/run-mongod
+++ b/3.2/root/usr/bin/run-mongod
@@ -6,18 +6,6 @@ set -o pipefail
 
 source ${CONTAINER_SCRIPTS_PATH}/common.sh
 
-function usage() {
-  echo "You must specify the following environment variables:"
-  echo "  MONGODB_ADMIN_PASSWORD"
-  echo "Optionally you can provide settings for user with 'readWrite' role:"
-  echo "  MONGODB_USER"
-  echo "  MONGODB_PASSWORD"
-  echo "  MONGODB_DATABASE"
-  echo "MongoDB settings:"
-  echo "  MONGODB_QUIET (default: true)"
-  exit 1
-}
-
 function cleanup() {
   echo "=> Shutting down MongoDB server ..."
   pkill -INT mongod || :
@@ -27,11 +15,7 @@ function cleanup() {
 
 trap 'cleanup' SIGINT SIGTERM
 
-[[ -v MONGODB_ADMIN_PASSWORD ]] || usage
-if [[ -v MONGODB_USER || -v MONGODB_PASSWORD || -v MONGODB_DATABASE ]]; then
-  [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE ]] || usage
-  export CREATE_USER=1
-fi
+check_env_vars
 
 setup_wiredtiger_cache ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template
 

--- a/3.2/root/usr/bin/run-mongod-replication
+++ b/3.2/root/usr/bin/run-mongod-replication
@@ -17,22 +17,6 @@ set -o pipefail
 
 source ${CONTAINER_SCRIPTS_PATH}/common.sh
 
-function usage() {
-  echo "You must specify the following environment variables:"
-  echo "  MONGODB_ADMIN_PASSWORD"
-  echo "  MONGODB_KEYFILE_VALUE"
-  echo "  MONGODB_REPLICA_NAME"
-  echo "Optionally you can provide settings for user with 'readWrite' role:"
-  echo "  MONGODB_USER"
-  echo "  MONGODB_PASSWORD"
-  echo "  MONGODB_DATABASE"
-  echo "Optional variables:"
-  echo "  MONGODB_SERVICE_NAME (default: mongodb)"
-  echo "MongoDB settings:"
-  echo "  MONGODB_QUIET (default: true)"
-  exit 1
-}
-
 function cleanup() {
   echo "=> Shutting down MongoDB server ..."
   pkill -INT mongod || :
@@ -42,11 +26,7 @@ function cleanup() {
 
 trap 'cleanup' SIGINT SIGTERM
 
-[[ -v MONGODB_ADMIN_PASSWORD ]] || usage
-if [[ -v MONGODB_USER || -v MONGODB_PASSWORD || -v MONGODB_DATABASE ]]; then
-  [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE ]] || usage
-  export CREATE_USER=1
-fi
+REPLICATION=1 check_env_vars
 
 setup_wiredtiger_cache ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template
 

--- a/3.2/root/usr/share/container-scripts/mongodb/common.sh
+++ b/3.2/root/usr/share/container-scripts/mongodb/common.sh
@@ -230,6 +230,7 @@ function usage() {
 You must specify the following environment variables:
   MONGODB_ADMIN_PASSWORD
 Optionally you can provide settings for a user with 'readWrite' role:
+(Note you MUST specify all three of these settings)
   MONGODB_USER
   MONGODB_PASSWORD
   MONGODB_DATABASE

--- a/3.2/root/usr/share/container-scripts/mongodb/common.sh
+++ b/3.2/root/usr/share/container-scripts/mongodb/common.sh
@@ -214,8 +214,7 @@ function check_env_vars() {
   fi
 
   if [[ -v REPLICATION ]]; then
-    [[ -v MONGODB_KEYFILE_VALUE ]] || usage "MONGODB_KEYFILE_VALUE has to be set"
-    [[ -v MONGODB_REPLICA_NAME ]] ||  usage "MONGODB_REPLICA_NAME has to be set"
+    [[ -v MONGODB_KEYFILE_VALUE && -v MONGODB_REPLICA_NAME ]] || usage "MONGODB_KEYFILE_VALUE and MONGODB_REPLICA_NAME have to be set"
   fi
 }
 
@@ -230,7 +229,7 @@ function usage() {
   echo "
 You must specify the following environment variables:
   MONGODB_ADMIN_PASSWORD
-Optionally you can provide settings for user with 'readWrite' role:
+Optionally you can provide settings for a user with 'readWrite' role:
   MONGODB_USER
   MONGODB_PASSWORD
   MONGODB_DATABASE

--- a/3.2/root/usr/share/container-scripts/mongodb/common.sh
+++ b/3.2/root/usr/share/container-scripts/mongodb/common.sh
@@ -196,6 +196,63 @@ function setup_wiredtiger_cache() {
   info "wiredTiger cacheSizeGB set to ${cache_size}"
 }
 
+# check_env_vars checks environmental variables
+# if variables to create non-admin user are provided, sets CREATE_USER=1
+# if REPLICATION variable is set, checks also replication variables
+function check_env_vars() {
+  local readonly database_regex='^[^/\. "$]*$'
+
+  [[ -v MONGODB_ADMIN_PASSWORD ]] || usage "MONGODB_ADMIN_PASSWORD has to be set."
+
+  if [[ -v MONGODB_USER || -v MONGODB_PASSWORD || -v MONGODB_DATABASE ]]; then
+    [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE ]] || usage "You have to set all or none of variables: MONGODB_USER, MONGODB_PASSWORD, MONGODB_DATABASE"
+
+    [[ "${MONGODB_DATABASE}" =~ $database_regex ]] || usage "Database name must match regex: $database_regex"
+    [ ${#MONGODB_DATABASE} -le 63 ] || usage "Database name too long (maximum 63 characters)"
+
+    export CREATE_USER=1
+  fi
+
+  if [[ -v REPLICATION ]]; then
+    [[ -v MONGODB_KEYFILE_VALUE ]] || usage "MONGODB_KEYFILE_VALUE has to be set"
+    [[ -v MONGODB_REPLICA_NAME ]] ||  usage "MONGODB_REPLICA_NAME has to be set"
+  fi
+}
+
+# usage prints info about required enviromental variables
+# if $1 is passed, prints error message containing $1
+# if REPLICATION variable is set, prints also info about replication variables
+function usage() {
+  if [ $# == 1 ]; then
+    echo >&2 "error: $1"
+  fi
+
+  echo "
+You must specify the following environment variables:
+  MONGODB_ADMIN_PASSWORD
+Optionally you can provide settings for user with 'readWrite' role:
+  MONGODB_USER
+  MONGODB_PASSWORD
+  MONGODB_DATABASE
+Optional settings:
+  MONGODB_QUIET (default: true)"
+
+  if [[ -v REPLICATION ]]; then
+    echo "
+For replication you must also specify the following environment variables:
+  MONGODB_KEYFILE_VALUE
+  MONGODB_REPLICA_NAME
+Optional settings:
+  MONGODB_SERVICE_NAME (default: mongodb)
+"
+  fi
+  echo "
+For more information see /usr/share/container-scripts/mongodb/README.md
+within the container or visit https://github.com/sclorgk/mongodb-container/."
+
+  exit 1
+}
+
 # info prints a message prefixed by date and time.
 function info() {
   printf "=> [%s] %s\n" "$(date +'%a %b %d %T')" "$*"


### PR DESCRIPTION
Move checkinkg of variables and usage into common.sh + prints more detailed error message

Adds validation of database name - https://docs.mongodb.com/manual/reference/limits/

Using similar approach as postgresql-container (https://github.com/sclorg/postgresql-container/blob/master/9.5/root/usr/share/container-scripts/postgresql/common.sh#L58)

Resolves: #235