### PR TITLE
changes stemming from testing this on OpenShift v4.1

### DIFF
--- a/2.6/root/usr/bin/run-mongod-replication
+++ b/2.6/root/usr/bin/run-mongod-replication
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Run mongod in a StatefulSet-based replica set. See
-# https://github.com/sclorg/mongodb-container/blob/master/examples/petset/README.md
+# https://github.com/sclorg/mongodb-container/blob/master/examples/statefulset/README.md
 # for a description of how this is intended to work.
 #
 # Note:

--- a/3.0-upg/root/usr/bin/run-mongod-replication
+++ b/3.0-upg/root/usr/bin/run-mongod-replication
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Run mongod in a StatefulSet-based replica set. See
-# https://github.com/sclorg/mongodb-container/blob/master/examples/petset/README.md
+# https://github.com/sclorg/mongodb-container/blob/master/examples/statefulset/README.md
 # for a description of how this is intended to work.
 #
 # Note:

--- a/3.2/root/usr/bin/run-mongod-replication
+++ b/3.2/root/usr/bin/run-mongod-replication
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Run mongod in a StatefulSet-based replica set. See
-# https://github.com/sclorg/mongodb-container/blob/master/examples/petset/README.md
+# https://github.com/sclorg/mongodb-container/blob/master/examples/statefulset/README.md
 # for a description of how this is intended to work.
 #
 # Note:

--- a/3.4/root/usr/bin/run-mongod-replication
+++ b/3.4/root/usr/bin/run-mongod-replication
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Run mongod in a StatefulSet-based replica set. See
-# https://github.com/sclorg/mongodb-container/blob/master/examples/petset/README.md
+# https://github.com/sclorg/mongodb-container/blob/master/examples/statefulset/README.md
 # for a description of how this is intended to work.
 #
 # Note:

--- a/examples/replset-docker/README.md
+++ b/examples/replset-docker/README.md
@@ -45,7 +45,7 @@ docker run -d --cidfile $CIDFILE_DIR/replset2 --name=replset-2 --hostname=replse
 docker exec replset-2 bash -c "while ! [ -f /tmp/initialized ]; do sleep 1; done"
 ```
 
-`run-mongod-replication` command have to be run in container (same script as for [OpenShift StatefulSet replication example](https://github.com/sclorg/mongodb-container/tree/master/examples/petset).
+`run-mongod-replication` command have to be run in container (same script as for [OpenShift StatefulSet replication example](https://github.com/sclorg/mongodb-container/tree/master/examples/statefulset).
 
 Parameters for `docker run` command:
 - `--name` and `--hostname` have to be set to the same value for each container to proper inter-container addressing

--- a/examples/statefulset/README.md
+++ b/examples/statefulset/README.md
@@ -26,7 +26,7 @@ In the context of a project where you want to create a MongoDB cluster, run
 `oc new-app` passing the template file as an argument:
 
 ```bash
-oc new-app https://raw.githubusercontent.com/sclorg/mongodb-container/master/examples/petset/mongodb-statefulset-persistent.yaml
+oc new-app https://raw.githubusercontent.com/sclorg/mongodb-container/master/examples/statefulset/mongodb-statefulset-persistent.yaml
 ```
 
 The command above will create a MongoDB cluster with 3 replica set members.

--- a/examples/statefulset/README.md
+++ b/examples/statefulset/README.md
@@ -26,7 +26,7 @@ In the context of a project where you want to create a MongoDB cluster, run
 `oc new-app` passing the template file as an argument:
 
 ```bash
-oc new-app https://raw.githubusercontent.com/sclorg/mongodb-container/master/examples/petset/mongodb-petset-persistent.yaml
+oc new-app https://raw.githubusercontent.com/sclorg/mongodb-container/master/examples/petset/mongodb-statefulset-persistent.yaml
 ```
 
 The command above will create a MongoDB cluster with 3 replica set members.
@@ -121,7 +121,7 @@ sufficient available persistent volumes, or a dynamic storage provisioner is
 present, scaling up is done with the `oc scale` command:
 
 ```bash
-oc scale --replicas=5 petset/mongodb
+oc scale --replicas=5 statefulset.app/mongodb
 ```
 
 New pods (containers) are created and they connect to the replica set, updating
@@ -149,7 +149,7 @@ preconditions are met (storage availability, size of existing database and
 To scaling down, start with setting the new number of replicas, e.g.:
 
 ```bash
