### PR TITLE
Remove the created containers during test properly

### DIFF
--- a/2.6/test/run
+++ b/2.6/test/run
@@ -55,7 +55,7 @@ function assert_container_creation_fails() {
   # container will keep running so we kill it with SIGKILL to make sure
   # timeout returns a non-zero value.
   set +e
-  timeout -s 9 --preserve-status 10s docker run --rm "$@" $IMAGE_NAME
+  timeout -s SIGTERM --preserve-status 10s docker run --rm "$@" $IMAGE_NAME
   ret=$?
   set -e
 

--- a/3.0-upg/test/run
+++ b/3.0-upg/test/run
@@ -55,7 +55,7 @@ function assert_container_creation_fails() {
   # container will keep running so we kill it with SIGKILL to make sure
   # timeout returns a non-zero value.
   set +e
-  timeout -s 9 --preserve-status 10s docker run --rm "$@" $IMAGE_NAME
+  timeout -s SIGTERM --preserve-status 10s docker run --rm "$@" $IMAGE_NAME
   ret=$?
   set -e
 

--- a/3.2/test/run
+++ b/3.2/test/run
@@ -55,7 +55,7 @@ function assert_container_creation_fails() {
   # container will keep running so we kill it with SIGKILL to make sure
   # timeout returns a non-zero value.
   set +e
-  timeout -s 9 --preserve-status 10s docker run --rm "$@" $IMAGE_NAME
+  timeout -s SIGTERM --preserve-status 10s docker run --rm "$@" $IMAGE_NAME
   ret=$?
   set -e
 


### PR DESCRIPTION
After running tests on containers, not all of them were cleaned up properly. It was in the container creation tests and the containers that should have been stopped and removed were left running.
Changing the signal sent to containers by timeout to SIGTERM solved the issue.