### PR TITLE
Add requirements on SSL certificate into README

### DIFF
--- a/3.2/root/usr/share/container-scripts/mongodb/README.md
+++ b/3.2/root/usr/share/container-scripts/mongodb/README.md
@@ -156,6 +156,8 @@ when running `run-mongod` or `run-mongod-replication` commands contained
 
 SSL/TLS certificates used to configure MongoDB server SSL/TLS support
 
+**Notice: To allow connections from internal scripts it is required to have `localhost` specified in SAN filed of SSL certificate.**
+
 ~~~~~
 - `mongodb.pem` - file containing a public key certificate and its
 associated private key. See [upstream

--- a/3.4/root/usr/share/container-scripts/mongodb/README.md
+++ b/3.4/root/usr/share/container-scripts/mongodb/README.md
@@ -156,6 +156,8 @@ when running `run-mongod` or `run-mongod-replication` commands contained
 
 SSL/TLS certificates used to configure MongoDB server SSL/TLS support
 
+**Notice: To allow connections from internal scripts it is required to have `localhost` specified in SAN filed of SSL certificate.**
+
 ~~~~~
 - `mongodb.pem` - file containing a public key certificate and its
 associated private key. See [upstream

--- a/latest/root/usr/share/container-scripts/mongodb/README.md
+++ b/latest/root/usr/share/container-scripts/mongodb/README.md
@@ -156,6 +156,8 @@ when running `run-mongod` or `run-mongod-replication` commands contained
 
 SSL/TLS certificates used to configure MongoDB server SSL/TLS support
 
+**Notice: To allow connections from internal scripts it is required to have `localhost` specified in SAN filed of SSL certificate.**
+
 ~~~~~
 - `mongodb.pem` - file containing a public key certificate and its
 associated private key. See [upstream


### PR DESCRIPTION
Discussed in #203 

> I understand that eval was removed and replaced with "-host localhost" option. MongoDB docs specify that with SSL enabled it becomes mandatory to specify hostname( localhost will not work). Is my understanding correct on this or am i missing something

Thanks, you are right. I've missed it first.

I'm thinking about it and I see no other option than having to specify `localhost` in SAN of SSL certificate.
Basically in the container 'localhost' and 'hostname` can be resolved. And the hostname often changes with every container start. Also IMHO using real server/certificate domain for "internal" connection isn't good idea (although it could be possible if set up properly). This would be also complicated in openshift because connection ability from outside of the cluster needs to be configured explicitly.


--------------------------------------------------------------------------------
So until better solution is found, it would be better to have this notice in README.

@pkubatrh Please review and merge. I would be great if it would be possible to have it merged before next rebuild.