### PR TITLE
Various small documentation related changes

### DIFF
--- a/2.6/Dockerfile
+++ b/2.6/Dockerfile
@@ -14,8 +14,8 @@ LABEL summary="$SUMMARY" \
       io.openshift.tags="database,mongodb,rh-mongodb26" \
       com.redhat.component="rh-mongodb26-docker" \
       name="centos/mongodb-26-centos7" \
+      usage="docker run -d -e MONGODB_ADMIN_PASSWORD=my_pass centos/mongodb-26-centos7" \
       version="2.6" \
-      release="1" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 ENV MONGODB_VERSION=2.6 \

--- a/2.6/Dockerfile.rhel7
+++ b/2.6/Dockerfile.rhel7
@@ -14,8 +14,9 @@ LABEL summary="$SUMMARY" \
       io.openshift.tags="database,mongodb,rh-mongodb26" \
       com.redhat.component="rh-mongodb26-docker" \
       name="rhscl/mongodb-26-rhel7" \
+      usage="docker run -d -e MONGODB_ADMIN_PASSWORD=my_pass rhscl/mongodb-26-rhel7" \
       version="2.6" \
-      release="1"
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 ENV MONGODB_VERSION=2.6 \
     # Set paths to avoid hard-coding them in scripts.

--- a/2.6/root/usr/bin/usage
+++ b/2.6/root/usr/bin/usage
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cat /usr/share/container-scripts/mongodb/README.md
+

--- a/2.6/root/usr/share/container-scripts/mongodb/README.md
+++ b/2.6/root/usr/share/container-scripts/mongodb/README.md
@@ -1,7 +1,3 @@
-% MONGODB-26(1) Container Image Pages
-% SoftwareCollections.org
-% July 18, 2017
-
 MongoDB 2.6 NoSQL Database Server Docker image
 ====================
 
@@ -48,37 +44,47 @@ Environment variables and volumes
 The image recognizes the following environment variables that you can set
 during initialization by passing `-e VAR=VALUE` to the Docker run command.
 
-|    Variable name          |    Description                              |
-| :------------------------ | -----------------------------------------   |
-|  `MONGODB_ADMIN_PASSWORD` | Password for the admin user                 |
+**`MONGODB_ADMIN_PASSWORD`**  
+       Password for the admin user
+
 
 Optionally you can provide settings for user with 'readWrite' role.
 (Note you MUST specify all three of these settings)
 
-|    Variable name          |    Description                              |
-| :------------------------ | -----------------------------------------   |
-|  `MONGODB_USER`           | User name for MONGODB account to be created |
-|  `MONGODB_PASSWORD`       | Password for the user account               |
-|  `MONGODB_DATABASE`       | Database name                               |
+**`MONGODB_USER`**  
+       User name for MONGODB account to be created
+
+**`MONGODB_PASSWORD`**  
+       Password for the user account
+
+**`MONGODB_DATABASE`**  
+       Database name
+
 
 
 The following environment variables influence the MongoDB configuration file.
 They are all optional.
 
-|    Variable name      |    Description                                                            |    Default
-| :-------------------- | ------------------------------------------------------------------------- | ----------------
-|  `MONGODB_PREALLOC`   | Enable data file preallocation.                                           |  false
-|  `MONGODB_NOPREALLOC`   | DEPRECATED - use `MONGODB_PREALLOC` instead. Disable data file preallocation. |
-|  `MONGODB_SMALLFILES` | Set MongoDB to use a smaller default data file size.                      |  true
-|  `MONGODB_QUIET`      | Runs MongoDB in a quiet mode that attempts to limit the amount of output. |  true
+**`MONGODB_PREALLOC (default: false)`**  
+       Enable data file preallocation.
+
+**`MONGODB_NOPREALLOC`**  
+       DEPRECATED - use `MONGODB_PREALLOC` instead. Disable data file preallocation.
+
+**`MONGODB_SMALLFILES (default: true)`**  
+       Set MongoDB to use a smaller default data file size.
+
+**`MONGODB_QUIET (default: true)`**  
+       Runs MongoDB in a quiet mode that attempts to limit the amount of output.
+
 
 
 You can also set the following mount points by passing the `-v
 /host:/container` flag to Docker.
 