-oc scale --replicas=3 petset/mongodb
+oc scale --replicas=3 statefulset.app/mongodb
 ```
 
 Note that if the new number of replicas still constitutes a majority of the
@@ -161,7 +161,7 @@ On the other hand, scaling down to a lower number will temporarily render the
 replica set to have only SECONDARY members and be in read-only mode. That would
 be the case when scaling from 5 down to 1 member.
 
-The next step is to update the replica set configuration to
+The next step is to update the mongodb replica set configuration to
 [remove members](https://docs.mongodb.com/manual/tutorial/remove-replica-set-member/)
 that no longer exist. This may be improved in the future, a possible
 implementation being setting a PreStop pod hook that inspects the number of

--- a/examples/statefulset/mongodb-statefulset-persistent.yaml
+++ b/examples/statefulset/mongodb-statefulset-persistent.yaml
@@ -1,7 +1,7 @@
 kind: Template
 apiVersion: v1
 metadata:
-  name: mongodb-petset-replication
+  name: mongodb-statefulset-replication
   annotations:
     description: "MongoDB Replication Example (based on StatefulSet). You must have persistent volumes available in your cluster to use this template."
     iconClass: "icon-mongodb"
@@ -90,8 +90,6 @@ objects:
     apiVersion: v1
     metadata:
       name: "${MONGODB_SERVICE_NAME}-internal"
-      annotations:
-        service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
     spec:
       clusterIP: None
       # the list of ports that are exposed by this service
@@ -101,16 +99,23 @@ objects:
       # will route traffic to pods having labels matching this selector
       selector:
         name: "${MONGODB_SERVICE_NAME}"
+      # Without this setting, you may find that the hostname of the secondaries will not resolve
+      # from within the pod of the mongodb primary. This will prevent the replicaset from 
+      # initializing correctly.
+      publishNotReadyAddresses: true
 
   - kind: StatefulSet
-    apiVersion: apps/v1beta1
+    apiVersion: apps/v1
     metadata:
       name: "${MONGODB_SERVICE_NAME}"
     spec:
-      # pets get DNS/hostnames that follow the pattern: ${metadata.name}-NUM.${spec.serviceName}.default.svc.cluster.local
+      # stateful sets get DNS/hostnames that follow the pattern: ${metadata.name}-NUM.${spec.serviceName}.default.svc.cluster.local
       serviceName: "${MONGODB_SERVICE_NAME}-internal"
       replicas: 3
       # describes the pod that will be created if insufficient replicas are detected
+      selector:
+        matchLabels:
+          name: "${MONGODB_SERVICE_NAME}"
       template:
         metadata:
           # this label will be used for count running pods
@@ -153,13 +158,12 @@ objects:
       volumeClaimTemplates:
         - metadata:
             name: mongo-data
-            annotations:
-              # Uncomment this if using dynamic volume provisioning.
-              # https://docs.okd.io/latest/install_config/persistent_storage/dynamically_provisioning_pvs.html
-              # volume.alpha.kubernetes.io/storage-class: anything
           spec:
             # the volume can be mounted as read-write by a single node
             accessModes: [ ReadWriteOnce ]
             resources:
               requests:
                 storage: "${VOLUME_CAPACITY}"
+            # The gp2 storage class is used by the AWS EBS dynamic storage provisioner
+            # See https://docs.okd.io/latest/install_config/persistent_storage/dynamically_provisioning_pvs.html for alternatives
+            storageClassName: gp2

--- a/latest/root/usr/bin/run-mongod-replication
+++ b/latest/root/usr/bin/run-mongod-replication
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Run mongod in a StatefulSet-based replica set. See
-# https://github.com/sclorg/mongodb-container/blob/master/examples/petset/README.md
+# https://github.com/sclorg/mongodb-container/blob/master/examples/statefulset/README.md
 # for a description of how this is intended to work.
 #
 # Note:

--- a/test/run-openshift-local-cluster
+++ b/test/run-openshift-local-cluster
@@ -7,7 +7,7 @@
 #
 
 THISDIR=$(dirname ${BASH_SOURCE[0]})
-TEMPLATES="$THISDIR/examples/petset"
+TEMPLATES="$THISDIR/examples/statefulset"
 
 source "$THISDIR"/test-lib-openshift.sh
 source ${THISDIR}/test-lib-mongodb.sh
@@ -74,7 +74,7 @@ function test_mongodb_replication() {
   ct_os_new_project
   docker tag "${image_name}" "${image_name}:$VERSION"
 
-  ct_os_deploy_template_image "$TEMPLATES/mongodb-petset-persistent.yaml" \
+  ct_os_deploy_template_image "$TEMPLATES/mongodb-statefulset-persistent.yaml" \
                               MONGODB_IMAGE="${image_name}:$VERSION" \
                               MONGODB_SERVICE_NAME="${service_name}" \
                               MONGODB_USER=testu \


### PR DESCRIPTION
The included changes fall into two buckets:
1.  Technical changes such as getting rid of alpha / beta annotations and such stuff from the days when petsets were still new to k8s. There was one situation where it wasn't sufficient to remove the annotation, but I had to find the equivalent "GA" version that was introduced as an attribute
2.  Documentation / re-organization changes where I renamed the "examples/petset" directory to "examples/statefulset - which then meant I had to edit a lot of places where that file path was referenced.