### PR TITLE
Change how to compute WT cache 

### DIFF
--- a/3.2/root/usr/share/container-scripts/mongodb/README.md
+++ b/3.2/root/usr/share/container-scripts/mongodb/README.md
@@ -62,12 +62,14 @@ Optionally you can provide settings for user with 'readWrite' role.
 
 
 
-The following environment variables influence the MongoDB configuration file.
+The following environment variables influence the MongoDB default configuration file.
 They are all optional.
 
-**`MONGODB_QUIET (default: true)`**  
+**`MONGODB_QUIET (default: true)`**
        Runs MongoDB in a quiet mode that attempts to limit the amount of output.
 
+**`WIREDTIGER_CACHE_SIZE`**
+       Size of WiredTiger cache (value for `cache_size` configString option).
 
 
 You can also set the following mount points by passing the `-v

--- a/3.2/root/usr/share/container-scripts/mongodb/pre-init/20-setup-wiredtiger-cache.sh
+++ b/3.2/root/usr/share/container-scripts/mongodb/pre-init/20-setup-wiredtiger-cache.sh
@@ -15,10 +15,10 @@ function setup_wiredtiger_cache() {
     return 0;
   fi
 
-  cache_size=$($PYTHON -c "min=1; limit=int(($MEMORY_LIMIT_IN_BYTES / pow(2,30) - 1) * 0.6); print( min if limit < min else limit)")
-  echo "storage.wiredTiger.engineConfig.cacheSizeGB: ${cache_size}" >> ${config_file}
+  cache_size=$($PYTHON -c "min=256; limit=int(($MEMORY_LIMIT_IN_BYTES / pow(2,20) - 1024) * 0.5); print( min if limit < min else limit)")
+  echo "storage.wiredTiger.engineConfig.configString: cache_size=${cache_size}M" >> ${config_file}
 
-  info "wiredTiger cacheSizeGB set to ${cache_size}"
+  info "wiredTiger cache_size set to ${cache_size}M"
 }
 
 setup_wiredtiger_cache ${CONTAINER_SCRIPTS_PATH}/mongod.conf.template

--- a/3.2/root/usr/share/container-scripts/mongodb/pre-init/20-setup-wiredtiger-cache.sh
+++ b/3.2/root/usr/share/container-scripts/mongodb/pre-init/20-setup-wiredtiger-cache.sh
@@ -3,22 +3,27 @@ PYTHON=python3
 command -v $PYTHON &>/dev/null || PYTHON=python
 
 # setup_wiredtiger_cache checks amount of available RAM (it has to use cgroups in container)
-# and if there are any memory restrictions set storage.wiredTiger.engineConfig.cacheSizeGB
+# and if there are any memory restrictions set storage.wiredTiger.engineConfig.configString: cache_size=
 # in MONGODB_CONFIG_PATH to upstream default size
 # it is intended to update mongod.conf.template, with custom config file it might create conflict
 function setup_wiredtiger_cache() {
   local config_file
   config_file=${1:-$MONGODB_CONFIG_PATH}
 
-  declare $($PYTHON /usr/libexec/cgroup-limits)
-  if [[ ! -v MEMORY_LIMIT_IN_BYTES || "${NO_MEMORY_LIMIT:-}" == "true" ]]; then
-    return 0;
+  if [[ -v WIREDTIGER_CACHE_SIZE ]]; then
+    cache_size=${WIREDTIGER_CACHE_SIZE}
+  else
+    declare $($PYTHON /usr/libexec/cgroup-limits)
+    if [[ ! -v MEMORY_LIMIT_IN_BYTES || "${NO_MEMORY_LIMIT:-}" == "true" ]]; then
+      return 0;
+    fi
+
+    cache_size=$($PYTHON -c "min=256; limit=int(($MEMORY_LIMIT_IN_BYTES / pow(2,20) - 1024) * 0.5); print( min if limit < min else limit)")M
   fi
 
-  cache_size=$($PYTHON -c "min=256; limit=int(($MEMORY_LIMIT_IN_BYTES / pow(2,20) - 1024) * 0.5); print( min if limit < min else limit)")
-  echo "storage.wiredTiger.engineConfig.configString: cache_size=${cache_size}M" >> ${config_file}
+  echo "storage.wiredTiger.engineConfig.configString: cache_size=${cache_size}" >> ${config_file}
 
-  info "wiredTiger cache_size set to ${cache_size}M"
+  info "wiredTiger cache_size set to ${cache_size}"
 }
 
 setup_wiredtiger_cache ${CONTAINER_SCRIPTS_PATH}/mongod.conf.template

--- a/3.4/root/usr/share/container-scripts/mongodb/README.md
+++ b/3.4/root/usr/share/container-scripts/mongodb/README.md
@@ -62,12 +62,14 @@ Optionally you can provide settings for user with 'readWrite' role.
 
 
 
-The following environment variables influence the MongoDB configuration file.
+The following environment variables influence the MongoDB default configuration file.
 They are all optional.
 
-**`MONGODB_QUIET (default: true)`**  
+**`MONGODB_QUIET (default: true)`**
        Runs MongoDB in a quiet mode that attempts to limit the amount of output.
 
+**`WIREDTIGER_CACHE_SIZE`**
+       Size of WiredTiger cache (value for `cache_size` configString option).
 
 
 You can also set the following mount points by passing the `-v