-|  Volume mount point         | Description            |
-| :-------------------------- | ---------------------- |
-|  `/var/lib/mongodb/data`   | MongoDB data directory |
+**`/var/lib/mongodb/data`**  
+       MongoDB data directory
+
 
 **Notice: When mounting a directory from the host into the container, ensure
 that the mounted directory has the appropriate permissions and that the owner

--- a/3.0-upg/Dockerfile
+++ b/3.0-upg/Dockerfile
@@ -14,8 +14,8 @@ LABEL summary="$SUMMARY" \
       io.openshift.tags="database,mongodb,rh-mongodb30upg" \
       com.redhat.component="rh-mongodb30-upg-docker" \
       name="centos/mongodb-30-upg-centos7" \
+      usage="docker run -d -e MONGODB_ADMIN_PASSWORD=my_pass centos/mongodb-30-upg-centos7" \
       version="3.0-upg" \
-      release="1" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 ENV MONGODB_VERSION=3.0-upg \

--- a/3.0-upg/Dockerfile.rhel7
+++ b/3.0-upg/Dockerfile.rhel7
@@ -14,8 +14,9 @@ LABEL summary="$SUMMARY" \
       io.openshift.tags="database,mongodb,rh-mongodb30upg" \
       com.redhat.component="rh-mongodb30-upg-docker" \
       name="rhscl/mongodb-30-upg-rhel7" \
+      usage="docker run -d -e MONGODB_ADMIN_PASSWORD=my_pass rhscl/mongodb-30-upg-rhel7" \
       version="3.0-upg" \
-      release="1"
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 ENV MONGODB_VERSION=3.0-upg \
     # Set paths to avoid hard-coding them in scripts.

--- a/3.0-upg/root/usr/bin/usage
+++ b/3.0-upg/root/usr/bin/usage
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cat /usr/share/container-scripts/mongodb/README.md
+

--- a/3.0-upg/root/usr/share/container-scripts/mongodb/README.md
+++ b/3.0-upg/root/usr/share/container-scripts/mongodb/README.md
@@ -1,7 +1,3 @@
-% MONGODB-30-upg(1) Container Image Pages
-% SoftwareCollections.org
-% July 18, 2017
-
 MongoDB 3.0-upg NoSQL Database Server Docker image
 ====================
 
@@ -47,37 +43,47 @@ Environment variables and volumes
 The image recognizes the following environment variables that you can set
 during initialization by passing `-e VAR=VALUE` to the Docker run command.
 
-|    Variable name          |    Description                              |
-| :------------------------ | -----------------------------------------   |
-|  `MONGODB_ADMIN_PASSWORD` | Password for the admin user                 |
+**`MONGODB_ADMIN_PASSWORD`**  
+       Password for the admin user
+
 
 Optionally you can provide settings for user with 'readWrite' role.
 (Note you MUST specify all three of these settings)
 
-|    Variable name          |    Description                              |
-| :------------------------ | -----------------------------------------   |
-|  `MONGODB_USER`           | User name for MONGODB account to be created |
-|  `MONGODB_PASSWORD`       | Password for the user account               |
-|  `MONGODB_DATABASE`       | Database name                               |
+**`MONGODB_USER`**  
+       User name for MONGODB account to be created
+
+**`MONGODB_PASSWORD`**  
+       Password for the user account
+
+**`MONGODB_DATABASE`**  
+       Database name
+
 
 
 The following environment variables influence the MongoDB configuration file.
 They are all optional.
 
-|    Variable name      |    Description                                                            |    Default
-| :-------------------- | ------------------------------------------------------------------------- | ----------------
-|  `MONGODB_PREALLOC`   | Enable data file preallocation.                                           |  false
-|  `MONGODB_NOPREALLOC`   | DEPRECATED - use `MONGODB_PREALLOC` instead. Disable data file preallocation. |
-|  `MONGODB_SMALLFILES` | Set MongoDB to use a smaller default data file size.                      |  true
-|  `MONGODB_QUIET`      | Runs MongoDB in a quiet mode that attempts to limit the amount of output. |  true
+**`MONGODB_PREALLOC (default: false)`**  
+       Enable data file preallocation.
+
+**`MONGODB_NOPREALLOC`**  
+       DEPRECATED - use `MONGODB_PREALLOC` instead. Disable data file preallocation.
+
+**`MONGODB_SMALLFILES (default: true)`**  
+       Set MongoDB to use a smaller default data file size.
+
+**`MONGODB_QUIET (default: true)`**  
+       Runs MongoDB in a quiet mode that attempts to limit the amount of output.
+
 
 
 You can also set the following mount points by passing the `-v
 /host:/container` flag to Docker.
 
