### PR TITLE
Fix fedora building and testing

### DIFF
--- a/2.6/root/usr/share/container-scripts/mongodb/init-replset.sh
+++ b/2.6/root/usr/share/container-scripts/mongodb/init-replset.sh
@@ -44,7 +44,7 @@ function add_member() {
   local host="$1"
   info "Adding ${host} to replica set ..."
 
-  if ! mongo "$(replset_addr admin)" -u admin -p "${MONGODB_ADMIN_PASSWORD}" --eval "while (!rs.add('${host}').ok) { sleep(100); }" --quiet; then
+  if ! mongo "$(replset_addr admin)" -u admin -p"${MONGODB_ADMIN_PASSWORD}" --eval "while (!rs.add('${host}').ok) { sleep(100); }" --quiet; then
     info "ERROR: couldn't add host to replica set!"
     return 1
   fi

--- a/2.6/root/usr/share/container-scripts/mongodb/init/10-init-users.sh
+++ b/2.6/root/usr/share/container-scripts/mongodb/init/10-init-users.sh
@@ -94,6 +94,6 @@ else
   if [ "${MEMBER_ID}" -eq 0 ]; then
     info "Creating MongoDB users ..."
     mongo_create_admin
-    [[ -v CREATE_USER ]] && mongo_create_user "-u admin -p ${MONGODB_ADMIN_PASSWORD}"
+    [[ -v CREATE_USER ]] && mongo_create_user "-u admin -p${MONGODB_ADMIN_PASSWORD}"
   fi
 fi

--- a/2.6/root/usr/share/container-scripts/mongodb/test-functions.sh
+++ b/2.6/root/usr/share/container-scripts/mongodb/test-functions.sh
@@ -34,7 +34,7 @@ function insert_and_wait_for_replication() {
     printjson(rs.status());
     quit(1);"
 
-  mongo "${host}" -u admin -p "${MONGODB_ADMIN_PASSWORD}" --eval "${script}"
+  mongo "${host}" -u admin -p"${MONGODB_ADMIN_PASSWORD}" --eval "${script}"
 }
 
 # wait_replicaset_members waits till replset has specified number of members
@@ -57,5 +57,5 @@ function wait_replicaset_members() {
   printjson(rs.status());
   quit(1);"
 
-  mongo "${host}" -u admin -p "${MONGODB_ADMIN_PASSWORD}" --eval "${script}"
+  mongo "${host}" -u admin -p"${MONGODB_ADMIN_PASSWORD}" --eval "${script}"
 }

--- a/3.0-upg/root/usr/share/container-scripts/mongodb/init-replset.sh
+++ b/3.0-upg/root/usr/share/container-scripts/mongodb/init-replset.sh
@@ -44,7 +44,7 @@ function add_member() {
   local host="$1"
   info "Adding ${host} to replica set ..."
 
-  if ! mongo "$(replset_addr admin)" -u admin -p "${MONGODB_ADMIN_PASSWORD}" --eval "while (!rs.add('${host}').ok) { sleep(100); }" --quiet; then
+  if ! mongo "$(replset_addr admin)" -u admin -p"${MONGODB_ADMIN_PASSWORD}" --eval "while (!rs.add('${host}').ok) { sleep(100); }" --quiet; then
     info "ERROR: couldn't add host to replica set!"
     return 1
   fi

--- a/3.0-upg/root/usr/share/container-scripts/mongodb/init/10-init-users.sh
+++ b/3.0-upg/root/usr/share/container-scripts/mongodb/init/10-init-users.sh
@@ -94,6 +94,6 @@ else
   if [ "${MEMBER_ID}" -eq 0 ]; then
     info "Creating MongoDB users ..."
     mongo_create_admin
-    [[ -v CREATE_USER ]] && mongo_create_user "-u admin -p ${MONGODB_ADMIN_PASSWORD}"
+    [[ -v CREATE_USER ]] && mongo_create_user "-u admin -p${MONGODB_ADMIN_PASSWORD}"
   fi
 fi

--- a/3.0-upg/root/usr/share/container-scripts/mongodb/test-functions.sh
+++ b/3.0-upg/root/usr/share/container-scripts/mongodb/test-functions.sh
@@ -34,7 +34,7 @@ function insert_and_wait_for_replication() {
     printjson(rs.status());
     quit(1);"
 
-  mongo "${host}" -u admin -p "${MONGODB_ADMIN_PASSWORD}" --eval "${script}"
+  mongo "${host}" -u admin -p"${MONGODB_ADMIN_PASSWORD}" --eval "${script}"
 }
 
 # wait_replicaset_members waits till replset has specified number of members
@@ -57,5 +57,5 @@ function wait_replicaset_members() {
   printjson(rs.status());
   quit(1);"
 
-  mongo "${host}" -u admin -p "${MONGODB_ADMIN_PASSWORD}" --eval "${script}"
+  mongo "${host}" -u admin -p"${MONGODB_ADMIN_PASSWORD}" --eval "${script}"
 }

--- a/3.2/Dockerfile.fedora
+++ b/3.2/Dockerfile.fedora
@@ -14,7 +14,7 @@ container image contains programs to run mongod server."
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \
       io.k8s.description="$DESCRIPTION" \
-      com.redhat.component = "$NAME" \
+      com.redhat.component="$NAME" \
       name="$FGC/$NAME" \
       version="$VERSION" \
       release="$RELEASE.$DISTTAG" \
@@ -37,7 +37,7 @@ EXPOSE 27017
 ENTRYPOINT ["container-entrypoint"]
 CMD ["run-mongod"]
 
-RUN INSTALL_PKGS="bind-utils gettext iproute rsync tar findutils python shadow-utils mongodb mongodb-server mongo-tools groff-base" && \
+RUN INSTALL_PKGS="bind-utils gettext iproute rsync tar hostname findutils shadow-utils mongodb mongodb-server mongo-tools groff-base" && \
     dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     dnf clean all

--- a/3.2/root/usr/share/container-scripts/mongodb/init-replset.sh
+++ b/3.2/root/usr/share/container-scripts/mongodb/init-replset.sh
@@ -44,7 +44,7 @@ function add_member() {
   local host="$1"
   info "Adding ${host} to replica set ..."
 
-  if ! mongo "$(replset_addr admin)" -u admin -p "${MONGODB_ADMIN_PASSWORD}" --eval "while (!rs.add('${host}').ok) { sleep(100); }" --quiet; then
+  if ! mongo "$(replset_addr admin)" -u admin -p"${MONGODB_ADMIN_PASSWORD}" --eval "while (!rs.add('${host}').ok) { sleep(100); }" --quiet; then
     info "ERROR: couldn't add host to replica set!"
     return 1
   fi

--- a/3.2/root/usr/share/container-scripts/mongodb/init/10-init-users.sh
+++ b/3.2/root/usr/share/container-scripts/mongodb/init/10-init-users.sh
@@ -94,6 +94,6 @@ else
   if [ "${MEMBER_ID}" -eq 0 ]; then
     info "Creating MongoDB users ..."
     mongo_create_admin
-    [[ -v CREATE_USER ]] && mongo_create_user "-u admin -p ${MONGODB_ADMIN_PASSWORD}"
+    [[ -v CREATE_USER ]] && mongo_create_user "-u admin -p${MONGODB_ADMIN_PASSWORD}"
   fi
 fi

--- a/3.2/root/usr/share/container-scripts/mongodb/test-functions.sh
+++ b/3.2/root/usr/share/container-scripts/mongodb/test-functions.sh
@@ -34,7 +34,7 @@ function insert_and_wait_for_replication() {
     printjson(rs.status());
     quit(1);"
 
-  mongo "${host}" -u admin -p "${MONGODB_ADMIN_PASSWORD}" --eval "${script}"
+  mongo "${host}" -u admin -p"${MONGODB_ADMIN_PASSWORD}" --eval "${script}"
 }
 
 # wait_replicaset_members waits till replset has specified number of members
@@ -57,5 +57,5 @@ function wait_replicaset_members() {
   printjson(rs.status());
   quit(1);"
 
-  mongo "${host}" -u admin -p "${MONGODB_ADMIN_PASSWORD}" --eval "${script}"
+  mongo "${host}" -u admin -p"${MONGODB_ADMIN_PASSWORD}" --eval "${script}"
 }

--- a/3.4/Dockerfile.fedora
+++ b/3.4/Dockerfile.fedora
@@ -14,7 +14,7 @@ container image contains programs to run mongod server."
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \
       io.k8s.description="$DESCRIPTION" \
-      com.redhat.component = "$NAME" \
+      com.redhat.component="$NAME" \
       name="$FGC/$NAME" \
       version="$VERSION" \
       release="$RELEASE.$DISTTAG" \
@@ -37,7 +37,7 @@ EXPOSE 27017
 ENTRYPOINT ["container-entrypoint"]
 CMD ["run-mongod"]
 
-RUN INSTALL_PKGS="bind-utils gettext iproute rsync tar findutils python shadow-utils mongodb mongodb-server mongo-tools groff-base" && \
+RUN INSTALL_PKGS="bind-utils gettext iproute rsync tar hostname findutils shadow-utils mongodb mongodb-server mongo-tools groff-base" && \
     dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     dnf clean all

--- a/3.4/root/usr/share/container-scripts/mongodb/init-replset.sh
+++ b/3.4/root/usr/share/container-scripts/mongodb/init-replset.sh
@@ -44,7 +44,7 @@ function add_member() {
   local host="$1"
   info "Adding ${host} to replica set ..."
 
-  if ! mongo "$(replset_addr admin)" -u admin -p "${MONGODB_ADMIN_PASSWORD}" --eval "while (!rs.add('${host}').ok) { sleep(100); }" --quiet; then
+  if ! mongo "$(replset_addr admin)" -u admin -p"${MONGODB_ADMIN_PASSWORD}" --eval "while (!rs.add('${host}').ok) { sleep(100); }" --quiet; then
     info "ERROR: couldn't add host to replica set!"
     return 1
   fi

--- a/3.4/root/usr/share/container-scripts/mongodb/init/10-init-users.sh
+++ b/3.4/root/usr/share/container-scripts/mongodb/init/10-init-users.sh
@@ -94,6 +94,6 @@ else
   if [ "${MEMBER_ID}" -eq 0 ]; then
     info "Creating MongoDB users ..."
     mongo_create_admin
-    [[ -v CREATE_USER ]] && mongo_create_user "-u admin -p ${MONGODB_ADMIN_PASSWORD}"
+    [[ -v CREATE_USER ]] && mongo_create_user "-u admin -p${MONGODB_ADMIN_PASSWORD}"
   fi
 fi

--- a/3.4/root/usr/share/container-scripts/mongodb/test-functions.sh
+++ b/3.4/root/usr/share/container-scripts/mongodb/test-functions.sh
@@ -34,7 +34,7 @@ function insert_and_wait_for_replication() {
     printjson(rs.status());
     quit(1);"
 
-  mongo "${host}" -u admin -p "${MONGODB_ADMIN_PASSWORD}" --eval "${script}"
+  mongo "${host}" -u admin -p"${MONGODB_ADMIN_PASSWORD}" --eval "${script}"
 }
 
 # wait_replicaset_members waits till replset has specified number of members
@@ -57,5 +57,5 @@ function wait_replicaset_members() {
   printjson(rs.status());
   quit(1);"
 
-  mongo "${host}" -u admin -p "${MONGODB_ADMIN_PASSWORD}" --eval "${script}"
+  mongo "${host}" -u admin -p"${MONGODB_ADMIN_PASSWORD}" --eval "${script}"
 }

--- a/examples/extending-image/mongodb-init/11-init-backup-user.sh
+++ b/examples/extending-image/mongodb-init/11-init-backup-user.sh
@@ -1,7 +1,7 @@
 # Create backup user
 
 js_command="db.createUser({user: '${MONGODB_BACKUP_USER}', pwd: '${MONGODB_BACKUP_PASSWORD}', roles: [ 'readAnyDatabase' ]});"
-if ! mongo admin -u admin -p $MONGODB_ADMIN_PASSWORD --eval "${js_command}"; then
+if ! mongo admin -u admin -p$MONGODB_ADMIN_PASSWORD --eval "${js_command}"; then
   echo >&2 "=> Failed to create MongoDB user: ${MONGODB_BACKUP_USER}"
   exit 1
 fi

--- a/examples/extending-image/mongodb-init/50-initial-store.sh
+++ b/examples/extending-image/mongodb-init/50-initial-store.sh
@@ -1,7 +1,7 @@
 # Store some initial information into database
 
 # Connect database as optional user
-mongo $MONGODB_DATABASE -u $MONGODB_USER -p $MONGODB_PASSWORD --eval "db.constants.insert({author: \"sclorg@redhat.com\"})"
+mongo $MONGODB_DATABASE -u $MONGODB_USER -p$MONGODB_PASSWORD --eval "db.constants.insert({author: \"sclorg@redhat.com\"})"
 
 # Connect database as admin user
-mongo admin -u admin -p $MONGODB_ADMIN_PASSWORD --eval "db.getSiblingDB(\"$MONGODB_DATABASE\").constants.insert({subject: \"s2i build example\"})"
+mongo admin -u admin -p$MONGODB_ADMIN_PASSWORD --eval "db.getSiblingDB(\"$MONGODB_DATABASE\").constants.insert({subject: \"s2i build example\"})"

--- a/examples/petset/README.md
+++ b/examples/petset/README.md
@@ -57,7 +57,7 @@ sh-4.2$
 And later from one of the pods you can also login into MongoDB:
 
 ```console
-sh-4.2$ mongo $MONGODB_DATABASE -u $MONGODB_USER -p $MONGODB_PASSWORD
+sh-4.2$ mongo $MONGODB_DATABASE -u $MONGODB_USER -p$MONGODB_PASSWORD
 MongoDB shell version: 3.2.6
 connecting to: sampledb
 rs0:PRIMARY>

--- a/examples/replset-docker/README.md
+++ b/examples/replset-docker/README.md
@@ -57,7 +57,7 @@ To be able to select a container, which initialize the ReplicaSet, `HOSTNAME` of
 And later from one of the containers you can easilly connect to MongoDB:
 
 ```console
-sh-4.2$ mongo $MONGODB_DATABASE -u $MONGODB_USER -p $MONGODB_PASSWORD --host $MONGODB_REPLICA_NAME/localhost
+sh-4.2$ mongo $MONGODB_DATABASE -u $MONGODB_USER -p$MONGODB_PASSWORD --host $MONGODB_REPLICA_NAME/localhost
 MongoDB shell version: 3.2.6
 connecting to: sampledb
 rs0:PRIMARY>

--- a/latest/Dockerfile.fedora
+++ b/latest/Dockerfile.fedora
@@ -14,7 +14,7 @@ container image contains programs to run mongod server."
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \
       io.k8s.description="$DESCRIPTION" \
-      com.redhat.component = "$NAME" \
+      com.redhat.component="$NAME" \
       name="$FGC/$NAME" \
       version="$VERSION" \
       release="$RELEASE.$DISTTAG" \
@@ -37,7 +37,7 @@ EXPOSE 27017
 ENTRYPOINT ["container-entrypoint"]
 CMD ["run-mongod"]
 
-RUN INSTALL_PKGS="bind-utils gettext iproute rsync tar findutils python shadow-utils mongodb mongodb-server mongo-tools groff-base" && \
+RUN INSTALL_PKGS="bind-utils gettext iproute rsync tar hostname findutils shadow-utils mongodb mongodb-server mongo-tools groff-base" && \
     dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     dnf clean all

--- a/latest/root/usr/share/container-scripts/mongodb/init-replset.sh
+++ b/latest/root/usr/share/container-scripts/mongodb/init-replset.sh
@@ -44,7 +44,7 @@ function add_member() {
   local host="$1"
   info "Adding ${host} to replica set ..."
 
-  if ! mongo "$(replset_addr admin)" -u admin -p "${MONGODB_ADMIN_PASSWORD}" --eval "while (!rs.add('${host}').ok) { sleep(100); }" --quiet; then
+  if ! mongo "$(replset_addr admin)" -u admin -p"${MONGODB_ADMIN_PASSWORD}" --eval "while (!rs.add('${host}').ok) { sleep(100); }" --quiet; then
     info "ERROR: couldn't add host to replica set!"
     return 1
   fi

--- a/latest/root/usr/share/container-scripts/mongodb/init/10-init-users.sh
+++ b/latest/root/usr/share/container-scripts/mongodb/init/10-init-users.sh
@@ -94,6 +94,6 @@ else
   if [ "${MEMBER_ID}" -eq 0 ]; then
     info "Creating MongoDB users ..."
     mongo_create_admin
-    [[ -v CREATE_USER ]] && mongo_create_user "-u admin -p ${MONGODB_ADMIN_PASSWORD}"
+    [[ -v CREATE_USER ]] && mongo_create_user "-u admin -p${MONGODB_ADMIN_PASSWORD}"
   fi
 fi

--- a/latest/root/usr/share/container-scripts/mongodb/test-functions.sh
+++ b/latest/root/usr/share/container-scripts/mongodb/test-functions.sh
@@ -34,7 +34,7 @@ function insert_and_wait_for_replication() {
     printjson(rs.status());
     quit(1);"
 
-  mongo "${host}" -u admin -p "${MONGODB_ADMIN_PASSWORD}" --eval "${script}"
+  mongo "${host}" -u admin -p"${MONGODB_ADMIN_PASSWORD}" --eval "${script}"
 }
 
 # wait_replicaset_members waits till replset has specified number of members
@@ -57,5 +57,5 @@ function wait_replicaset_members() {
   printjson(rs.status());
   quit(1);"
 
-  mongo "${host}" -u admin -p "${MONGODB_ADMIN_PASSWORD}" --eval "${script}"
+  mongo "${host}" -u admin -p"${MONGODB_ADMIN_PASSWORD}" --eval "${script}"
 }


### PR DESCRIPTION
Fix fedora building and testing

- when passing passwords to mongo shell don't put space after "-p"
parameter (it wasn't working for fedora env)

- disable building fedora image for mongodb 3.6 - base image is
not yet available