### PR TITLE
Fix cleanup in tests

### DIFF
--- a/2.6/test/run
+++ b/2.6/test/run
@@ -29,7 +29,7 @@ function cleanup() {
     rmdir $CIDFILE_DIR
 
     local network_name="mongodb-replset-$$"
-    docker network ls | grep -qv ${network_name} || docker network rm ${network_name}
+    ! docker network ls | grep -q ${network_name} || docker network rm ${network_name}
 }
 trap cleanup EXIT SIGINT
 

--- a/3.0-upg/test/run
+++ b/3.0-upg/test/run
@@ -29,7 +29,7 @@ function cleanup() {
     rmdir $CIDFILE_DIR
 
     local network_name="mongodb-replset-$$"
-    docker network ls | grep -qv ${network_name} || docker network rm ${network_name}
+    ! docker network ls | grep -q  ${network_name} || docker network rm ${network_name}
 }
 trap cleanup EXIT SIGINT
 

--- a/3.2/test/run
+++ b/3.2/test/run
@@ -29,7 +29,7 @@ function cleanup() {
     rmdir $CIDFILE_DIR
 
     local network_name="mongodb-replset-$$"
-    docker network ls | grep -qv ${network_name} || docker network rm ${network_name}
+    ! docker network ls | grep -q ${network_name} || docker network rm ${network_name}
 }
 trap cleanup EXIT SIGINT
 


### PR DESCRIPTION
Checking for presence of network used for replication isn't right
- `docker network rm` is never run now

Discovered in https://github.com/sclorg/mongodb-container/pull/250

@hhorak @pkubatrh What about this solution?