### PR TITLE
Use refactored functions and enable testing in remote OCP4

### DIFF
--- a/test/run-openshift-local-cluster
+++ b/test/run-openshift-local-cluster
@@ -12,11 +12,11 @@ TEMPLATES="$THISDIR/examples/petset"
 source "$THISDIR"/test-lib-openshift.sh
 source ${THISDIR}/test-lib-mongodb.sh
 
-set -exo nounset
+set -eo nounset
 
-test -n "${IMAGE_NAME-}" || false 'make sure $IMAGE_NAME is defined'
-test -n "${VERSION-}" || false 'make sure $VERSION is defined'
-test -n "${OS-}" || false 'make sure $OS is defined'
+trap ct_os_cleanup EXIT SIGINT
+
+ct_os_check_compulsory_vars
 
 ct_os_enable_print_logs
 
@@ -103,19 +103,34 @@ test_mongodb_pure_image "${IMAGE_NAME}"
 test_mongodb_replication "${IMAGE_NAME}"
 
 # test with the just built image and an integrated template
+echo "Running test_mongodb_integration with ${IMAGE_NAME}"
 test_mongodb_integration "${IMAGE_NAME}" "${VERSION}" mongodb
 
 # test with a released image and an integrated template
+# ignore possible failure of this test for centos images
+fail_not_released=true
 if [ "${OS}" == "rhel7" ] ; then