-|  Volume mount point         | Description            |
-| :-------------------------- | ---------------------- |
-|  `/var/lib/mongodb/data`   | MongoDB data directory |
+**`/var/lib/mongodb/data`**  
+       MongoDB data directory
+
 
 **Notice: When mounting a directory from the host into the container, ensure
 that the mounted directory has the appropriate permissions and that the owner

--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -14,8 +14,8 @@ LABEL summary="$SUMMARY" \
       io.openshift.tags="database,mongodb,rh-mongodb32" \
       com.redhat.component="rh-mongodb32-docker" \
       name="centos/mongodb-32-centos7" \
+      usage="docker run -d -e MONGODB_ADMIN_PASSWORD=my_pass centos/mongodb-32-centos7" \
       version="3.2" \
-      release="1" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 ENV MONGODB_VERSION=3.2 \

--- a/3.2/Dockerfile.rhel7
+++ b/3.2/Dockerfile.rhel7
@@ -14,8 +14,9 @@ LABEL summary="$SUMMARY" \
       io.openshift.tags="database,mongodb,rh-mongodb32" \
       com.redhat.component="rh-mongodb32-docker" \
       name="rhscl/mongodb-32-rhel7" \
+      usage="docker run -d -e MONGODB_ADMIN_PASSWORD=my_pass rhscl/mongodb-32-rhel7" \
       version="3.2" \
-      release="1"
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 ENV MONGODB_VERSION=3.2 \
     # Set paths to avoid hard-coding them in scripts.

--- a/3.2/root/usr/bin/usage
+++ b/3.2/root/usr/bin/usage
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cat /usr/share/container-scripts/mongodb/README.md
+

--- a/3.2/root/usr/share/container-scripts/mongodb/README.md
+++ b/3.2/root/usr/share/container-scripts/mongodb/README.md
@@ -1,7 +1,3 @@
-% MONGODB-32(1) Container Image Pages
-% SoftwareCollections.org
-% July 18, 2017
-
 MongoDB 3.2 NoSQL Database Server Docker image
 ====================
 
@@ -48,34 +44,38 @@ Environment variables and volumes
 The image recognizes the following environment variables that you can set
 during initialization by passing `-e VAR=VALUE` to the Docker run command.
 
-|    Variable name          |    Description                              |
-| :------------------------ | -----------------------------------------   |
-|  `MONGODB_ADMIN_PASSWORD` | Password for the admin user                 |
+**`MONGODB_ADMIN_PASSWORD`**  
+       Password for the admin user
+
 
 Optionally you can provide settings for user with 'readWrite' role.
 (Note you MUST specify all three of these settings)
 
-|    Variable name          |    Description                              |
-| :------------------------ | -----------------------------------------   |
-|  `MONGODB_USER`           | User name for MONGODB account to be created |
-|  `MONGODB_PASSWORD`       | Password for the user account               |
-|  `MONGODB_DATABASE`       | Database name                               |
+**`MONGODB_USER`**  
+       User name for MONGODB account to be created
+
+**`MONGODB_PASSWORD`**  
+       Password for the user account
+
+**`MONGODB_DATABASE`**  
+       Database name
+
 
 
 The following environment variables influence the MongoDB configuration file.
 They are all optional.
 
-|    Variable name      |    Description                                                            |    Default
-| :-------------------- | ------------------------------------------------------------------------- | ----------------
-|  `MONGODB_QUIET`      | Runs MongoDB in a quiet mode that attempts to limit the amount of output. |  true
+**`MONGODB_QUIET (default: true)`**  
+       Runs MongoDB in a quiet mode that attempts to limit the amount of output.
+
 
 
 You can also set the following mount points by passing the `-v
 /host:/container` flag to Docker.
 