--- a/3.4/root/usr/share/container-scripts/mongodb/pre-init/20-setup-wiredtiger-cache.sh
+++ b/3.4/root/usr/share/container-scripts/mongodb/pre-init/20-setup-wiredtiger-cache.sh
@@ -15,10 +15,10 @@ function setup_wiredtiger_cache() {
     return 0;
   fi
 
-  cache_size=$($PYTHON -c "min=1; limit=int(($MEMORY_LIMIT_IN_BYTES / pow(2,30) - 1) * 0.6); print( min if limit < min else limit)")
-  echo "storage.wiredTiger.engineConfig.cacheSizeGB: ${cache_size}" >> ${config_file}
+  cache_size=$($PYTHON -c "min=256; limit=int(($MEMORY_LIMIT_IN_BYTES / pow(2,20) - 1024) * 0.5); print( min if limit < min else limit)")
+  echo "storage.wiredTiger.engineConfig.configString: cache_size=${cache_size}M" >> ${config_file}
 
-  info "wiredTiger cacheSizeGB set to ${cache_size}"
+  info "wiredTiger cache_size set to ${cache_size}M"
 }
 
 setup_wiredtiger_cache ${CONTAINER_SCRIPTS_PATH}/mongod.conf.template

--- a/3.4/root/usr/share/container-scripts/mongodb/pre-init/20-setup-wiredtiger-cache.sh
+++ b/3.4/root/usr/share/container-scripts/mongodb/pre-init/20-setup-wiredtiger-cache.sh
@@ -3,22 +3,27 @@ PYTHON=python3
 command -v $PYTHON &>/dev/null || PYTHON=python
 
 # setup_wiredtiger_cache checks amount of available RAM (it has to use cgroups in container)
-# and if there are any memory restrictions set storage.wiredTiger.engineConfig.cacheSizeGB
+# and if there are any memory restrictions set storage.wiredTiger.engineConfig.configString: cache_size=
 # in MONGODB_CONFIG_PATH to upstream default size
 # it is intended to update mongod.conf.template, with custom config file it might create conflict
 function setup_wiredtiger_cache() {
   local config_file
   config_file=${1:-$MONGODB_CONFIG_PATH}
 
-  declare $($PYTHON /usr/libexec/cgroup-limits)
-  if [[ ! -v MEMORY_LIMIT_IN_BYTES || "${NO_MEMORY_LIMIT:-}" == "true" ]]; then
-    return 0;
+  if [[ -v WIREDTIGER_CACHE_SIZE ]]; then
+    cache_size=${WIREDTIGER_CACHE_SIZE}
+  else
+    declare $($PYTHON /usr/libexec/cgroup-limits)
+    if [[ ! -v MEMORY_LIMIT_IN_BYTES || "${NO_MEMORY_LIMIT:-}" == "true" ]]; then
+      return 0;
+    fi
+
+    cache_size=$($PYTHON -c "min=256; limit=int(($MEMORY_LIMIT_IN_BYTES / pow(2,20) - 1024) * 0.5); print( min if limit < min else limit)")M
   fi
 
-  cache_size=$($PYTHON -c "min=256; limit=int(($MEMORY_LIMIT_IN_BYTES / pow(2,20) - 1024) * 0.5); print( min if limit < min else limit)")
-  echo "storage.wiredTiger.engineConfig.configString: cache_size=${cache_size}M" >> ${config_file}
+  echo "storage.wiredTiger.engineConfig.configString: cache_size=${cache_size}" >> ${config_file}
 
-  info "wiredTiger cache_size set to ${cache_size}M"
+  info "wiredTiger cache_size set to ${cache_size}"
 }
 
 setup_wiredtiger_cache ${CONTAINER_SCRIPTS_PATH}/mongod.conf.template