-  PUBLIC_IMAGE_NAME=${PUBLIC_IMAGE_NAME:-${REGISTRY:-registry.access.redhat.com/}rhscl/${BASE_IMAGE_NAME}-${VERSION//./}-rhel7}
+  PUBLIC_IMAGE_NAME=${PUBLIC_IMAGE_NAME:-${REGISTRY:-registry.redhat.io/}rhscl/${BASE_IMAGE_NAME}-${VERSION//./}-rhel7}
 else
   PUBLIC_IMAGE_NAME=${PUBLIC_IMAGE_NAME:-${REGISTRY:-}centos/${BASE_IMAGE_NAME}-${VERSION//./}-centos7}
+  fail_not_released=false
 fi
 
-export CT_SKIP_UPLOAD_IMAGE=true
-test_mongodb_integration mongodb "${VERSION}" "${PUBLIC_IMAGE_NAME}"
+# Try pulling the image first to see if it is accessible
+if docker pull "${PUBLIC_IMAGE_NAME}"; then
+  echo "Running test_mongodb_integration with ${PUBLIC_IMAGE_NAME}"
+  test_mongodb_integration "${PUBLIC_IMAGE_NAME}" "${VERSION}" mongodb
+else
+  echo "Warning: ${PUBLIC_IMAGE_NAME} could not be downloaded via 'docker'"
+  ! $fail_not_released || false "ERROR: Failed to pull image"
+fi
+
+# Check the imagestream
+test_mongodb_imagestream
 
 OS_TESTSUITE_RESULT=0
 
 ct_os_cluster_down
+
+# vim: set tabstop=2:shiftwidth=2:expandtab:
 

--- a/test/run-openshift-local-cluster
+++ b/test/run-openshift-local-cluster
@@ -104,25 +104,19 @@ test_mongodb_replication "${IMAGE_NAME}"
 
 # test with the just built image and an integrated template
 echo "Running test_mongodb_integration with ${IMAGE_NAME}"
-test_mongodb_integration "${IMAGE_NAME}" "${VERSION}" mongodb
+test_mongodb_integration "${IMAGE_NAME}"
 
 # test with a released image and an integrated template
-# ignore possible failure of this test for centos images
-fail_not_released=true
-if [ "${OS}" == "rhel7" ] ; then
-  PUBLIC_IMAGE_NAME=${PUBLIC_IMAGE_NAME:-${REGISTRY:-registry.redhat.io/}rhscl/${BASE_IMAGE_NAME}-${VERSION//./}-rhel7}
-else
-  PUBLIC_IMAGE_NAME=${PUBLIC_IMAGE_NAME:-${REGISTRY:-}centos/${BASE_IMAGE_NAME}-${VERSION//./}-centos7}
-  fail_not_released=false
-fi
+PUBLIC_IMAGE_NAME=${PUBLIC_IMAGE_NAME:-$(ct_get_public_image_name "${OS}" "${BASE_IMAGE_NAME}" "${VERSION}")}
 
 # Try pulling the image first to see if it is accessible
 if docker pull "${PUBLIC_IMAGE_NAME}"; then
   echo "Running test_mongodb_integration with ${PUBLIC_IMAGE_NAME}"
-  test_mongodb_integration "${PUBLIC_IMAGE_NAME}" "${VERSION}" mongodb
+  test_mongodb_integration "${PUBLIC_IMAGE_NAME}"
 else
   echo "Warning: ${PUBLIC_IMAGE_NAME} could not be downloaded via 'docker'"
-  ! $fail_not_released || false "ERROR: Failed to pull image"
+  # ignore possible failure of this test for centos images
+  [ "${OS}" == "rhel7" ] && false "ERROR: Failed to pull image"
 fi
 
 # Check the imagestream

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -24,7 +24,13 @@ export CT_SKIP_NEW_PROJECT=true
 export CT_SKIP_UPLOAD_IMAGE=true
 export CT_NAMESPACE=openshift
 
-test_mongodb_integration mongodb ${VERSION} "${IMAGE_NAME}"
+# Check the template
+test_mongodb_integration "${IMAGE_NAME}" ${VERSION} mongodb
+
+# Check the imagestream
+test_mongodb_imagestream
 
 OS_TESTSUITE_RESULT=0
+
+# vim: set tabstop=2:shiftwidth=2:expandtab:
 

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -25,7 +25,7 @@ export CT_SKIP_UPLOAD_IMAGE=true
 export CT_NAMESPACE=openshift
 
 # Check the template
-test_mongodb_integration "${IMAGE_NAME}" ${VERSION} mongodb
+test_mongodb_integration "${IMAGE_NAME}"
 
 # Check the imagestream
 test_mongodb_imagestream

--- a/test/test-lib-mongodb.sh
+++ b/test/test-lib-mongodb.sh
@@ -13,9 +13,7 @@ source ${THISDIR}/test-lib-openshift.sh
 
 function test_mongodb_integration() {
   local image_name=$1
-  local VERSION=$2
-  local service_name=$3
-  local image_tagged="${service_name}:${VERSION}"
+  local service_name=mongodb
   ct_os_template_exists mongodb-ephemeral && t=mongodb-ephemeral || t=mongodb-persistent
   ct_os_test_template_app_func "${image_name}" \
                                "${t}" \

--- a/test/test-lib-mongodb.sh
+++ b/test/test-lib-mongodb.sh
@@ -14,18 +14,28 @@ source ${THISDIR}/test-lib-openshift.sh
 function test_mongodb_integration() {
   local image_name=$1
   local VERSION=$2
-  local import_image=$3
-  local service_name=${import_image##*/}
+  local service_name=$3
+  local image_tagged="${service_name}:${VERSION}"
   ct_os_template_exists mongodb-ephemeral && t=mongodb-ephemeral || t=mongodb-persistent
   ct_os_test_template_app_func "${image_name}" \
                                "${t}" \
                                "${service_name}" \
-                               "ct_os_check_cmd_internal '${import_image}' '${service_name}' \"mongo <IP>/testdb -u testu -ptestp --eval 'quit()'\" '.*' 120" \
+                               "ct_os_check_cmd_internal '<SAME_IMAGE>' '${service_name}-testing' \"mongo <IP>/testdb -u testu -ptestp --eval 'quit()'\" '.*' 120" \
                                "-p MONGODB_VERSION=${VERSION} \
                                 -p DATABASE_SERVICE_NAME="${service_name}-testing" \
                                 -p MONGODB_USER=testu \
                                 -p MONGODB_PASSWORD=testp \
-                                -p MONGODB_DATABASE=testdb" "" "${import_image}"
+                                -p MONGODB_DATABASE=testdb"
+}
+
+# Check the imagestream
+function test_mongodb_imagestream() {
+  case ${OS} in
+    rhel7|centos7) ;;
+    *) echo "Imagestream testing not supported for $OS environment." ; return 0 ;;
+  esac
+
+  ct_os_test_image_stream_template "${THISDIR}/../imagestreams/mongodb-${OS}.json" "${THISDIR}/../examples/mongodb-ephemeral-template.json" mongodb "-p MONGODB_VERSION=${VERSION}"
 }
 
 # vim: set tabstop=2:shiftwidth=2:expandtab:

--- a/test/test-lib.sh
+++ b/test/test-lib.sh
@@ -1,0 +1,1 @@
+../common/test-lib.sh


### PR DESCRIPTION
This PR combines more changes:

- add image stream test
- adopts new functions refactored in https://github.com/sclorg/container-common-scripts/pull/155/files
- enables tests to be run in a remote OCP4 cluster