### PR TITLE
Fix creation of user in run-mongod-replication

### DIFF
--- a/2.6/root/usr/bin/run-mongod
+++ b/2.6/root/usr/bin/run-mongod
@@ -32,7 +32,7 @@ trap 'cleanup' SIGINT SIGTERM
 [[ -v MONGODB_ADMIN_PASSWORD ]] || usage
 if [[ -v MONGODB_USER || -v MONGODB_PASSWORD || -v MONGODB_DATABASE ]]; then
   [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE ]] || usage
-  CREATE_USER=1
+  export CREATE_USER=1
 fi
 
 # If user provides own config file use it and do not generate new one

--- a/2.6/root/usr/bin/run-mongod-replication
+++ b/2.6/root/usr/bin/run-mongod-replication
@@ -47,7 +47,7 @@ trap 'cleanup' SIGINT SIGTERM
 [[ -v MONGODB_ADMIN_PASSWORD ]] || usage
 if [[ -v MONGODB_USER || -v MONGODB_PASSWORD || -v MONGODB_DATABASE ]]; then
   [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE ]] || usage
-  CREATE_USER=1
+  export CREATE_USER=1
 fi
 
 # If user provides own config file use it and do not generate new one

--- a/3.0-upg/root/usr/bin/run-mongod
+++ b/3.0-upg/root/usr/bin/run-mongod
@@ -40,7 +40,7 @@ trap 'cleanup' SIGINT SIGTERM
 [[ -v MONGODB_ADMIN_PASSWORD ]] || usage
 if [[ -v MONGODB_USER || -v MONGODB_PASSWORD || -v MONGODB_DATABASE ]]; then
   [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE ]] || usage
-  CREATE_USER=1
+  export CREATE_USER=1
 fi
 
 # If user provides own config file use it and do not generate new one

--- a/3.0-upg/root/usr/bin/run-mongod-replication
+++ b/3.0-upg/root/usr/bin/run-mongod-replication
@@ -47,7 +47,7 @@ trap 'cleanup' SIGINT SIGTERM
 [[ -v MONGODB_ADMIN_PASSWORD ]] || usage
 if [[ -v MONGODB_USER || -v MONGODB_PASSWORD || -v MONGODB_DATABASE ]]; then
   [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE ]] || usage
-  CREATE_USER=1
+  export CREATE_USER=1
 fi
 
 # If user provides own config file use it and do not generate new one

--- a/3.2/root/usr/bin/run-mongod
+++ b/3.2/root/usr/bin/run-mongod
@@ -30,7 +30,7 @@ trap 'cleanup' SIGINT SIGTERM
 [[ -v MONGODB_ADMIN_PASSWORD ]] || usage
 if [[ -v MONGODB_USER || -v MONGODB_PASSWORD || -v MONGODB_DATABASE ]]; then
   [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE ]] || usage
-  CREATE_USER=1
+  export CREATE_USER=1
 fi
 
 setup_wiredtiger_cache ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template

--- a/3.2/root/usr/bin/run-mongod-replication
+++ b/3.2/root/usr/bin/run-mongod-replication
@@ -45,7 +45,7 @@ trap 'cleanup' SIGINT SIGTERM
 [[ -v MONGODB_ADMIN_PASSWORD ]] || usage
 if [[ -v MONGODB_USER || -v MONGODB_PASSWORD || -v MONGODB_DATABASE ]]; then
   [[ -v MONGODB_USER && -v MONGODB_PASSWORD && -v MONGODB_DATABASE ]] || usage
-  CREATE_USER=1
+  export CREATE_USER=1
 fi
 
 setup_wiredtiger_cache ${CONTAINER_SCRIPTS_PATH}/mongodb.conf.template


### PR DESCRIPTION
In `run-mongod-replication` `CREATE_USER` was not exported, so it can't be used in `init-replset.sh`.

[test-openshift]

Fixes: https://github.com/openshift/origin/issues/13659#issuecomment-292263840