--- a/latest/root/usr/share/container-scripts/mongodb/README.md
+++ b/latest/root/usr/share/container-scripts/mongodb/README.md
@@ -62,12 +62,14 @@ Optionally you can provide settings for user with 'readWrite' role.
 
 
 
-The following environment variables influence the MongoDB configuration file.
+The following environment variables influence the MongoDB default configuration file.
 They are all optional.
 
-**`MONGODB_QUIET (default: true)`**  
+**`MONGODB_QUIET (default: true)`**
        Runs MongoDB in a quiet mode that attempts to limit the amount of output.
 
+**`WIREDTIGER_CACHE_SIZE`**
+       Size of WiredTiger cache (value for `cache_size` configString option).
 
 
 You can also set the following mount points by passing the `-v

--- a/latest/root/usr/share/container-scripts/mongodb/pre-init/20-setup-wiredtiger-cache.sh
+++ b/latest/root/usr/share/container-scripts/mongodb/pre-init/20-setup-wiredtiger-cache.sh
@@ -15,10 +15,10 @@ function setup_wiredtiger_cache() {
     return 0;
   fi
 
-  cache_size=$($PYTHON -c "min=1; limit=int(($MEMORY_LIMIT_IN_BYTES / pow(2,30) - 1) * 0.6); print( min if limit < min else limit)")
-  echo "storage.wiredTiger.engineConfig.cacheSizeGB: ${cache_size}" >> ${config_file}
+  cache_size=$($PYTHON -c "min=256; limit=int(($MEMORY_LIMIT_IN_BYTES / pow(2,20) - 1024) * 0.5); print( min if limit < min else limit)")
+  echo "storage.wiredTiger.engineConfig.configString: cache_size=${cache_size}M" >> ${config_file}
 
-  info "wiredTiger cacheSizeGB set to ${cache_size}"
+  info "wiredTiger cache_size set to ${cache_size}M"
 }
 
 setup_wiredtiger_cache ${CONTAINER_SCRIPTS_PATH}/mongod.conf.template

--- a/latest/root/usr/share/container-scripts/mongodb/pre-init/20-setup-wiredtiger-cache.sh
+++ b/latest/root/usr/share/container-scripts/mongodb/pre-init/20-setup-wiredtiger-cache.sh
@@ -3,22 +3,27 @@ PYTHON=python3
 command -v $PYTHON &>/dev/null || PYTHON=python
 
 # setup_wiredtiger_cache checks amount of available RAM (it has to use cgroups in container)
-# and if there are any memory restrictions set storage.wiredTiger.engineConfig.cacheSizeGB
+# and if there are any memory restrictions set storage.wiredTiger.engineConfig.configString: cache_size=
 # in MONGODB_CONFIG_PATH to upstream default size
 # it is intended to update mongod.conf.template, with custom config file it might create conflict
 function setup_wiredtiger_cache() {
   local config_file
   config_file=${1:-$MONGODB_CONFIG_PATH}
 
-  declare $($PYTHON /usr/libexec/cgroup-limits)
-  if [[ ! -v MEMORY_LIMIT_IN_BYTES || "${NO_MEMORY_LIMIT:-}" == "true" ]]; then
-    return 0;
+  if [[ -v WIREDTIGER_CACHE_SIZE ]]; then
+    cache_size=${WIREDTIGER_CACHE_SIZE}
+  else
+    declare $($PYTHON /usr/libexec/cgroup-limits)
+    if [[ ! -v MEMORY_LIMIT_IN_BYTES || "${NO_MEMORY_LIMIT:-}" == "true" ]]; then
+      return 0;
+    fi
+
+    cache_size=$($PYTHON -c "min=256; limit=int(($MEMORY_LIMIT_IN_BYTES / pow(2,20) - 1024) * 0.5); print( min if limit < min else limit)")M
   fi
 
-  cache_size=$($PYTHON -c "min=256; limit=int(($MEMORY_LIMIT_IN_BYTES / pow(2,20) - 1024) * 0.5); print( min if limit < min else limit)")
-  echo "storage.wiredTiger.engineConfig.configString: cache_size=${cache_size}M" >> ${config_file}
+  echo "storage.wiredTiger.engineConfig.configString: cache_size=${cache_size}" >> ${config_file}
 
-  info "wiredTiger cache_size set to ${cache_size}M"
+  info "wiredTiger cache_size set to ${cache_size}"
 }
 
 setup_wiredtiger_cache ${CONTAINER_SCRIPTS_PATH}/mongod.conf.template

--- a/test/ctest_WT_cache
+++ b/test/ctest_WT_cache
@@ -22,16 +22,16 @@ ctest_WT_cache() {
     DB=${database}
     ADMIN_PASS=${admin_password}
 
-    # minimum is 1G
+    # minimum is 256MB
     CONTAINER_ARGS="$common_arguments -m 200M"
     ct_create_container "${name}_200M"
     test_connection ${name}_200M
-    mongo_admin_cmd "if (db.serverStatus()['wiredTiger']['cache']['maximum bytes configured'] == Math.pow(2,30)){quit(0)}; quit(1)"
-    # if greater that 1G, use 60% of (RAM - 1G)
+    mongo_admin_cmd "if (db.serverStatus()['wiredTiger']['cache']['maximum bytes configured'] == 256*Math.pow(2,20)){quit(0)}; quit(1)"
+    # if greater that 256MB, use 50% of (RAM - 1G)
     CONTAINER_ARGS="$common_arguments -m 6G"
     ct_create_container "${name}_6G"
     test_connection ${name}_6G
-    mongo_admin_cmd "if (db.serverStatus()['wiredTiger']['cache']['maximum bytes configured'] == 3*Math.pow(2,30)){quit(0)}; quit(1)"
+    mongo_admin_cmd "if (db.serverStatus()['wiredTiger']['cache']['maximum bytes configured'] == 2.5*Math.pow(2,30)){quit(0)}; quit(1)"
 
     echo "  Success!"
     echo

--- a/test/ctest_WT_cache
+++ b/test/ctest_WT_cache
@@ -27,10 +27,17 @@ ctest_WT_cache() {
     ct_create_container "${name}_200M"
     test_connection ${name}_200M
     mongo_admin_cmd "if (db.serverStatus()['wiredTiger']['cache']['maximum bytes configured'] == 256*Math.pow(2,20)){quit(0)}; quit(1)"
+
     # if greater that 256MB, use 50% of (RAM - 1G)
     CONTAINER_ARGS="$common_arguments -m 6G"
     ct_create_container "${name}_6G"
     test_connection ${name}_6G
+    mongo_admin_cmd "if (db.serverStatus()['wiredTiger']['cache']['maximum bytes configured'] == 2.5*Math.pow(2,30)){quit(0)}; quit(1)"
+
+    # use WIREDTIGER_CACHE_SIZE to set WT cache
+    CONTAINER_ARGS="$common_arguments -e WIREDTIGER_CACHE_SIZE=2684354560B"
+    ct_create_container "${name}_var"
+    test_connection ${name}_var
     mongo_admin_cmd "if (db.serverStatus()['wiredTiger']['cache']['maximum bytes configured'] == 2.5*Math.pow(2,30)){quit(0)}; quit(1)"
 
     echo "  Success!"


### PR DESCRIPTION
Change how to compute WT cache - minimal amount is now 256MB (upstream changed this since 3.4)

https://docs.mongodb.com/v3.6/administration/production-notes/#id3

Because our templates by default set 512MB limit, it makes sense to change this for `3.2/` too. Otherwise our templates can work incorrectly.

@UncleAlbie Please review - if it's now implemented as described in mentioned docs. Thanks.