### PR TITLE
Move to test-lib s2i functions to provide podman compatibility

### DIFF
--- a/test/ctest_ssl
+++ b/test/ctest_ssl
@@ -27,7 +27,7 @@ function _ssl_test_image() {
 function ctest_ssl() {
     CONTAINER_ARGS=
     echo "  Testing SSL s2i"
-    s2i build file://${TEST_DIR}/examples/ssl/ ${IMAGE_NAME} ${IMAGE_NAME}-testapp
+    ct_s2i_build_as_df file://${TEST_DIR}/examples/ssl/ ${IMAGE_NAME} ${IMAGE_NAME}-testapp
     IMAGE_NAME=${IMAGE_NAME}-testapp _ssl_test_image "ssl_config_s2i"
 
     echo "  Testing SSL mount"

--- a/test/run
+++ b/test/run
@@ -141,7 +141,7 @@ noprealloc = true"
 
 function ctest_s2i() {
     echo "  Testing s2i usage"
-    s2i usage ${S2I_ARGS} ${IMAGE_NAME} &>/dev/null
+    ct_s2i_usage ${IMAGE_NAME} ${S2I_ARGS} &>/dev/null
 
     # Set configuration file (differs for mmapv1 storage engine)
     mv ${TEST_DIR}/examples/extending-image/mongodb-cfg/mongod.conf ${TEST_DIR}/examples/extending-image/mongodb-cfg/mongod.conf.backup
@@ -153,7 +153,7 @@ function ctest_s2i() {
     fi
 
     echo "  Testing s2i build"
-    s2i build file://${TEST_DIR}/examples/extending-image/ ${IMAGE_NAME} ${IMAGE_NAME}-testapp
+    ct_s2i_build_as_df file://${TEST_DIR}/examples/extending-image/ ${IMAGE_NAME} ${IMAGE_NAME}-testapp
 
     local container_name=s2i_config_build
     IMAGE_NAME=${IMAGE_NAME}-testapp _s2i_test_image "s2i_config_build" ""


### PR DESCRIPTION
Works ok except for test cases using 'docker network' as podman does not support the command right now:
https://github.com/containers/libpod/blob/master/transfer.md#missing-commands-in-podman