### PR TITLE
doc: fixing typos

### DIFF
--- a/2.6/root/usr/share/container-scripts/mongodb/common.sh
+++ b/2.6/root/usr/share/container-scripts/mongodb/common.sh
@@ -112,7 +112,7 @@ Optional settings:
   fi
   echo "
 For more information see /usr/share/container-scripts/mongodb/README.md
-within the container or visit https://github.com/sclorgk/mongodb-container/."
+within the container or visit https://github.com/sclorg/mongodb-container/."
 
   exit 1
 }

--- a/3.0-upg/root/usr/share/container-scripts/mongodb/common.sh
+++ b/3.0-upg/root/usr/share/container-scripts/mongodb/common.sh
@@ -112,7 +112,7 @@ Optional settings:
   fi
   echo "
 For more information see /usr/share/container-scripts/mongodb/README.md
-within the container or visit https://github.com/sclorgk/mongodb-container/."
+within the container or visit https://github.com/sclorg/mongodb-container/."
 
   exit 1
 }

--- a/3.2/root/usr/share/container-scripts/mongodb/common.sh
+++ b/3.2/root/usr/share/container-scripts/mongodb/common.sh
@@ -104,7 +104,7 @@ Optional settings:
   fi
   echo "
 For more information see /usr/share/container-scripts/mongodb/README.md
-within the container or visit https://github.com/sclorgk/mongodb-container/."
+within the container or visit https://github.com/sclorg/mongodb-container/."
 
   exit 1
 }

--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ Usage
 ---------------------------------
 
 For information about usage of Dockerfile for MongoDB 2.6,
-see [usage documentation](2.6/README.md).
+see [usage documentation](2.6/).
 
 For information about usage of Dockerfile for MongoDB 3.0-upg,
-see [usage documentation](3.0-upg/README.md).
+see [usage documentation](3.0-upg/).
 
 For information about usage of Dockerfile for MongoDB 3.2,
-see [usage documentation](3.2/README.md).
+see [usage documentation](3.2/).
 
 Test
 ---------------------------------

--- a/examples/extending-image/mongodb-pre-init/1-mkdir-socker-dir.sh
+++ b/examples/extending-image/mongodb-pre-init/1-mkdir-socker-dir.sh
@@ -1,3 +1,0 @@
-# Create directory for socket
-
-mkdir ~/socket/

--- a/examples/extending-image/mongodb-pre-init/1-mkdir-socker-dir.sh
+++ b/examples/extending-image/mongodb-pre-init/1-mkdir-socker-dir.sh
@@ -1,3 +1,3 @@
-# Create directory for socker
+# Create directory for socket
 
 mkdir ~/socket/

--- a/examples/extending-image/mongodb-pre-init/1-mkdir-socket-dir.sh
+++ b/examples/extending-image/mongodb-pre-init/1-mkdir-socket-dir.sh
@@ -1,3 +1,3 @@
-# Create directory for socker
+# Create directory for socket
 
 mkdir ~/socket/

--- a/examples/extending-image/mongodb-pre-init/1-mkdir-socket-dir.sh
+++ b/examples/extending-image/mongodb-pre-init/1-mkdir-socket-dir.sh
@@ -1,0 +1,3 @@
+# Create directory for socker
+
+mkdir ~/socket/


### PR DESCRIPTION
- typo in the link to upstream repo fixed.
- `usage documentation` link now points to the version directory, because current link only display path to README.md file.
- typo in the example script fixed.