### PR TITLE
Use s2i-core instead of s2i-base

### DIFF
--- a/2.6/Dockerfile
+++ b/2.6/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos/s2i-base-centos7
+FROM centos/s2i-core-centos7
 
 ENV SUMMARY="MongoDB NoSQL database server" \
     DESCRIPTION="MongoDB (from humongous) is a free and open-source \

--- a/2.6/Dockerfile.rhel7
+++ b/2.6/Dockerfile.rhel7
@@ -33,7 +33,10 @@ EXPOSE 27017
 ENTRYPOINT ["container-entrypoint"]
 CMD ["run-mongod"]
 
-RUN yum install -y yum-utils && \
+# We need to call 2 (!) yum commands before being able to enable repositories properly
+# This is a workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1479388
+RUN yum repolist > /dev/null && \
+    yum install -y yum-utils && \
     yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     INSTALL_PKGS="bind-utils gettext iproute rsync tar hostname shadow-utils v8314 rh-mongodb26-mongodb rh-mongodb26 groff-base" && \

--- a/2.6/Dockerfile.rhel7
+++ b/2.6/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM rhscl/s2i-base-rhel7
+FROM rhscl/s2i-core-rhel7
 
 ENV SUMMARY="MongoDB NoSQL database server" \
     DESCRIPTION="MongoDB (from humongous) is a free and open-source \

--- a/3.0-upg/Dockerfile
+++ b/3.0-upg/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos/s2i-base-centos7
+FROM centos/s2i-core-centos7
 
 ENV SUMMARY="MongoDB NoSQL database server" \
     DESCRIPTION="MongoDB (from humongous) is a free and open-source \

--- a/3.0-upg/Dockerfile.rhel7
+++ b/3.0-upg/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM rhscl/s2i-base-rhel7
+FROM rhscl/s2i-core-rhel7
 
 ENV SUMMARY="MongoDB NoSQL database server" \
     DESCRIPTION="MongoDB (from humongous) is a free and open-source \

--- a/3.0-upg/Dockerfile.rhel7
+++ b/3.0-upg/Dockerfile.rhel7
@@ -33,7 +33,10 @@ EXPOSE 27017
 ENTRYPOINT ["container-entrypoint"]
 CMD ["run-mongod"]
 
-RUN yum install -y yum-utils && \
+# We need to call 2 (!) yum commands before being able to enable repositories properly
+# This is a workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1479388
+RUN yum repolist > /dev/null && \
+    yum install -y yum-utils && \
     yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     INSTALL_PKGS="bind-utils gettext iproute rsync tar hostname shadow-utils v8314 rh-mongodb30upg-mongodb rh-mongodb30upg groff-base" && \

--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos/s2i-base-centos7
+FROM centos/s2i-core-centos7
 
 ENV SUMMARY="MongoDB NoSQL database server" \
     DESCRIPTION="MongoDB (from humongous) is a free and open-source \

--- a/3.2/Dockerfile.rhel7
+++ b/3.2/Dockerfile.rhel7
@@ -33,7 +33,10 @@ EXPOSE 27017
 ENTRYPOINT ["container-entrypoint"]
 CMD ["run-mongod"]
 
-RUN yum install -y yum-utils && \
+# We need to call 2 (!) yum commands before being able to enable repositories properly
+# This is a workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1479388
+RUN yum repolist > /dev/null && \
+    yum install -y yum-utils && \
     yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     INSTALL_PKGS="bind-utils gettext iproute rsync tar hostname shadow-utils rh-mongodb32-mongodb rh-mongodb32 rh-mongodb32-mongo-tools groff-base" && \

--- a/3.2/Dockerfile.rhel7
+++ b/3.2/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM rhscl/s2i-base-rhel7
+FROM rhscl/s2i-core-rhel7
 
 ENV SUMMARY="MongoDB NoSQL database server" \
     DESCRIPTION="MongoDB (from humongous) is a free and open-source \


### PR DESCRIPTION
Change to `Dockerfile.fedora` is not part of this PR as it seems the Fedora version of s2i-core has yet to be built.