### PR TITLE
Support mongodb on Quay.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 MongoDB container images
-=====================
+========================
+
+MongoDB 3.6 status: [![Docker Repository on Quay](https://quay.io/repository/centos7/mongodb-36-centos7/status "Docker Repository on Quay")](https://quay.io/repository/centos7/mongodb-36-centos7)
 
 This repository contains Dockerfiles for MongoDB images for OpenShift.
 Users can choose between RHEL, Fedora and CentOS based images.
@@ -14,7 +16,7 @@ For more information about concepts used in these container images, see the
 
 
 Versions
----------------------------------
+--------
 MongoDB versions currently provided are:
 * [MongoDB 3.6](latest)
 
@@ -26,7 +28,7 @@ CentOS versions currently supported are:
 
 
 Installation
----------------------------------
+------------
 Choose either the CentOS7 or RHEL7 based image:
 
 *  **RHEL7 based image**
@@ -52,7 +54,7 @@ Choose either the CentOS7 or RHEL7 based image:
     This image is available on DockerHub. To download it run:
 
     ```
-    $ docker pull centos/mongodb-36-centos7
+    $ docker pull quay.io/centos7/mongodb-36-centos7
     ```
 
     To build a MongoDB image from scratch run:
@@ -69,13 +71,13 @@ performed on all provided versions of MongoDB.**
 
 
 Usage
----------------------------------
+-----
 
 For information about usage of Dockerfile for MongoDB 3.6,
 see [usage documentation](latest/).
 
 Test
----------------------------------
+----
 
 This repository also provides a test framework which checks basic
 functionality of the MongoDB image.

--- a/imagestreams/mongodb-centos7.json
+++ b/imagestreams/mongodb-centos7.json
@@ -38,7 +38,7 @@
         },
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/centos/mongodb-36-centos7:latest"
+          "name": "quay.io/centos7/mongodb-36-centos7:latest"
         },
         "referencePolicy": {
           "type": "Local"

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos/s2i-core-centos7
+FROM quay.io/centos7/s2i-core-centos7
 
 ENV SUMMARY="MongoDB NoSQL database server" \
     DESCRIPTION="MongoDB (from humongous) is a free and open-source \
@@ -13,8 +13,8 @@ LABEL summary="$SUMMARY" \
       io.openshift.expose-services="27017:mongodb" \
       io.openshift.tags="database,mongodb,rh-mongodb36" \
       com.redhat.component="rh-mongodb36-container" \
-      name="centos/mongodb-36-centos7" \
-      usage="docker run -d -e MONGODB_ADMIN_PASSWORD=my_pass centos/mongodb-36-centos7" \
+      name="centos7/mongodb-36-centos7" \
+      usage="docker run -d -e MONGODB_ADMIN_PASSWORD=my_pass quay.io/centos7/mongodb-36-centos7" \
       version="1" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 

--- a/latest/root/usr/share/container-scripts/mongodb/README.md
+++ b/latest/root/usr/share/container-scripts/mongodb/README.md
@@ -1,12 +1,12 @@
 MongoDB 3.6 NoSQL Database Server container image
-====================
+=================================================
 
 This repository contains Dockerfiles for MongoDB images for general usage and OpenShift.
 Users can choose between RHEL and CentOS based images.
 The RHEL image is available in the [Red Hat Container Catalog](https://access.redhat.com/containers/#/registry.access.redhat.com/rhscl/mongodb-36-rhel7)
 as registry.access.redhat.com/rhscl/mongodb-36-rhel7.
-The CentOS image is then available on [Docker Hub](https://hub.docker.com/r/centos/mongodb-36-centos7/)
-as centos/mongodb-36-centos7.
+The CentOS image is then available on [Quay.io](https://quay.io/organization/centos7)
+as centos7/mongodb-36-centos7.
 
 
 Description
@@ -86,7 +86,7 @@ inside the container.**
 
 
 MongoDB admin user
----------------------------------
+------------------
 
 The admin user name is set to `admin` and you have to to specify the password by
 setting the `MONGODB_ADMIN_PASSWORD` environment variable.
@@ -98,7 +98,7 @@ reference](https://docs.mongodb.com/manual/reference/built-in-roles/)).
 
 
 Optional unprivileged user
----------------------------------
+--------------------------
 
 The user with `$MONGODB_USER` name is created in database `$MONGODB_DATABASE`
 and you have to to specify the password by setting the `MONGODB_PASSWORD`
@@ -108,7 +108,7 @@ This user has only 'readWrite' role in the database.
 
 
 Changing passwords
----------------------------------
+------------------
 
 Since passwords are part of the image configuration, the only supported method
 to change passwords for the database user (`MONGODB_USER`) and admin user is
@@ -122,7 +122,7 @@ the environment variables.
 
 
 Extending image
----------------------------------
+---------------
 
 This image can be extended using
 [source-to-image](https://github.com/openshift/source-to-image).


### PR DESCRIPTION
This commit adds support mongodb 3.6 on Quay.io registry.
README.md files and Dockerfile are updated accordingly.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>