### PR TITLE
tests: Only test help.1

### DIFF
--- a/2.6/test/run
+++ b/2.6/test/run
@@ -366,11 +366,11 @@ run_doc_test() {
   local f
   echo "  Testing documentation in the container image"
   # Extract the help files from the container
-  for f in /usr/share/container-scripts/mongodb/README.md help.1 ; do
+  for f in help.1 ; do
     docker run --rm ${IMAGE_NAME} /bin/bash -c "cat /${f}" >${tmpdir}/$(basename ${f})
     # Check whether the files include some important information
-    for term in MONGODB_ADMIN_PASSWORD volume ; do
-      if ! cat ${tmpdir}/$(basename ${f}) | grep -q -e "${term}" ; then
+    for term in "MONGODB\_ADMIN\_PASSWORD" volume ; do
+      if ! cat ${tmpdir}/$(basename ${f}) | grep -F -q -e "${term}" ; then
         echo "ERROR: File /${f} does not include '${term}'."
         return 1
       fi

--- a/3.0-upg/test/run
+++ b/3.0-upg/test/run
@@ -366,11 +366,11 @@ run_doc_test() {
   local f
   echo "  Testing documentation in the container image"
   # Extract the help files from the container
-  for f in /usr/share/container-scripts/mongodb/README.md help.1 ; do
+  for f in help.1 ; do
     docker run --rm ${IMAGE_NAME} /bin/bash -c "cat /${f}" >${tmpdir}/$(basename ${f})
     # Check whether the files include some important information
-    for term in MONGODB_ADMIN_PASSWORD volume ; do
-      if ! cat ${tmpdir}/$(basename ${f}) | grep -q -e "${term}" ; then
+    for term in "MONGODB\_ADMIN\_PASSWORD" volume ; do
+      if ! cat ${tmpdir}/$(basename ${f}) | grep -F -q -e "${term}" ; then
         echo "ERROR: File /${f} does not include '${term}'."
         return 1
       fi

--- a/3.2/test/run
+++ b/3.2/test/run
@@ -361,11 +361,11 @@ run_doc_test() {
   local f
   echo "  Testing documentation in the container image"
   # Extract the help files from the container
-  for f in /usr/share/container-scripts/mongodb/README.md help.1 ; do
+  for f in help.1 ; do
     docker run --rm ${IMAGE_NAME} /bin/bash -c "cat /${f}" >${tmpdir}/$(basename ${f})
     # Check whether the files include some important information
-    for term in MONGODB_ADMIN_PASSWORD volume ; do
-      if ! cat ${tmpdir}/$(basename ${f}) | grep -q -e "${term}" ; then
+    for term in "MONGODB\_ADMIN\_PASSWORD" volume ; do
+      if ! cat ${tmpdir}/$(basename ${f}) | grep -F -q -e "${term}" ; then
         echo "ERROR: File /${f} does not include '${term}'."
         return 1
       fi


### PR DESCRIPTION
Also pulls in newer sclorg/container-common-scripts to be able to build help.1

same PR as sclorg/mariadb-container#35 only modified to leave the `for` loop in place in case we need to test multiple files in future