-|  Volume mount point         | Description            |
-| :-------------------------- | ---------------------- |
-|  `/var/lib/mongodb/data`   | MongoDB data directory |
+**`/var/lib/mongodb/data`**  
+       MongoDB data directory
+
 
 **Notice: When mounting a directory from the host into the container, ensure
 that the mounted directory has the appropriate permissions and that the owner

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ MongoDB Docker images
 =====================
 
 This repository contains Dockerfiles for MongoDB images for OpenShift.
-Users can choose between RHEL and CentOS based images.
+Users can choose between RHEL, Fedora and CentOS based images.
 
 For more information about using these images with OpenShift, please see the
 official [OpenShift Documentation](https://docs.openshift.org/latest/using_images/db_images/mongodb.html).
@@ -19,6 +19,7 @@ MongoDB versions currently provided are:
 * [MongoDB 2.6](2.6)
 * [MongoDB 3.0 (just for upgrades)](3.0)
 * [MongoDB 3.2](3.2)
+* [MongoDB 3.2](3.4)
 
 RHEL versions currently supported are:
 * RHEL7
@@ -33,38 +34,38 @@ Choose either the CentOS7 or RHEL7 based image:
 
 *  **RHEL7 based image**
 
-	This image is available in the [Red Hat Container Catalog](https://access.redhat.com/containers#/registry.access.redhat.com/rhscl/mongodb-32-rhel7). To download it run:
+    This image is available in the [Red Hat Container Catalog](https://access.redhat.com/containers#/registry.access.redhat.com/rhscl/mongodb-34-rhel7). To download it run:
 
-	```
-	$ docker pull registry.access.redhat.com/rhscl/mongodb-32-rhel7
-	```
+    ```
+    $ docker pull registry.access.redhat.com/rhscl/mongodb-32-rhel7
+    ```
 
-	To build a RHEL7 based image, you need to run Docker build on a properly
+    To build a RHEL7 based image, you need to run Docker build on a properly
     subscribed RHEL machine.
 
-	```
-	$ git clone https://github.com/sclorg/mongodb-container.git
-	$ cd mongodb-container
-        $ git submodule update --init
-	$ make build TARGET=rhel7 VERSIONS=3.2
-	```
+    ```
+    $ git clone https://github.com/sclorg/mongodb-container.git
+    $ cd mongodb-container
+    $ git submodule update --init
+    $ make build TARGET=rhel7 VERSIONS=3.2
+    ```
 
 *  **CentOS7 based image**
 
-	This image is available on DockerHub. To download it run:
+    This image is available on DockerHub. To download it run:
 
-	```
-	$ docker pull centos/mongodb-32-centos7
-	```
+    ```
+    $ docker pull centos/mongodb-34-centos7
+    ```
 
-	To build a MongoDB image from scratch run:
+    To build a MongoDB image from scratch run:
 
-	```
-	$ git clone https://github.com/sclorg/mongodb-container.git
-	$ cd mongodb-container
+    ```
+    $ git clone https://github.com/sclorg/mongodb-container.git
+    $ cd mongodb-container
         $ git submodule update --init
-	$ make build TARGET=centos7 VERSIONS=3.2
-	```
+    $ make build TARGET=centos7 VERSIONS=3.4
+    ```
 
 **Notice: By omitting the `VERSIONS` parameter, the build/test action will be
 performed on all provided versions of MongoDB.**
@@ -82,6 +83,9 @@ see [usage documentation](3.0-upg/).
 For information about usage of Dockerfile for MongoDB 3.2,
 see [usage documentation](3.2/).
 
+For information about usage of Dockerfile for MongoDB 3.4,
+see [usage documentation](3.4/).
+
 Test
 ---------------------------------
 
@@ -98,7 +102,7 @@ Users can choose between testing MongoDB based on a RHEL or CentOS image.
     ```
     $ cd mongodb-container
     $ git submodule update --init
-    $ make test TARGET=rhel7 VERSIONS=3.2
+    $ make test TARGET=rhel7 VERSIONS=3.4
     ```
 
 *  **CentOS based image**
@@ -106,7 +110,7 @@ Users can choose between testing MongoDB based on a RHEL or CentOS image.
     ```
     $ cd mongodb-container
     $ git submodule update --init
-    $ make test TARGET=centos7 VERSIONS=3.2
+    $ make test TARGET=centos7 VERSIONS=3.4
     ```
 
 **Notice: By omitting the `VERSIONS` parameter, the build/test action will be

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -14,6 +14,7 @@ LABEL summary="$SUMMARY" \
       io.openshift.tags="database,mongodb,rh-mongodb34" \
       com.redhat.component="rh-mongodb34-docker" \
       name="centos/mongodb-34-centos7" \
+      usage="docker run -d -e MONGODB_ADMIN_PASSWORD=my_pass centos/mongodb-34-centos7" \
       version="1" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 

--- a/latest/Dockerfile.rhel7
+++ b/latest/Dockerfile.rhel7
@@ -14,7 +14,9 @@ LABEL summary="$SUMMARY" \
       io.openshift.tags="database,mongodb,rh-mongodb34" \
       com.redhat.component="rh-mongodb34-docker" \
       name="rhscl/mongodb-34-rhel7" \
-      version="1"
+      usage="docker run -d -e MONGODB_ADMIN_PASSWORD=my_pass rhscl/mongodb-34-rhel7" \
+      version="1" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 ENV MONGODB_VERSION=3.4 \
     # Set paths to avoid hard-coding them in scripts.

--- a/latest/root/usr/bin/usage
+++ b/latest/root/usr/bin/usage
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cat /usr/share/container-scripts/mongodb/README.md
+

--- a/latest/root/usr/share/container-scripts/mongodb/README.md
+++ b/latest/root/usr/share/container-scripts/mongodb/README.md
@@ -1,7 +1,3 @@
-% MONGODB-34(1) Container Image Pages
-% SoftwareCollections.org
-% July 18, 2017
-
 MongoDB 3.4 NoSQL Database Server Docker image
 ====================
 
@@ -48,34 +44,38 @@ Environment variables and volumes
 The image recognizes the following environment variables that you can set
 during initialization by passing `-e VAR=VALUE` to the Docker run command.
 
-|    Variable name          |    Description                              |
-| :------------------------ | -----------------------------------------   |
-|  `MONGODB_ADMIN_PASSWORD` | Password for the admin user                 |
+**`MONGODB_ADMIN_PASSWORD`**  
+       Password for the admin user
+
 
 Optionally you can provide settings for user with 'readWrite' role.
 (Note you MUST specify all three of these settings)
 
-|    Variable name          |    Description                              |
-| :------------------------ | -----------------------------------------   |
-|  `MONGODB_USER`           | User name for MONGODB account to be created |
-|  `MONGODB_PASSWORD`       | Password for the user account               |
-|  `MONGODB_DATABASE`       | Database name                               |
+**`MONGODB_USER`**  
+       User name for MONGODB account to be created
+
+**`MONGODB_PASSWORD`**  
+       Password for the user account
+
+**`MONGODB_DATABASE`**  
+       Database name
+
 
 
 The following environment variables influence the MongoDB configuration file.
 They are all optional.
 
-|    Variable name      |    Description                                                            |    Default
-| :-------------------- | ------------------------------------------------------------------------- | ----------------
-|  `MONGODB_QUIET`      | Runs MongoDB in a quiet mode that attempts to limit the amount of output. |  true
+**`MONGODB_QUIET (default: true)`**  
+       Runs MongoDB in a quiet mode that attempts to limit the amount of output.
+
 
 
 You can also set the following mount points by passing the `-v
 /host:/container` flag to Docker.
 
-|  Volume mount point         | Description            |
-| :-------------------------- | ---------------------- |
-|  `/var/lib/mongodb/data`   | MongoDB data directory |
+**`/var/lib/mongodb/data`**  
+       MongoDB data directory
+
 
 **Notice: When mounting a directory from the host into the container, ensure
 that the mounted directory has the appropriate permissions and that the owner


### PR DESCRIPTION
Few edits in top-level README
Using usage label and command
Remove tables in README, because go-md2man cannot convert them properly
Remove man-page header from README